### PR TITLE
Added options to select storage profile, bus type and add comment when creating an independent disk

### DIFF
--- a/pyvcloud/vapp.py
+++ b/pyvcloud/vapp.py
@@ -442,7 +442,7 @@ class VAPP(object):
                 return taskType.parseString(self.response.content, True)
 
 
-    def attach_disk_to_vm(self, vm_name, disk_ref):
+    def attach_disk_to_vm(self, vm_name, disk_ref, bus_number=None, unit_number=None):
         """
         Attach a disk volume to a VM.
 
@@ -462,8 +462,15 @@ class VAPP(object):
                  <DiskAttachOrDetachParams xmlns="http://www.vmware.com/vcloud/v1.5">
                      <Disk type="application/vnd.vmware.vcloud.disk+xml"
                          href="%s" />
-                 </DiskAttachOrDetachParams>
                 """ % disk_ref.href
+                if bus_number is not None and unit_number is not None:
+                    body += """
+                          <BusNumber>%s</BusNumber>
+                          <UnitNumber>%s</UnitNumber>
+                    """ % (bus_number, unit_number)
+                body += """
+                </DiskAttachOrDetachParams>
+                """
                 return self.execute("disk:attach", "post", body=body, targetVM=vms[0])
 
 

--- a/pyvcloud/vcloudair.py
+++ b/pyvcloud/vcloudair.py
@@ -1453,8 +1453,6 @@ class VCA(object):
 
         """
         resourceEntities = vdc.get_ResourceEntities().get_ResourceEntity()
-        for res in resourceEntities:
-            Log.error(self.logger, "Ressource: " + res.get_name())
         return [resourceEntity for resourceEntity in resourceEntities
                     if resourceEntity.get_type() == "application/vnd.vmware.vcloud.disk+xml"]
 

--- a/pyvcloud/vcloudair.py
+++ b/pyvcloud/vcloudair.py
@@ -1511,7 +1511,7 @@ class VCA(object):
             disks.append([disk, vms])
         return disks
 
-    def add_disk(self, vdc_name, name, size, busType=None, busSubType=None, description=None, storageProfileName=None):
+    def add_disk(self, vdc_name, name, size, bus_type=None, bus_sub_type=None, description=None, storage_profile_name=None):
         """
         Request the creation of an indepdent disk (not attached to a vApp).
 
@@ -1528,24 +1528,24 @@ class VCA(object):
         disk.Disk.size = size
         if description != None:
                 disk.Disk.set_Description(description)
-        if busType != None and busSubType != None:
-                disk.Disk.busType = busType
-                disk.Disk.busSubType = busSubType
+        if bus_type != None and bus_sub_type != None:
+                disk.Disk.busType = bus_type
+                disk.Disk.busSubType = bus_sub_type
 
         vdc = self.get_vdc(vdc_name)
 
-        if storageProfileName != None:
+        if storage_profile_name != None:
             content_type = "application/vnd.vmware.vcloud.vdcStorageProfile+xml" 
-            storage_profile = filter(lambda storage_profile: storage_profile.get_name() == storageProfileName, vdc.get_VdcStorageProfiles().get_VdcStorageProfile())
+            storage_profile = filter(lambda storage_profile: storage_profile.get_name() == storage_profile_name, vdc.get_VdcStorageProfiles().get_VdcStorageProfile())
 
             if len(storage_profile) != 1:
                 return(False, self.response.content)
 
-            storageProfile = VdcStorageProfileType()
-            storageProfile.set_href(storage_profile[0].get_href())
-            storageProfile.set_name(storage_profile[0].get_name())
+            storage_profile_type = VdcStorageProfileType()
+            storage_profile_type.set_href(storage_profile[0].get_href())
+            storage_profile_type.set_name(storage_profile[0].get_name())
 
-            disk.Disk.set_StorageProfile(storageProfile)
+            disk.Disk.set_StorageProfile(storage_profile_type)
 
         data = CommonUtils.convertPythonObjToStr(disk, name="DiskCreateParams", namespacedef='xmlns="http://www.vmware.com/vcloud/v1.5"')
 


### PR DESCRIPTION
Since API version 5.6 allows a single virtual machine (VM) to access different tiers of storage, this patch will allow for the selection of a storage profile when creating an independent disk.

I have modified add_disk to accept the following additional parameters :

- bus_type to define a specific Disk.busType
- bus_sub_type to define a specific Disk.busSubType
- comment that will be visible in the disk details
- storage_profile_name to define a specific storage profile for that disk (must be in the allowed storage profile defined for the vDC)