### PR TITLE
Introducing capability to print xml in monochrome

### DIFF
--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -340,11 +340,13 @@ def to_camel_case(name, names):
     return result
 
 
-def stdout_xml(the_xml):
-    print(
-        highlight(
-            str(etree.tostring(the_xml, pretty_print=True), 'utf-8'),
-            lexers.XmlLexer(), formatters.TerminalFormatter()))
+def stdout_xml(the_xml, is_colorized=True):
+    message = str(etree.tostring(the_xml, pretty_print=True), 'utf-8')
+    if is_colorized is True:
+        print(highlight(message,
+                        lexers.XmlLexer(), formatters.TerminalFormatter()))
+    else:
+        print(message)
 
 
 def get_admin_href(href):

--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -342,7 +342,7 @@ def to_camel_case(name, names):
 
 def stdout_xml(the_xml, is_colorized=True):
     message = str(etree.tostring(the_xml, pretty_print=True), 'utf-8')
-    if is_colorized is True:
+    if is_colorized:
         print(highlight(message,
                         lexers.XmlLexer(), formatters.TerminalFormatter()))
     else:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 tox
 flake8
+flake8-import-order
 hacking
 nose>=1.3.6
 nose-testconfig>=0.9.1


### PR DESCRIPTION
Tested the following scenarios

Environment variable USE_COLORED_OUPUT not set
------------------------------------------------------
vcd info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 : Colored output
vcd --colorized info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 : Colored output
vcd --no-colorized info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 : Monochrome output

Environment variable USE_COLORED_OUPUT is set to 0
------------------------------------------------------
vcd info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 :  Monochrome output
vcd --colorized info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 : Colored output
vcd --no-colorized info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 : Monochrome output

Environment variable USE_COLORED_OUPUT is set to 1
------------------------------------------------------
vcd info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 :  Colored output
vcd --colorized info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 : Colored output
vcd --no-colorized info catalog 87d6f1f7-6d29-4abc-9f09-ce8322175901 : Monochrome output

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/155)
<!-- Reviewable:end -->
