### PR TITLE
VCDA-471: Fixed listing of edge gateways, when there are none in the system

### DIFF
--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -360,11 +360,12 @@ class VDC(object):
                                                 RelationType.EDGE_GATEWAYS,
                                                 EntityType.RECORDS.value)
         edge_gateways = []
-        for e in links.EdgeGatewayRecord:
-            edge_gateways.append({
-                'name': e.get('name'),
-                'href': e.get('href')
-            })
+        if hasattr(links, 'EdgeGatewayRecord'):
+            for e in links.EdgeGatewayRecord:
+                edge_gateways.append({
+                    'name': e.get('name'),
+                    'href': e.get('href')
+                })
         return edge_gateways
 
     def create_disk(self,


### PR DESCRIPTION
Added check to make sure that we try to iterate over EdgeGatewayRecord only if there is atleast one of them.

Ran vcd-cli command vcd gateway list to make sure that no errors were thrown on a system with 0 edge gateways.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/192)
<!-- Reviewable:end -->
