### PR TITLE
VCDA-472: get_vcenter() in platform.py should raise exception when a vCenter with the user provided name can't be found.

### DIFF
--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -52,11 +52,13 @@ class Platform(object):
         :param name: (str): The name of vCenter.
 
         :return: (lxml.objectify.ObjectifiedElement): vCenter resource.
+
+        :raises: Exception: If the named vCenter cannot be located.
         """
         for record in self.list_vcenters():
             if record.get('name') == name:
                 return self.client.get_resource(record.get('href'))
-        return None
+        raise Exception('vCenter \'%s\' not found' % name)
 
     def list_external_networks(self):
         """List all external networks available in the system.

--- a/tests/vcd_vc.py
+++ b/tests/vcd_vc.py
@@ -14,8 +14,10 @@
 # limitations under the License.
 
 import unittest
-from pyvcloud.vcd.test import TestCase
+
 from pyvcloud.vcd.platform import Platform
+from pyvcloud.vcd.test import TestCase
+
 
 class TestVC(TestCase):
 
@@ -32,6 +34,15 @@ class TestVC(TestCase):
         self.logger.debug('vCenter: name=%s, url=%s' %
                           (vcenter.get('name'), vcenter.Url.text))
         assert vcenter is not None
+
+    def test_0003_get_vc_negative(self):
+        try:
+            platform = Platform(self.client)
+            platform.get_vcenter(self.config['vcd']['vcenter_invalid'])
+            assert False
+        except Exception as e:
+            assert 'not found' in str(e).lower()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* Modified get_vcenter() to raise exception if a suitable vCenter is not found
* Added unit test

(pyvcloud) C:\code\pyvcloud\tests>python -m unittest vcd_vc.TestVC.test_0003_get_vc_negative
.
----------------------------------------------------------------------
Ran 1 test in 1.233s

OK

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/193)
<!-- Reviewable:end -->
