### PR TITLE
Revert casting from boolean to strings

### DIFF
--- a/pyvcloud/score.py
+++ b/pyvcloud/score.py
@@ -226,8 +226,8 @@ class ExecutionsClient(object):
             'deployment_id': deployment_id,
             'workflow_id': workflow_id,
             'parameters': parameters,
-            'allow_custom_parameters': str(allow_custom_parameters).lower(),
-            'force': str(force).lower()
+            'allow_custom_parameters': allow_custom_parameters,
+            'force': force,
         }
         headers = self.score.get_headers()
         headers['Content-type'] = 'application/json'


### PR DESCRIPTION
Revert casting from boolean to strings.
Score expects to have booleans instead of sting during install executions.