### PR TITLE
Fixes Issue #41 for users who are using vCloud Director API version 5.5

### DIFF
--- a/pyvcloud/schema/vcd/v1_5/schemas/vcloud/vcloudType.py
+++ b/pyvcloud/schema/vcd/v1_5/schemas/vcloud/vcloudType.py
@@ -8823,9 +8823,8 @@ class InstantiateVAppParamsType(VAppCreationParamsType):
             outfile.write('<%sIsSourceDelete>%s</%sIsSourceDelete>%s' % (namespace_, self.gds_format_boolean(self.IsSourceDelete, input_name='IsSourceDelete'), namespace_, eol_))
         for SourcedVmInstantiationParams_ in self.SourcedVmInstantiationParams:
             SourcedVmInstantiationParams_.export(outfile, level, namespace_, name_='SourcedVmInstantiationParams', pretty_print=pretty_print)
-        if self.SourcedItem is not None:
-            for SourcedItem_ in self.SourcedItem:
-                SourcedItem_.export(outfile, level, namespace_, name_='SourcedItem', pretty_print=pretty_print)
+        for SourcedItem_ in self.SourcedItem:
+            SourcedItem_.export(outfile, level, namespace_, name_='SourcedItem', pretty_print=pretty_print)
     def exportLiteral(self, outfile, level, name_='InstantiateVAppParamsType'):
         level += 1
         already_processed = set()

--- a/pyvcloud/schema/vcd/v1_5/schemas/vcloud/vcloudType.py
+++ b/pyvcloud/schema/vcd/v1_5/schemas/vcloud/vcloudType.py
@@ -8823,8 +8823,9 @@ class InstantiateVAppParamsType(VAppCreationParamsType):
             outfile.write('<%sIsSourceDelete>%s</%sIsSourceDelete>%s' % (namespace_, self.gds_format_boolean(self.IsSourceDelete, input_name='IsSourceDelete'), namespace_, eol_))
         for SourcedVmInstantiationParams_ in self.SourcedVmInstantiationParams:
             SourcedVmInstantiationParams_.export(outfile, level, namespace_, name_='SourcedVmInstantiationParams', pretty_print=pretty_print)
-        for SourcedItem_ in self.SourcedItem:
-            SourcedItem_.export(outfile, level, namespace_, name_='SourcedItem', pretty_print=pretty_print)
+        if self.SourcedItem is not None:
+            for SourcedItem_ in self.SourcedItem:
+                SourcedItem_.export(outfile, level, namespace_, name_='SourcedItem', pretty_print=pretty_print)
     def exportLiteral(self, outfile, level, name_='InstantiateVAppParamsType'):
         level += 1
         already_processed = set()

--- a/pyvcloud/vcloudair.py
+++ b/pyvcloud/vcloudair.py
@@ -371,6 +371,7 @@ class VCA(object):
                 vapp = VAPP(vAppType.parseString(self.response.content, True), self.vcloud_session.get_vcloud_headers(), self.verify, self.log)
                 return vapp
 
+    
     def _create_instantiateVAppTemplateParams(self, name, template_href,
                                               vm_name, vm_href, deploy,
                                               power, vm_cpus=None,
@@ -387,7 +388,7 @@ class VCA(object):
             params = vcloudType.SourcedCompositionItemParamType()
             params.set_Source(vcloudType.ReferenceType(href=vm_href))
             if self.version == "5.5":
-                templateParams.set_SourcedItem(None)
+                pass
             else:
                 templateParams.add_SourcedItem(params)
 

--- a/pyvcloud/vcloudair.py
+++ b/pyvcloud/vcloudair.py
@@ -386,12 +386,18 @@ class VCA(object):
         if vm_name or vm_cpus or vm_memory:
             params = vcloudType.SourcedCompositionItemParamType()
             params.set_Source(vcloudType.ReferenceType(href=vm_href))
-            templateParams.add_SourcedItem(params)
+            if self.version == "5.5":
+                templateParams.set_SourcedItem(None)
+            else:
+                templateParams.add_SourcedItem(params)
 
             if vm_name:
-                gen_params = vcloudType.VmGeneralParamsType()
-                gen_params.set_Name(vm_name)
-                params.set_VmGeneralParams(gen_params)
+                if self.version == "5.5":
+                   templateParams.set_name(vm_name)
+                else:
+                   gen_params = vcloudType.VmGeneralParamsType()
+                   gen_params.set_Name(vm_name)
+                   params.set_VmGeneralParams(gen_params)
 
             if vm_cpus or vm_memory:
                 inst_param = vcloudType.InstantiationParamsType()
@@ -508,7 +514,6 @@ class VCA(object):
                         vapp_name, entity.get("href"), vm_name=vm_name,
                         vm_href=vm_href, vm_cpus=vm_cpus, vm_memory=vm_memory,
                         deploy=deploy, power=poweron)
-
                     if network_name:
                         pass
                     output = StringIO()


### PR DESCRIPTION
For users who are on API version 5.5 there is an issue when using create_vapp and having a vm_name set.

The 5.5 API doesn't like the ```<SourcedItem>``` tag with VmGeneralParams and as a result will respond with an Error as it is not part of the 5.5 API

The resolution is to set the SourcedItem = None and not setting any vcloudType.VmGeneralParamsType parameters since the VmGeneralParamsType was not added to the API until 5.6  (Reference: http://pubs.vmware.com/vca/index.jsp?topic=%2Fcom.vmware.vcloud.api.reference.doc_56%2Fdiff%2Flanding-all_types_diff.html)

And since we want to change a name, we can set the templateParams.set_name function to be the vm_name

Its not the perfect solution but it will help those who are on 5.5

