### PR TITLE
VCDA-365,366: Shutdown and Reboot a vapp/VM

### DIFF
--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -146,8 +146,7 @@ class VApp(object):
             self.resource.get('href') + '/owner/', new_owner,
             EntityType.OWNER.value)
 
-    def deploy(self, power_on=None,
-               force_customization=None):
+    def deploy(self, power_on=None, force_customization=None):
         """Deploys the vApp.
 
         Deploying the vApp will allocate all resources assigned to the vApp.

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -199,9 +199,9 @@ class VApp(object):
     def shutdown(self):
         """Shuts down a vApp.
 
-            :return: A :class:`lxml.objectify.StringElement` object describing
-                the asynchronous Task shutting down the vApp.
-            """
+        :return: A :class:`lxml.objectify.StringElement` object describing
+            the asynchronous Task shutting down the vApp.
+        """
         if self.resource is None:
             self.resource = self.client.get_resource(self.href)
         return self.client.post_linked_resource(

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -197,6 +197,11 @@ class VApp(object):
             self.resource, RelationType.POWER_ON, None, None)
 
     def shutdown(self):
+        """Shuts down a vApp.
+
+            :return: A :class:`lxml.objectify.StringElement` object describing
+                the asynchronous Task shutting down the vApp.
+            """
         if self.resource is None:
             self.resource = self.client.get_resource(self.href)
         return self.client.post_linked_resource(
@@ -212,6 +217,17 @@ class VApp(object):
             self.resource = self.client.get_resource(self.href)
         return self.client.post_linked_resource(
             self.resource, RelationType.POWER_RESET, None, None)
+
+    def reboot(self):
+        """Reboots the vApp.
+
+        :return: A :class:`lxml.objectify.StringElement` object describing
+            the asynchronous Task rebooting the vApp.
+        """
+        if self.resource is None:
+            self.resource = self.client.get_resource(self.href)
+        return self.client.post_linked_resource(
+            self.resource, RelationType.POWER_REBOOT, None, None)
 
     def connect_vm(self, mode='DHCP', reset_mac_address=False):
         if self.resource is None:

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -197,7 +197,7 @@ class VApp(object):
             self.resource, RelationType.POWER_ON, None, None)
 
     def shutdown(self):
-        """Shuts down a vApp.
+        """Shutdown the vApp.
 
         :return: A :class:`lxml.objectify.StringElement` object describing
             the asynchronous Task shutting down the vApp.

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -84,6 +84,28 @@ class VM(object):
         item['{' + NSMAP['rasd'] + '}VirtualQuantity'] = virtual_quantity
         return self.client.put_resource(uri, item, EntityType.RASD_ITEM.value)
 
