### PR TITLE
Adding new params to create_cluster function

### DIFF
--- a/pyvcloud/vcd/cluster.py
+++ b/pyvcloud/vcd/cluster.py
@@ -40,12 +40,24 @@ class Cluster(object):
             raise Exception(json.loads(response.content))
 
     def create_cluster(self, vdc, network_name, name, node_count=2,
-                       storage_profile=None):
+                       cpu_count=None, memory=None, storage_profile=None,
+                       ssh_key=None):
+        """
+        Create a new Kubernetes cluster
+        :param cpu_count: (str): The number of virtual cpus on each of the nodes in the cluster
+        :param memory: (str): The amount of memory (in MB) on each of the nodes in the cluster
+        :param ssh_key: (str): The ssh key that clients can use to log into the node vms without 
+                               explicitly providing passwords
+        :return: (json) A paresed json object describing the requested cluster.
+        """  # NOQA
         method = 'POST'
         uri = self._uri
         data = {'name': name, 'node_count': node_count, 'vdc': vdc,
+                'cpu-count': cpu_count,
+                'memory': memory,
                 'network': network_name,
-                'storage_profile': storage_profile}
+                'storage_profile': storage_profile,
+                'ssh-key': ssh_key}
         response = self.client._do_request_prim(
             method,
             uri,

--- a/pyvcloud/vcd/cluster.py
+++ b/pyvcloud/vcd/cluster.py
@@ -57,11 +57,11 @@ class Cluster(object):
         method = 'POST'
         uri = self._uri
         data = {'name': name, 'node_count': node_count, 'vdc': vdc,
-                'cpu-count': cpu_count,
+                'cpu_count': cpu_count,
                 'memory': memory,
                 'network': network_name,
                 'storage_profile': storage_profile,
-                'ssh-key': ssh_key}
+                'ssh_key': ssh_key}
         response = self.client._do_request_prim(
             method,
             uri,

--- a/pyvcloud/vcd/cluster.py
+++ b/pyvcloud/vcd/cluster.py
@@ -44,11 +44,15 @@ class Cluster(object):
                        ssh_key=None):
         """
         Create a new Kubernetes cluster
+        :param vdc: (str): The name of the vdc backing the org in which the cluster would be created
+        :param network_name: (str): The name of the network to which the cluster vApp will connect to
+        :param name: (str): The name of the cluster
+        :param node_count: (str): The number of slave nodes
         :param cpu_count: (str): The number of virtual cpus on each of the nodes in the cluster
         :param memory: (str): The amount of memory (in MB) on each of the nodes in the cluster
-        :param ssh_key: (str): The ssh key that clients can use to log into the node vms without 
-                               explicitly providing passwords
-        :return: (json) A paresed json object describing the requested cluster.
+        :param storage_profile: (str): The name of the storage profile which will back the cluster
+        :param ssh_key: (str): The ssh key that clients can use to log into the node vms without explicitly providing passwords
+        :return: (json) A parsed json object describing the requested cluster.
         """  # NOQA
         method = 'POST'
         uri = self._uri


### PR DESCRIPTION
Testing done :
CLI command :
(vcd-cli) C:\code\vcd-cli>vcd cluster create -n net1 -N 2 -c 2 -m 1025 --ssh-key ssh-key.txt "aritra-test-cluster"

cse.log :
DEBUG    2017-11-29 08:14:08,615 container_service_extension.processor    process_request                      55  : request body: {"name": "aritra-test-cluster", "node_count": 2, "vdc": "vdc1", "cpu-count": "2", "memory": "1025", "network": "net1", "storage_profile": null, "ssh-key": "sample SSH key"}

Note : the command failed with an error stating 'not enough IP addresses' on the extension. But I believe it's not related to my changes.
