### PR TITLE
Fix get_service_type cannot detect standalone vCD

### DIFF
--- a/pyvcloud/vcloudair.py
+++ b/pyvcloud/vcloudair.py
@@ -129,7 +129,7 @@ class VCA(object):
         headers = {}
         headers["Accept"] = "application/json;version=" + '5.7'
         response = Http.post(url, headers=headers, auth=('_', '_'), verify=self.verify, logger=self.logger)
-        if response.status_code != 404:
+        if response.status_code not in (403, 404):
             return VCA.VCA_SERVICE_TYPE_VCA
         url = self.host + '/api/vchs/sessions'
         headers = {}


### PR DESCRIPTION
`get_service_type` cannot detect standalone vCD, because vCD 8.0 returns `403 Forbidden` error when requesting to `https://<vcd_host>/api/iam/login`.