+    def shutdown(self):
+        """Shuts down a VM.
+
+            :return: A :class:`lxml.objectify.StringElement` object describing
+                the asynchronous Task shutting down the VM.
+            """
+        if self.resource is None:
+            self.resource = self.client.get_resource(self.href)
+        return self.client.post_linked_resource(
+            self.resource, RelationType.POWER_SHUTDOWN, None, None)
+
+    def reboot(self):
+        """Reboots the VM.
+
+        :return: A :class:`lxml.objectify.StringElement` object describing
+            the asynchronous Task rebooting the VM.
+        """
+        if self.resource is None:
+            self.resource = self.client.get_resource(self.href)
+        return self.client.post_linked_resource(
+            self.resource, RelationType.POWER_REBOOT, None, None)
+
     def power_on(self):
         """Powers on the VM.
 

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -139,28 +139,6 @@ class VM(object):
         return self.client.post_linked_resource(
             self.resource, RelationType.POWER_RESET, None, None)
 
-    def reboot(self):
-        """Reboots the VM.
-
-        :return: A :class:`lxml.objectify.StringElement` object describing \
-            the asynchronous Task rebooting the vApp.
-        """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
-        return self.client.post_linked_resource(
-            self.resource, RelationType.POWER_REBOOT, None, None)
-
-    def shutdown(self):
-        """Shuts down a VM.
-
-        :return: A :class:`lxml.objectify.StringElement` object describing \
-            the asynchronous Task resetting the vApp.
-        """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
-        return self.client.post_linked_resource(
-            self.resource, RelationType.POWER_SHUTDOWN, None, None)
-
     def deploy(self, power_on=True,
                force_customization=False):
         """Deploys the VM.

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -81,9 +81,9 @@ class VM(object):
     def shutdown(self):
         """Shutdown the VM.
 
-            :return: A :class:`lxml.objectify.StringElement` object describing
-                the asynchronous Task shutting down the VM.
-            """
+        :return: A :class:`lxml.objectify.StringElement` object describing
+            the asynchronous Task shutting down the VM.
+        """
         if self.resource is None:
             self.resource = self.client.get_resource(self.href)
         return self.client.post_linked_resource(
@@ -133,8 +133,7 @@ class VM(object):
         return self.client.post_linked_resource(
             self.resource, RelationType.POWER_RESET, None, None)
 
-    def deploy(self, power_on=True,
-               force_customization=False):
+    def deploy(self, power_on=True, force_customization=False):
         """Deploys the VM.
 
         Deploying the VM will allocate all resources assigned

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -139,6 +139,28 @@ class VM(object):
         return self.client.post_linked_resource(
             self.resource, RelationType.POWER_RESET, None, None)
 
