### PR TITLE
Fix bug, with configure cpus and memory during creating vapp.

### DIFF
--- a/pyvcloud/vapp.py
+++ b/pyvcloud/vapp.py
@@ -24,6 +24,7 @@ from iptools import ipv4, IpRange
 from tabulate import tabulate
 from pyvcloud.helper import CommonUtils
 
+
 VCLOUD_STATUS_MAP = {
     -1: "Could not be created",
     0: "Unresolved",
@@ -417,7 +418,7 @@ class VAPP(object):
                 virtualHardwareSection = filter(lambda section: section.__class__.__name__== "VirtualHardwareSection_Type", sections)[0]
                 items = virtualHardwareSection.get_Item()
                 cpu = filter(lambda item: item.get_Description().get_valueOf_() == "Number of Virtual CPUs", items)[0]
-                cpu_capacity = cpu.get_ElementName().get_valueOf_().split(" virtual CPU(s)")[0]
+                cpu_capacity = int(cpu.get_ElementName().get_valueOf_().split(" virtual CPU(s)")[0])
                 memory = filter(lambda item: item.get_Description().get_valueOf_() == "Memory Size", items)[0]
                 memory_capacity = int(memory.get_ElementName().get_valueOf_().split(" MB of memory")[0]) / 1024
                 operatingSystemSection = filter(lambda section: section.__class__.__name__== "OperatingSystemSection_Type", sections)[0]


### PR DESCRIPTION
The old version of function _create_instantiateVAppTemplateParams() uses SourcedVmInstantiationParamsType  for customization cpu and memory.
SourcedCompositionItemParamType and SourcedVmInstantiationParamsType 	can't be presents together.
If SourcedCompositionItemParamType section is present, then SourcedVmInstantiationParamsTypesection (if present) will be ignored. 
But customizing vm_name uses SourcedCompositionItemParamType.
Also InstantiateVmHardwareCustomizationParamsType is deprecated since v.5.6.

Also fix error in get_vms_details()
