### PR TITLE
VCDA-421 & VCDA-422: Implementing SDK methods and cli commands to connect/disconnect ovdc_network to/from vapp.

### DIFF
--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -22,6 +22,7 @@ from pyvcloud.vcd.acl import Acl
 from pyvcloud.vcd.client import E
 from pyvcloud.vcd.client import E_OVF
 from pyvcloud.vcd.client import EntityType
+from pyvcloud.vcd.client import FenceMode
 from pyvcloud.vcd.client import find_link
 from pyvcloud.vcd.client import NSMAP
 from pyvcloud.vcd.client import RelationType
@@ -612,17 +613,21 @@ class VApp(object):
             self.resource, RelationType.RECOMPOSE,
             EntityType.RECOMPOSE_VAPP_PARAMS.value, params)
 
-    def connect_org_vdc_network(self, orgvdc_network_name, retain_ip=False,
-                                is_deployed=False):
-        """Connect an orgvdc network to the vapp.
+    def connect_org_vdc_network(self,
+                                orgvdc_network_name,
+                                retain_ip=None,
+                                is_deployed=None,
+                                fence_mode=FenceMode.BRIDGED.value):
+        """Connect the vapp to an orgvdc network.
 
         :param orgvdc_network_name: (str): name of the orgvdc network to be
             connected
         :param retain_ip: (bool): True if  the network resources such as
-            IP/MAC of router will be retained across deployments. False by
-            default.
+            IP/MAC of router will be retained across deployments.
         :param is_deployed: (bool): True if this orgvdc network has been
-            deployed. False by default.
+            deployed.
+        :param fence_mode: (str): Controls connectivity to the parent
+            network. One of bridged, isolated or natRouted. bridged by default.
 
         :return: A :class:`lxml.objectify.StringElement` object representing
             the updated NetworkConfigSection of the vapp.
@@ -641,22 +646,24 @@ class VApp(object):
         orgvdc_network_href = orgvdc_networks[0].get('href')
 
         network_configuration_section = \
-            self.get_network_configuration_section()
+            deepcopy(self.resource.NetworkConfigSection)
 
-        matched_orgvdc_network_config = self.search_for_network_config_by_name(
-            orgvdc_network_name, network_configuration_section)
+        matched_orgvdc_network_config = \
+            self._search_for_network_config_by_name(
+                orgvdc_network_name, network_configuration_section)
         if matched_orgvdc_network_config is not None:
             raise Exception("Orgvdc network \'%s\' is already connected to "
                             "vapp." % orgvdc_network_name)
 
-        network_config = E.Configuration(
-            E.ParentNetwork(href=orgvdc_network_href), E.FenceMode('bridged'),
-            E.RetainNetInfoAcrossDeployments(retain_ip))
-
-        network_configuration_section.append(
-            E.NetworkConfig(
-                network_config, E.IsDeployed(is_deployed),
-                networkName=orgvdc_network_name))
+        configuration = E.Configuration(
+            E.ParentNetwork(href=orgvdc_network_href), E.FenceMode(fence_mode))
+        if retain_ip is not None:
+            configuration.append(E.RetainNetInfoAcrossDeployments(retain_ip))
+        network_config = E.NetworkConfig(
+            configuration, networkName=orgvdc_network_name)
+        if is_deployed is not None:
+            network_config.append(E.IsDeployed(is_deployed))
+        network_configuration_section.append(network_config)
 
         return self.client.put_linked_resource(
             self.resource.NetworkConfigSection, RelationType.EDIT,
@@ -664,10 +671,10 @@ class VApp(object):
             network_configuration_section)
 
     def disconnect_org_vdc_network(self, orgvdc_network_name):
-        """Disconnect an orgvdc network from the vapp.
+        """Disconnect the vapp from an orgvdc network.
 
         :param orgvdc_network_name: (str): name of the orgvdc
-            network to be disconnected
+            network to be disconnected.
 
         :return: A :class:`lxml.objectify.StringElement` object
             representing the updated NetworkConfigSection of the vapp.
