### PR TITLE
Clean requirements

### DIFF
--- a/pyvcloud/vapp.py
+++ b/pyvcloud/vapp.py
@@ -21,7 +21,6 @@ from schema.vcd.v1_5.schemas.vcloud import vAppType, vdcType, queryRecordViewTyp
 from schema.vcd.v1_5.schemas.vcloud.taskType import TaskType
 from schema.vcd.v1_5.schemas.vcloud.vAppType import VAppType, NetworkConnectionSectionType
 from iptools import ipv4, IpRange
-from tabulate import tabulate
 from pyvcloud.helper import CommonUtils
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,4 @@
-PyYAML==3.10
 iptools==0.6.1
-requests==2.4.3
-tabulate==0.7.3
-wsgiref==0.1.2
-xmltodict==0.9.0
 lxml==3.4.1
 netaddr==0.7.13
+requests==2.4.3


### PR DESCRIPTION
Some dependencies are only useful for vca-cli, this cleans the requirements.txt (and an unused import)
PyYAML, tabulate and xmltodict should be moved to vca-cli dependencies
I could not find any use in vca for wsgiref but maybe missed it