### PR TITLE
get_disk(name, id) now alerts users if there are multiple namesake disks

### DIFF
--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -484,18 +484,29 @@ class VDC(object):
 
         disks = self.get_disks()
 
+        result = None
         if disk_id is not None:
             if not disk_id.startswith('urn:vcloud:disk:'):
                 disk_id = 'urn:vcloud:disk:' + disk_id
             for disk in disks:
                 if disk.get('id') == disk_id:
-                    return disk
+                    result = disk
+                    # disk-id's are unique so it's ok to break the loop
+                    # and stop looking further.
+                    break
+        elif name is not None:
+            for disk in disks:
+                if disk.get('name') == name:
+                    if result is None:
+                        result = disk
+                    else:
+                        raise Exception('Found multiple disks with name %s'
+                                        ', please specify disk id along '
+                                        'with disk name. ' % disk.get('name'))
+        if result is None:
+            raise Exception('No disk found with the given name/id.')
         else:
-            if name is not None:
-                for disk in disks:
-                    if disk.get('name') == name:
-                        return disk
-        return None
+            return result
 
     def change_disk_owner(self, name, user_href, disk_id=None):
         """


### PR DESCRIPTION
Testing done :

(vcd-cli) C:\code\vcd-cli>vcd disk list
id                                    name    size        size_bytes  status
------------------------------------  ------  --------  ------------  --------
477fe6a5-1fc8-4bf9-b54b-2a7a7849b775  disk1   20 bytes            20  Resolved
b714176a-9c72-48df-9017-c73550e7bee0  disk1   10 bytes            10  Resolved

(vcd-cli) C:\code\vcd-cli>vcd disk delete disk1
Are you sure you want to delete the disk? [y/N]: y
Usage: vcd disk delete [OPTIONS] <name>

Error: Found multiple disks with name disk1, please specify disk id along with disk name.

(vcd-cli) C:\code\vcd-cli>vcd disk delete disk11234
Are you sure you want to delete the disk? [y/N]: y
Usage: vcd disk delete [OPTIONS] <name>

Error: No disk found with the given name/id.

(vcd-cli) C:\code\vcd-cli>vcd disk delete disk1 -i 477fe6a5-1fc8-4bf9-b54b-2a7a7849b775
Are you sure you want to delete the disk? [y/N]: y
task: d3d8edb9-1efe-4b93-b1a8-0acaec563431, Deleted Disk disk1(477fe6a5-1fc8-4bf9-b54b-2a7a7849b775), result: success