### PR TITLE
VCDA-217: Retrieve access control settings of a catalog

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -227,6 +227,7 @@ class EntityType(Enum):
     CATALOG = 'application/vnd.vmware.vcloud.catalog+xml'
     CAPTURE_VAPP_PARAMS = \
         'application/vnd.vmware.vcloud.captureVAppParams+xml'
+    CONTROL_ACCESS_PARAMS = 'application/vnd.vmware.vcloud.controlAccess+xml'
     DISK = 'application/vnd.vmware.vcloud.disk+xml'
     DISK_ATTACH_DETACH_PARAMS = 'application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml'
     DISK_CREATE_PARMS = 'application/vnd.vmware.vcloud.diskCreateParams+xml'

--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -25,7 +25,9 @@ from pyvcloud.vcd.client import get_links
 from pyvcloud.vcd.client import MissingRecordException
 from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.client import RelationType
+from pyvcloud.vcd.utils import access_settings_to_dict
 from pyvcloud.vcd.utils import to_dict
+
 import shutil
 import tarfile
 import tempfile
@@ -141,7 +143,7 @@ class Org(object):
         elif len(records) > 1:
             raise Exception('multiple users found')
         return self.client.get_resource(records[0].get('href'))
-      
+
     def update_catalog(self, old_catalog_name, new_catalog_name, description):
         """
         Update the name and/or description of a catalog.
@@ -160,12 +162,14 @@ class Org(object):
             if old_catalog_name == link.name:
                 catalog = self.client.get_resource(link.href)
                 href = catalog.get('href')
-                admin_href = href.replace('/api/catalog/', '/api/admin/catalog/')
+                admin_href = href.replace('/api/catalog/',
+                                          '/api/admin/catalog/')
                 adminViewOfCatalog = self.client.get_resource(admin_href)
                 if new_catalog_name is not None:
-                    adminViewOfCatalog.set('name',new_catalog_name)
+                    adminViewOfCatalog.set('name', new_catalog_name)
                 if description is not None:
-                    adminViewOfCatalog['Description'] = E.Description(description)
+                    adminViewOfCatalog['Description'] = E.Description(
+                        description)
                 return self.client.put_resource(
                     admin_href,
                     adminViewOfCatalog,
@@ -546,3 +550,27 @@ class Org(object):
             equality_filter=name_filter,
             qfilter=org_filter)
         return query, resource_type
+
+    def get_catalog_access_control_settings(self, catalog_name):
+        """
+        Get the access control settings of a catalog.
+        :param catalog_name: (str): The name of the catalog.
+        :return: Access control settings of the catalog.
+        """  # NOQA
+        catalog_resource = self.get_catalog(name=catalog_name)
+        control_access = self.client.get_linked_resource(
+            catalog_resource,
+            RelationType.DOWN,
+            EntityType.CONTROL_ACCESS_PARAMS.value)
+        access_settings = []
+        if hasattr(control_access, 'AccessSettings') and \
+           hasattr(control_access.AccessSettings, 'AccessSetting') and \
+           len(control_access.AccessSettings.AccessSetting) > 0:
+                        for access_setting in list(
+                                control_access.AccessSettings.AccessSetting):
+                            access_settings.append(access_settings_to_dict(
+                                access_setting))
+        result = to_dict(control_access)
+        if len(access_settings) > 0:
+            result['AccessSettings'] = access_settings
+        return result

--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 from lxml import etree
 from lxml.objectify import NoneElement
 from pygments import formatters
@@ -239,6 +240,16 @@ def disk_to_dict(disk):
         result['description'] = disk.Description
     if hasattr(disk, 'StorageProfile'):
         result['storageProfile'] = disk.StorageProfile.get('name')
+    return result
+
+
+def access_settings_to_dict(access_setting):
+    result = collections.OrderedDict()
+    if hasattr(access_setting, 'Subject'):
+        result['name'] = access_setting.Subject.get('name')
+        result['href'] = access_setting.Subject.get('href')
+    if hasattr(access_setting, 'AccessLevel'):
+        result['access_level'] = access_setting.AccessLevel
     return result
 
 

--- a/tests/vcd_catalog.py
+++ b/tests/vcd_catalog.py
@@ -14,6 +14,13 @@ class TestCatalog(TestCase):
         catalog = org.get_catalog(self.config['vcd']['catalog'])
         assert self.config['vcd']['catalog'] == catalog.get('name')
 
+    def test_catalog_control_access_retrieval(self):
+        logged_in_org = self.client.get_org()
+        org = Org(self.client, resource=logged_in_org)
+        catalog = org.get_catalog(self.config['vcd']['catalog'])
+        assert self.config['vcd']['catalog'] == catalog.get('name')
+        control_access = org.get_catalog_access_control_settings(catalog.get('name'))
+        assert control_access is not None
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
(pyvcloud) malakars-m01:pyvcloud malakars$ pwd
/Users/malakars/pyworkspace/pyvcloud
(pyvcloud) malakars-m01:pyvcloud malakars$ cd tests
(pyvcloud) malakars-m01:tests malakars$ python -m unittest vcd_catalog.TestCatalog.test_catalog_control_access_retrieval
/Users/malakars/.virtualenvs/pyvcloud/lib/python3.6/site-packages/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
InsecureRequestWarning)
.

Ran 1 test in 0.435s

OK