@@ -675,10 +682,11 @@ class VApp(object):
         :raises: Exception: If orgvdc network is not connected to the vapp.
         """
         network_configuration_section = \
-            self.get_network_configuration_section()
+            deepcopy(self.resource.NetworkConfigSection)
 
-        matched_orgvdc_network_config = self.search_for_network_config_by_name(
-            orgvdc_network_name, network_configuration_section)
+        matched_orgvdc_network_config = \
+            self._search_for_network_config_by_name(
+                orgvdc_network_name, network_configuration_section)
         if matched_orgvdc_network_config is None:
             raise Exception("Orgvdc network \'%s\' is not attached to the vapp"
                             % orgvdc_network_name)
@@ -690,24 +698,16 @@ class VApp(object):
             EntityType.NETWORK_CONFIG_SECTION.value,
             network_configuration_section)
 
-    def get_network_configuration_section(self):
-        """Get the NetworkConfigSection of a vapp.
-
-        :return: A :class:`lxml.objectify.StringElement` object
-            representing the  NetworkConfigSection of the vapp.
-        """
-        return self.client.get_resource(
-            self.resource.get('href') + '/networkConfigSection/')
-
     @staticmethod
-    def search_for_network_config_by_name(orgvdc_network_name,
-                                          network_configuration_section):
+    def _search_for_network_config_by_name(orgvdc_network_name,
+                                           network_configuration_section):
         """Search for the NetworkConfig element by orgvdc network name.
 
         :param orgvdc_network_name: (str): name of the orgvdc network to be
             searched.
         :param network_configuration_section :(lxml.objectify.StringElement):
             NetworkConfigSection of a vapp.
+
         :return: A :class:`lxml.objectify.StringElement` object
             representing the  NetworkConfig element in NetworkConfigSection.
         """

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -629,8 +629,8 @@ class VApp(object):
         :param fence_mode: (str): Controls connectivity to the parent
             network. One of bridged, isolated or natRouted. bridged by default.
 
-        :return: A :class:`lxml.objectify.StringElement` object representing
-            the updated NetworkConfigSection of the vapp.
+        :return:  A :class:`lxml.objectify.StringElement` object representing
+            the asynchronous task that is connecting the network.
 
         :raises: Exception: If orgvdc network does not exist in the vdc or if
         it is already connected to the vapp.
@@ -676,8 +676,8 @@ class VApp(object):
         :param orgvdc_network_name: (str): name of the orgvdc
             network to be disconnected.
 
-        :return: A :class:`lxml.objectify.StringElement` object
-            representing the updated NetworkConfigSection of the vapp.
+        :return:  A :class:`lxml.objectify.StringElement` object representing
+            the asynchronous task that is disconnecting the network.
 
         :raises: Exception: If orgvdc network is not connected to the vapp.
         """

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -380,7 +380,7 @@ class VDC(object):
         :param name: (str): The name of the new disk.
         :param size: (int): The size of the new disk in bytes.
         :param bus_type: (str): The bus type of the new disk.
-        :param bus_subtype: (str): The bus subtype  of the new disk.
+        :param bus_sub_type: (str): The bus subtype  of the new disk.
         :param description: (str): A description of the new disk.
         :param storage_profile_name: (str): The name of an existing
             storage profile to be used by the new disk.
@@ -634,7 +634,7 @@ class VDC(object):
     def enable_vdc(self, enable=True):
         """Enable current vdc.
 
-        :param is_enabled: (bool): enable/disable the vdc.
+        :param enable: (bool): enable/disable the vdc.
         :return: (OrgVdcType) updated vdc object.
         """
         resource_admin = self.client.get_resource(self.href_admin)
