### PR TITLE
Fixing service type identification for VCD

### DIFF
--- a/pyvcloud/vcloudair.py
+++ b/pyvcloud/vcloudair.py
@@ -129,7 +129,7 @@ class VCA(object):
         headers = {}
         headers["Accept"] = "application/json;version=" + '5.7'
         response = Http.post(url, headers=headers, auth=('_', '_'), verify=self.verify, logger=self.logger)
-        if response.status_code != 404:
+        if response.status_code != 406:
             return VCA.VCA_SERVICE_TYPE_VCA
         url = self.host + '/api/vchs/sessions'
         headers = {}


### PR DESCRIPTION
Status code 404 results in incorrect VCD identification as VCA. The correct status code returned by VCD is 406 (Not acceptable).