### PR TITLE
VCDA-331: catalog_item download fails with 'No such file or director' error.

### DIFF
--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -297,7 +297,7 @@ class Org(object):
                         chunk_size=chunk_size,
                         size=source_file['size'],
                         callback=callback)
-                    if num_bytes != source_file['size']:
+                    if num_bytes != int(source_file['size']):
                         raise Exception('download incomplete for file %s' %
                                         source_file['href'])
                     files.append(source_file)


### PR DESCRIPTION


This issue happens because the check `if num_bytes != source_file['size']:` fails because source_file['size'] value is str instead of int.

Before fix:
C:\sources\github\service_ecosystem\vcd-cli (master)
(vcd-cli) λ vcd catalog download Tester v1 test-ova1.ova
catalogItemEnableDownload: Enabling Catalog Item v1(a96ab70b-4641-4290-935b-27935e52b2b7)
download 68,096 of 68,096 bytes, 100%
Usage: vcd catalog download [OPTIONS] <catalog-name> <item-name> [file-name]

Error: [WinError 2] The system cannot find the file specified: 'test-ova1.ova'

After fix:
C:\sources\github\service_ecosystem\vcd-cli (master)
(vcd-cli) λ vcd catalog download Tester v1 test-ova1.ova
catalogItemEnableDownload: Enabling Catalog Item v1(a96ab70b-4641-4290-935b-27935e52b2b7)
catalogItemEnableDownload: Enabling Catalog Item v1(a96ab70b-4641-4290-935b-27935e52b2b7)
download 68,096 of 68,096 bytes, 100%
property    value
----------  -------------
file        test-ova1.ova
size        81920
