### PR TITLE
Validate blueprint before upload

### DIFF
--- a/pyvcloud/score.py
+++ b/pyvcloud/score.py
@@ -99,6 +99,7 @@ class BlueprintsClient(object):
         return json.loads(self.score.response.content)
 
     def upload(self, blueprint_path, blueprint_id):
+        self.validate(blueprint_path)
         tempdir = tempfile.mkdtemp()
         try:
             tar_path = self._tar_blueprint(blueprint_path, tempdir)


### PR DESCRIPTION
Force blueprint upload method to check blueprint.
This change prevents from bothering Score to run
simple validation, i.e valid YAML syntax, absence of imports, etc.