@@ -838,24 +838,24 @@ class VDC(object):
         """Create a new isolated OrgVdc network in this vdc.
 
         :param network_name: (str): Name of the new network.
-        :param gateway_ip (str): IP address of the gateway of the new network.
-        :param netmask (str): Network mask.
+        :param gateway_ip: (str): IP address of the gateway of the new network.
+        :param netmask: (str): Network mask.
         :param description: (str): Description of the new network.
-        :param primary_dns_ip (str): IP address of primary DNS server.
-        :param secondary_dns_ip (str): IP address of secondary DNS Server.
-        :param dns_suffix (str): DNS suffix.
-        :param ip_range_start (str): Start address of the IP ranges used for
+        :param primary_dns_ip: (str): IP address of primary DNS server.
+        :param secondary_dns_ip: (str): IP address of secondary DNS Server.
+        :param dns_suffix: (str): DNS suffix.
+        :param ip_range_start: (str): Start address of the IP ranges used for
             static pool allocation in the network.
-        :param ip_range_end (str): End address of the IP ranges used for
+        :param ip_range_end: (str): End address of the IP ranges used for
             static pool allocation in the network.
-        :param is_dhcp_enabled (bool): Is DHCP service enabled on the new
+        :param is_dhcp_enabled: (bool): Is DHCP service enabled on the new
             network.
-        :param default_lease_time (int): Default lease in seconds for DHCP
+        :param default_lease_time: (int): Default lease in seconds for DHCP
             addresses.
-        :param max_lease_time (int): Max lease in seconds for DHCP addresses.
-        :param dhcp_ip_range_start (str): Start address of the IP range
+        :param max_lease_time: (int): Max lease in seconds for DHCP addresses.
+        :param dhcp_ip_range_start: (str): Start address of the IP range
             used for DHCP addresses.
-        :param dhcp_ip_range_end (str): End address of the IP range used for
+        :param dhcp_ip_range_end: (str): End address of the IP range used for
             DHCP addresses.
         :param is_shared: (bool): True, if the network is shared with other
             vdc(s) in the organization, else False.
@@ -932,8 +932,8 @@ class VDC(object):
     def list_orgvdc_network_resources(self, name=None, type=None):
         """Fetch orgvdc networks with filtering by name and type.
 
-        :param name (str): Name of the networks we want to retrieve.
-        :param type (str): Type of networks we want to retrieve, valid values
+        :param name: (str): Name of the networks we want to retrieve.
+        :param type: (str): Type of networks we want to retrieve, valid values
             are 'bridged' and 'isolated'.
 
         :return:  A list of :class:`lxml.objectify.StringElement` objects
@@ -979,7 +979,7 @@ class VDC(object):
     def get_direct_orgvdc_network(self, name):
         """Retrieve a directly connected orgvdc network in the current vdc.
 
-        :param name (str): Name of the orgvdc network we want to retieve.
+        :param name: (str): Name of the orgvdc network we want to retrieve.
 
         :return:  A :class:`lxml.objectify.StringElement` object representing
             a directly connected orgvdc network resource.
@@ -996,7 +996,7 @@ class VDC(object):
     def get_isolated_orgvdc_network(self, name):
         """Retrieve an isolated orgvdc network in the current vdc.
 
-        :param name (str): Name of the orgvdc network we want to retieve.
+        :param name: (str): Name of the orgvdc network we want to retrieve.
 
         :return:  A :class:`lxml.objectify.StringElement` object representing
             an isolated orgvdc network resource.
@@ -1013,8 +1013,8 @@ class VDC(object):
     def delete_direct_orgvdc_network(self, name, force=False):
         """Delete a directly connected orgvdc network in the current vdc.
 
-        :param name (str): Name of the orgvdc network to be deleted.
-        :param force (bool): If True, will instruct vcd to force delete
+        :param name: (str): Name of the orgvdc network to be deleted.
+        :param force: (bool): If True, will instruct vcd to force delete
             the network, ignoring whether it's connected to a vm or vapp
             network or not.
 
@@ -1030,8 +1030,8 @@ class VDC(object):
     def delete_isolated_orgvdc_network(self, name, force=False):
         """Delete an isolated orgvdc network in the current vdc.
 
-        :param name (str): Name of the orgvdc network to be deleted.
-        :param force (bool): If True, will instruct vcd to force delete
+        :param name: (str): Name of the orgvdc network to be deleted.
+        :param force: (bool): If True, will instruct vcd to force delete
             the network, ignoring whether it's connected to a vm or vapp
             network or not.
 

