### PR TITLE
Issue#142: Fixed bug in vdc.py : get_storage_profiles() that was returning only first storage profile.

### DIFF
--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -607,7 +607,7 @@ class VDC(object):
            hasattr(self.resource.VdcStorageProfiles, 'VdcStorageProfile'):
             for profile in self.resource.VdcStorageProfiles.VdcStorageProfile:
                 profile_list.append(profile)
-                return profile_list
+            return profile_list
         return None
 
     def get_storage_profile(self, profile_name):


### PR DESCRIPTION
Root cause : Due to an extra level of indentation, the loop that collected all the storage profiles was getting terminated earlier than expected.
Fix : Remove the extra indentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/181)
<!-- Reviewable:end -->
