### PR TITLE
Import cloudify-dsl-parser only when validation required.

### DIFF
--- a/pyvcloud/score.py
+++ b/pyvcloud/score.py
@@ -25,8 +25,6 @@ from os.path import expanduser
 from pyvcloud import exceptions
 from pyvcloud import _get_logger, Http, Log
 
-from dsl_parser import parser
-
 
 class Score(object):
 
@@ -67,6 +65,7 @@ class BlueprintsClient(object):
         self.logger = _get_logger() if log else None
 
     def validate(self, blueprint_path):
+        from dsl_parser import parser
         return parser.parse_from_path(blueprint_path)
 
     def list(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ netaddr>=0.7.13
 requests>=2.4.3
 PyYAML==3.10
 progressbar>=2.3
-cloudify-dsl-parser==3.2


### PR DESCRIPTION
dsl_parser uses only with score service, but score service package already has dsl_parser module in requirements.