+    def reboot(self):
+        """Reboots the VM.
+
+        :return: A :class:`lxml.objectify.StringElement` object describing \
+            the asynchronous Task rebooting the vApp.
+        """
+        if self.resource is None:
+            self.resource = self.client.get_resource(self.href)
+        return self.client.post_linked_resource(
+            self.resource, RelationType.POWER_REBOOT, None, None)
+
+    def shutdown(self):
+        """Shuts down a VM.
+
+        :return: A :class:`lxml.objectify.StringElement` object describing \
+            the asynchronous Task resetting the vApp.
+        """
+        if self.resource is None:
+            self.resource = self.client.get_resource(self.href)
+        return self.client.post_linked_resource(
+            self.resource, RelationType.POWER_SHUTDOWN, None, None)
+
     def deploy(self, power_on=True,
                force_customization=False):
         """Deploys the VM.

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -85,7 +85,7 @@ class VM(object):
         return self.client.put_resource(uri, item, EntityType.RASD_ITEM.value)
 
     def shutdown(self):
-        """Shuts down a VM.
+        """Shutdown the VM.
 
             :return: A :class:`lxml.objectify.StringElement` object describing
                 the asynchronous Task shutting down the VM.

--- a/tests/vcd_vapp_vm.py
+++ b/tests/vcd_vapp_vm.py
@@ -184,51 +184,5 @@ class TestVAppVM(TestCase):
             callback=None)
         assert task.get('status') == TaskStatus.SUCCESS.value
 
-    def test_1004_shutdown_vapp(self):
-        logged_in_org = self.client.get_org()
-        org = Org(self.client, resource=logged_in_org)
-        v = org.get_vdc(self.config['vcd']['vdc'])
-        vdc = VDC(self.client, href=v.get('href'))
-        assert self.config['vcd']['vdc'] == vdc.get_resource().get('name')
-        vapp_resource = vdc.get_vapp(self.config['vcd']['vapp'])
-        assert vapp_resource.get('name') == self.config['vcd']['vapp']
-        vapp = VApp(self.client, resource=vapp_resource)
-        result = vapp.shutdown()
-        task = self.client.get_task_monitor().wait_for_status(
-            task=result,
-            timeout=60,
-            poll_frequency=2,
-            fail_on_statuses=None,
-            expected_target_statuses=[
-                TaskStatus.SUCCESS,
-                TaskStatus.ABORTED,
-                TaskStatus.ERROR,
-                TaskStatus.CANCELED],
-            callback=None)
-        assert task.get('status') == TaskStatus.SUCCESS.value
-
-    def test_1005_reboot_vapp(self):
-        logged_in_org = self.client.get_org()
-        org = Org(self.client, resource=logged_in_org)
-        v = org.get_vdc(self.config['vcd']['vdc'])
-        vdc = VDC(self.client, href=v.get('href'))
-        assert self.config['vcd']['vdc'] == vdc.get_resource().get('name')
-        vapp_resource = vdc.get_vapp(self.config['vcd']['vapp'])
-        assert vapp_resource.get('name') == self.config['vcd']['vapp']
-        vapp = VApp(self.client, resource=vapp_resource)
-        result = vapp.reboot()
-        task = self.client.get_task_monitor().wait_for_status(
-            task=result,
-            timeout=60,
-            poll_frequency=2,
-            fail_on_statuses=None,
-            expected_target_statuses=[
-                TaskStatus.SUCCESS,
-                TaskStatus.ABORTED,
-                TaskStatus.ERROR,
-                TaskStatus.CANCELED],
-            callback=None)
-        assert task.get('status') == TaskStatus.SUCCESS.value
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/vcd_vapp_vm.py
+++ b/tests/vcd_vapp_vm.py
@@ -124,6 +124,53 @@ class TestVAppVM(TestCase):
         assert vapp_resource.get('name') == self.config['vcd']['vapp']
         vapp = VApp(self.client, resource=vapp_resource)
         result = vapp.power_reset()
+        # result = vapp.reboot()
+        task = self.client.get_task_monitor().wait_for_status(
+            task=result,
+            timeout=60,
+            poll_frequency=2,
+            fail_on_statuses=None,
+            expected_target_statuses=[
+                TaskStatus.SUCCESS,
+                TaskStatus.ABORTED,
+                TaskStatus.ERROR,
+                TaskStatus.CANCELED],
+            callback=None)
+        assert task.get('status') == TaskStatus.SUCCESS.value
+
+    def test_1004_shutdown_vapp(self):
+        logged_in_org = self.client.get_org()
+        org = Org(self.client, resource=logged_in_org)
+        v = org.get_vdc(self.config['vcd']['vdc'])
+        vdc = VDC(self.client, href=v.get('href'))
+        assert self.config['vcd']['vdc'] == vdc.get_resource().get('name')
+        vapp_resource = vdc.get_vapp(self.config['vcd']['vapp'])
+        assert vapp_resource.get('name') == self.config['vcd']['vapp']
+        vapp = VApp(self.client, resource=vapp_resource)
+        result = vapp.shutdown()
+        task = self.client.get_task_monitor().wait_for_status(
+            task=result,
+            timeout=60,
+            poll_frequency=2,
+            fail_on_statuses=None,
+            expected_target_statuses=[
+                TaskStatus.SUCCESS,
+                TaskStatus.ABORTED,
+                TaskStatus.ERROR,
+                TaskStatus.CANCELED],
+            callback=None)
+        assert task.get('status') == TaskStatus.SUCCESS.value
+
+    def test_1005_reboot_vapp(self):
+        logged_in_org = self.client.get_org()
+        org = Org(self.client, resource=logged_in_org)
+        v = org.get_vdc(self.config['vcd']['vdc'])
+        vdc = VDC(self.client, href=v.get('href'))
+        assert self.config['vcd']['vdc'] == vdc.get_resource().get('name')
+        vapp_resource = vdc.get_vapp(self.config['vcd']['vapp'])
+        assert vapp_resource.get('name') == self.config['vcd']['vapp']
+        vapp = VApp(self.client, resource=vapp_resource)
+        result = vapp.reboot()
         task = self.client.get_task_monitor().wait_for_status(
             task=result,
             timeout=60,

--- a/tests/vcd_vapp_vm.py
+++ b/tests/vcd_vapp_vm.py
@@ -184,5 +184,51 @@ class TestVAppVM(TestCase):
             callback=None)
         assert task.get('status') == TaskStatus.SUCCESS.value
 
+    def test_1004_shutdown_vapp(self):
+        logged_in_org = self.client.get_org()
+        org = Org(self.client, resource=logged_in_org)
+        v = org.get_vdc(self.config['vcd']['vdc'])
+        vdc = VDC(self.client, href=v.get('href'))
+        assert self.config['vcd']['vdc'] == vdc.get_resource().get('name')
+        vapp_resource = vdc.get_vapp(self.config['vcd']['vapp'])
+        assert vapp_resource.get('name') == self.config['vcd']['vapp']
+        vapp = VApp(self.client, resource=vapp_resource)
+        result = vapp.shutdown()
+        task = self.client.get_task_monitor().wait_for_status(
+            task=result,
+            timeout=60,
+            poll_frequency=2,
+            fail_on_statuses=None,
+            expected_target_statuses=[
+                TaskStatus.SUCCESS,
+                TaskStatus.ABORTED,
+                TaskStatus.ERROR,
+                TaskStatus.CANCELED],
+            callback=None)
+        assert task.get('status') == TaskStatus.SUCCESS.value
+
+    def test_1005_reboot_vapp(self):
+        logged_in_org = self.client.get_org()
+        org = Org(self.client, resource=logged_in_org)
+        v = org.get_vdc(self.config['vcd']['vdc'])
+        vdc = VDC(self.client, href=v.get('href'))
+        assert self.config['vcd']['vdc'] == vdc.get_resource().get('name')
+        vapp_resource = vdc.get_vapp(self.config['vcd']['vapp'])
+        assert vapp_resource.get('name') == self.config['vcd']['vapp']
+        vapp = VApp(self.client, resource=vapp_resource)
+        result = vapp.reboot()
+        task = self.client.get_task_monitor().wait_for_status(
+            task=result,
+            timeout=60,
+            poll_frequency=2,
+            fail_on_statuses=None,
+            expected_target_statuses=[
+                TaskStatus.SUCCESS,
+                TaskStatus.ABORTED,
+                TaskStatus.ERROR,
+                TaskStatus.CANCELED],
+            callback=None)
+        assert task.get('status') == TaskStatus.SUCCESS.value
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/vcd_vm.py
+++ b/tests/vcd_vm.py
@@ -193,6 +193,57 @@ class TestVM(TestCase):
         vm_resource = vapp.get_vm(self.config['vcd']['vm'])
         vm = VM(self.client, resource=vm_resource)
         result = vm.deploy()
+        # result = vm.shutdown()
+        task = self.client.get_task_monitor().wait_for_status(
+            task=result,
+            timeout=60,
+            poll_frequency=2,
+            fail_on_statuses=None,
+            expected_target_statuses=[
+                TaskStatus.SUCCESS,
+                TaskStatus.ABORTED,
+                TaskStatus.ERROR,
+                TaskStatus.CANCELED],
+            callback=None)
+        assert task.get('status') == TaskStatus.SUCCESS.value
+
+    def test_0008_shutdown_vm(self):
+        logged_in_org = self.client.get_org()
+        org = Org(self.client, resource=logged_in_org)
+        v = org.get_vdc(self.config['vcd']['vdc'])
+        vdc = VDC(self.client, href=v.get('href'))
+        assert self.config['vcd']['vdc'] == vdc.get_resource().get('name')
+        vapp_resource = vdc.get_vapp(self.config['vcd']['vapp'])
+        assert vapp_resource.get('name') == self.config['vcd']['vapp']
+        vapp = VApp(self.client, resource=vapp_resource)
+        vm_resource = vapp.get_vm(self.config['vcd']['vm'])
+        vm = VM(self.client, resource=vm_resource)
+        result = vm.shutdown()
+        task = self.client.get_task_monitor().wait_for_status(
+            task=result,
+            timeout=60,
+            poll_frequency=2,
+            fail_on_statuses=None,
+            expected_target_statuses=[
+                TaskStatus.SUCCESS,
+                TaskStatus.ABORTED,
+                TaskStatus.ERROR,
+                TaskStatus.CANCELED],
+            callback=None)
+        assert task.get('status') == TaskStatus.SUCCESS.value
+
+    def test_0009_reboot_vm(self):
+        logged_in_org = self.client.get_org()
+        org = Org(self.client, resource=logged_in_org)
+        v = org.get_vdc(self.config['vcd']['vdc'])
+        vdc = VDC(self.client, href=v.get('href'))
+        assert self.config['vcd']['vdc'] == vdc.get_resource().get('name')
+        vapp_resource = vdc.get_vapp(self.config['vcd']['vapp'])
+        assert vapp_resource.get('name') == self.config['vcd']['vapp']
+        vapp = VApp(self.client, resource=vapp_resource)
+        vm_resource = vapp.get_vm(self.config['vcd']['vm'])
+        vm = VM(self.client, resource=vm_resource)
+        result = vm.reboot()
         task = self.client.get_task_monitor().wait_for_status(
             task=result,
             timeout=60,

--- a/tests/vcd_vm.py
+++ b/tests/vcd_vm.py
@@ -257,5 +257,55 @@ class TestVM(TestCase):
             callback=None)
         assert task.get('status') == TaskStatus.SUCCESS.value
 
+    def test_1004_shutdown_vm(self):
+        logged_in_org = self.client.get_org()
+        org = Org(self.client, resource=logged_in_org)
+        v = org.get_vdc(self.config['vcd']['vdc'])
+        vdc = VDC(self.client, href=v.get('href'))
+        assert self.config['vcd']['vdc'] == vdc.get_resource().get('name')
+        vapp_resource = vdc.get_vapp(self.config['vcd']['vapp'])
+        assert vapp_resource.get('name') == self.config['vcd']['vapp']
+        vapp = VApp(self.client, resource=vapp_resource)
+        vm_resource = vapp.get_vm(self.config['vcd']['vm'])
+        vm = VM(self.client, resource=vm_resource)
+        result = vm.shutdown()
+        task = self.client.get_task_monitor().wait_for_status(
+            task=result,
+            timeout=60,
+            poll_frequency=2,
+            fail_on_statuses=None,
+            expected_target_statuses=[
+                TaskStatus.SUCCESS,
+                TaskStatus.ABORTED,
+                TaskStatus.ERROR,
+                TaskStatus.CANCELED],
+            callback=None)
+        assert task.get('status') == TaskStatus.SUCCESS.value
+
+    def test_1005_reboot_vm(self):
+        logged_in_org = self.client.get_org()
+        org = Org(self.client, resource=logged_in_org)
+        v = org.get_vdc(self.config['vcd']['vdc'])
+        vdc = VDC(self.client, href=v.get('href'))
+        assert self.config['vcd']['vdc'] == vdc.get_resource().get('name')
+        vapp_resource = vdc.get_vapp(self.config['vcd']['vapp'])
+        assert vapp_resource.get('name') == self.config['vcd']['vapp']
+        vapp = VApp(self.client, resource=vapp_resource)
+        vm_resource = vapp.get_vm(self.config['vcd']['vm'])
+        vm = VM(self.client, resource=vm_resource)
+        result = vm.reboot()
+        task = self.client.get_task_monitor().wait_for_status(
+            task=result,
+            timeout=60,
+            poll_frequency=2,
+            fail_on_statuses=None,
+            expected_target_statuses=[
+                TaskStatus.SUCCESS,
+                TaskStatus.ABORTED,
+                TaskStatus.ERROR,
+                TaskStatus.CANCELED],
+            callback=None)
+        assert task.get('status') == TaskStatus.SUCCESS.value
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Includes SDK methods for rebooting and shutting down a vapp or VM(s) within a vapp

Added SDK methods for rebooting a vApp/VM
Added SDK methods for shutting down a vApp/VM
Added required unit tests.

**Command** : **vcd vapp shutdown sompa-vapp**
```
Are you sure you want to shutdown the vApp? [y/N]: y
vappShutdownGuest: Shutting down Virtual Application sompa-vapp(e332aacb-9a80-4aed-860c-af7de0ca10e9)
vappShutdownGuest: Shutting down Virtual Application sompa-vapp(e332aacb-9a80-4aed-860c-af7de0ca10e9)
task: 0df63085-0b7a-4bf4-9c46-203d2979655e, Shut down Virtual Application sompa-vapp(e332aacb-9a80-4aed-860c-af7de0ca10e9), result: success


```
**Command:** **vcd vapp shutdown sompa-vapp vm3**
```
Are you sure you want to shutdown the vApp? [y/N]: y
vappShutdownGuest: Shutting down Virtual Machine vm3(afe0a16d-2750-43ec-a779-73073d12088c)
task: bd97d769-4de7-47b1-b5e5-49c9bf258cb7, result: error, message: [ 21bbfe02-5ce1-4247-bccc-f2f25b214d26 ] null
 - Cannot complete operation because VMware Tools is not running in this virtual machine.
(vcd-cli) malakars-m01:vcd-cli malakars$ vcd vapp reboot sompa-vapp vm3
Are you sure you want to reboot the vApp or VM(s)? [y/N]: y
vappRebootGuest: Rebooting Virtual Machine vm3(afe0a16d-2750-43ec-a779-73073d12088c)
task: f7ede655-0f53-404e-b216-e40e1a3085a6, result: error, message: [ 4d2e708f-cc9e-4f8e-8d95-bc67dc3d8fce ] Internal Server Error
 - Failed to reboot guest os for the VM "vm3 (afe0a16d-2750-43ec-a779-73073d12088c)" as required VM tools were found unavailable.
 - Cannot complete operation because VMware Tools is not running in this virtual machine.
```
**Command : vcd vapp reboot sompa-vapp**
```
Are you sure you want to reboot the vApp or VM(s)? [y/N]: y
vappRebootGuest: Rebooting Virtual Application sompa-vapp(e332aacb-9a80-4aed-860c-af7de0ca10e9)
vappRebootGuest: Rebooting Virtual Application sompa-vapp(e332aacb-9a80-4aed-860c-af7de0ca10e9)
task: 85ed6d2b-eb0f-4199-99bf-bc4b7d6a64eb, Reboot Virtual Application sompa-vapp(e332aacb-9a80-4aed-860c-af7de0ca10e9), result: success

```
**Command : vcd vapp reboot sompa-vapp vm3**
```
Are you sure you want to reboot the vApp or VM(s)? [y/N]: y
vappRebootGuest: Rebooting Virtual Machine vm3(afe0a16d-2750-43ec-a779-73073d12088c)
task: 3d07779b-4849-4ad7-bfc2-686af445a04f, result: error, message: [ 94940880-d9e0-41b6-80db-7c04a56f7f28 ] Internal Server Error
 - Failed to reboot guest os for the VM "vm3 (afe0a16d-2750-43ec-a779-73073d12088c)" as required VM tools were found unavailable.
 - Cannot complete operation because VMware Tools is not running in this virtual machine.
```

Tests Run : 
`(pyvcloud) malakars-m01:tests malakars$ python -m unittest vcd_vapp_vm.TestVAppVM.test_1004_shutdown_vapp
.
----------------------------------------------------------------------
Ran 1 test in 14.628s

OK
(pyvcloud) malakars-m01:tests malakars$ python -m unittest vcd_vapp_vm.TestVAppVM.test_1005_reboot_vapp
.
----------------------------------------------------------------------
Ran 1 test in 10.343s

OK

`
`(pyvcloud) malakars-m01:tests malakars$ python -m unittest vcd_vm.TestVM.test_1005_reboot_vm
.
----------------------------------------------------------------------
Ran 1 test in 6.778s

OK
(pyvcloud) malakars-m01:tests malakars$ python -m unittest vcd_vm.TestVM.test_1004_shutdown_vm
.
----------------------------------------------------------------------
Ran 1 test in 8.307s

OK
`
- @rocknes @pacogomez @anusuyar @sahithi @hodgesrm @rdbwebster

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/185)
<!-- Reviewable:end -->