--- a/tests/vcd_vapp.py
+++ b/tests/vcd_vapp.py
@@ -115,6 +115,50 @@ class TestVApp(TestCase):
         assert len(vm) > 0
         assert vm[0].get('name') == self.config['vcd']['vm']
 
+    def test_101_connect_orgvdc_network(self):
+        org_in_use = self.config['vcd']['org_in_use']
+        org = Org(self.client,
+                  href=self.client.get_org_by_name(org_in_use).get('href'))
+        v = org.get_vdc(self.config['vcd']['vdc'])
+        vdc = VDC(self.client, href=v.get('href'))
+        vapp_resource = vdc.get_vapp(self.config['vcd']['vapp'])
+        vapp = VApp(self.client, resource=vapp_resource)
+        result = vapp.connect_org_vdc_network(self.config['vcd'][
+                                                 'orgvdc_network'])
+        task = self.client.get_task_monitor().wait_for_status(
+            task=result,
+            timeout=60,
+            poll_frequency=2,
+            fail_on_statuses=None,
+            expected_target_statuses=[
+                TaskStatus.SUCCESS, TaskStatus.ABORTED, TaskStatus.ERROR,
+                TaskStatus.CANCELED
+            ],
+            callback=None)
+        assert task.get('status') == TaskStatus.SUCCESS.value
+
+    def test_102_disconnect_orgvdc_network(self):
+        org_in_use = self.config['vcd']['org_in_use']
+        org = Org(self.client,
+                  href=self.client.get_org_by_name(org_in_use).get('href'))
+        v = org.get_vdc(self.config['vcd']['vdc'])
+        vdc = VDC(self.client, href=v.get('href'))
+        vapp_resource = vdc.get_vapp(self.config['vcd']['vapp'])
+        vapp = VApp(self.client, resource=vapp_resource)
+        result = vapp.disconnect_org_vdc_network(self.config['vcd'][
+                                                 'orgvdc_network'])
+        task = self.client.get_task_monitor().wait_for_status(
+            task=result,
+            timeout=60,
+            poll_frequency=2,
+            fail_on_statuses=None,
+            expected_target_statuses=[
+                TaskStatus.SUCCESS, TaskStatus.ABORTED, TaskStatus.ERROR,
+                TaskStatus.CANCELED
+            ],
+            callback=None)
+        assert task.get('status') == TaskStatus.SUCCESS.value
+
     def test_11_change_owner(self):
         logged_in_org = self.client.get_org()
         org = Org(self.client, resource=logged_in_org)


### PR DESCRIPTION


```
C:\sources\github\service_ecosystem\vcd-cli (master)
(vcd-cli) λ vcd vapp disconnect v1 ovdcnet
Are you sure you want to disconnect the network? [y/N]: y
Successfully disconnected ovdc network 'ovdcnet' from vapp 'v1'

C:\sources\github\service_ecosystem\vcd-cli (master)
(vcd-cli) λ vcd vapp disconnect v1 ovdcneter
Are you sure you want to disconnect the network? [y/N]: y
Usage: vcd vapp disconnect [OPTIONS] <vapp-name> <orgvdc-network-name>

Error: Orgvdc network 'ovdcneter' is not attached to the vapp

C:\sources\github\service_ecosystem\vcd-cli (master)
(vcd-cli) λ vcd vapp connect v1 ovdcneter
Usage: vcd vapp connect [OPTIONS] <vapp-name> <orgvdc-network-name>

Error: Orgvdc network 'ovdcneter' does not exist in vdc 'vdc1'

C:\sources\github\service_ecosystem\vcd-cli (master)
(vcd-cli) λ vcd vapp connect v1 ovdcnet
Successfully connected ovdc network 'ovdcnet' to vapp 'v1'

C:\sources\github\service_ecosystem\vcd-cli (master)
(vcd-cli) λ vcd vapp connect v1 ovdcnet
Usage: vcd vapp connect [OPTIONS] <vapp-name> <orgvdc-network-name>

Error: Orgvdc network 'ovdcnet' is already connected to vapp.

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/190)
<!-- Reviewable:end -->
