### PR TITLE
VCDA-397: Refactor constructors to raise Error when both href and resource are None.

### DIFF
--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -50,6 +50,8 @@ class Org(object):
 
         """
         self.client = client
+        if href is None and resource is None:
+            raise TypeError("Org initialization failed as arguments are invalid or None")
         self.href = href
         self.resource = resource
         if resource is not None:

--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -51,7 +51,8 @@ class Org(object):
         """
         self.client = client
         if href is None and resource is None:
-            raise TypeError("Org initialization failed as arguments are invalid or None")
+            raise TypeError("Org initialization failed as arguments"
+                            " are either invalid or None")
         self.href = href
         self.resource = resource
         if resource is not None:

--- a/pyvcloud/vcd/pvdc.py
+++ b/pyvcloud/vcd/pvdc.py
@@ -29,6 +29,8 @@ class PVDC(object):
             representation of the entity.
         """
         self.client = client
+        if href is None and resource is None:
+            raise TypeError("PVDC initialization failed as arguments are invalid or None")
         self.href = href
         self.resource = resource
         if resource is not None:

--- a/pyvcloud/vcd/pvdc.py
+++ b/pyvcloud/vcd/pvdc.py
@@ -30,7 +30,8 @@ class PVDC(object):
         """
         self.client = client
         if href is None and resource is None:
-            raise TypeError("PVDC initialization failed as arguments are invalid or None")
+            raise TypeError("PVDC initialization failed as arguments"
+                            " are either invalid or None")
         self.href = href
         self.resource = resource
         if resource is not None:

--- a/pyvcloud/vcd/role.py
+++ b/pyvcloud/vcd/role.py
@@ -32,7 +32,8 @@ class Role(object):
         """
         self.client = client
         if href is None and resource is None:
-            raise TypeError("Role initialization failed as arguments are invalid or None")
+            raise TypeError("Role initialization failed as arguments"
+                            " are either invalid or None")
         self.href = href
         self.resource = resource
         if resource is not None:

--- a/pyvcloud/vcd/role.py
+++ b/pyvcloud/vcd/role.py
@@ -31,6 +31,8 @@ class Role(object):
 
         """
         self.client = client
+        if href is None and resource is None:
+            raise TypeError("Role initialization failed as arguments are invalid or None")
         self.href = href
         self.resource = resource
         if resource is not None:

--- a/pyvcloud/vcd/system.py
+++ b/pyvcloud/vcd/system.py
@@ -33,7 +33,8 @@ class System(object):
         """
         self.client = client
         if admin_href is None and admin_resource is None:
-            raise TypeError("System initialization failed as arguments are invalid or None")
+            raise TypeError("System initialization failed as arguments"
+                            " are either invalid or None")
         self.admin_href = admin_href
         self.admin_resource = admin_resource
         if admin_resource is not None:

--- a/pyvcloud/vcd/system.py
+++ b/pyvcloud/vcd/system.py
@@ -32,6 +32,8 @@ class System(object):
 
         """
         self.client = client
+        if admin_href is None and admin_resource is None:
+            raise TypeError("System initialization failed as arguments are invalid or None")
         self.admin_href = admin_href
         self.admin_resource = admin_resource
         if admin_resource is not None:

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -33,6 +33,8 @@ class VApp(object):
     def __init__(self, client, name=None, href=None, resource=None):
         self.client = client
         self.name = name
+        if href is None and resource is None:
+            raise TypeError("VApp initialization failed as arguments are invalid or None")
         self.href = href
         self.resource = resource
         if resource is not None:

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -34,7 +34,8 @@ class VApp(object):
         self.client = client
         self.name = name
         if href is None and resource is None:
-            raise TypeError("VApp initialization failed as arguments are invalid or None")
+            raise TypeError("VApp initialization failed as arguments"
+                            " are either invalid or None")
         self.href = href
         self.resource = resource
         if resource is not None:

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -31,6 +31,8 @@ class VDC(object):
     def __init__(self, client, name=None, href=None, resource=None):
         self.client = client
         self.name = name
+        if href is None and resource is None:
+            raise TypeError("VDC initialization failed as arguments are invalid or None")
         self.href = href
         self.resource = resource
         if resource is not None:

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -32,7 +32,8 @@ class VDC(object):
         self.client = client
         self.name = name
         if href is None and resource is None:
-            raise TypeError("VDC initialization failed as arguments are invalid or None")
+            raise TypeError("VDC initialization failed as arguments"
+                            " are either invalid or None")
         self.href = href
         self.resource = resource
         if resource is not None:

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -32,7 +32,8 @@ class VM(object):
         """
         self.client = client
         if href is None and resource is None:
-            raise TypeError("VM initialization failed as arguments are invalid or None")
+            raise TypeError("VM initialization failed as arguments "
+                            "are either invalid or None")
         self.href = href
         self.resource = resource
         if resource is not None:

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -31,6 +31,8 @@ class VM(object):
             object describing the VM.
         """
         self.client = client
+        if href is None and resource is None:
+            raise TypeError("VM initialization failed as arguments are invalid or None")
         self.href = href
         self.resource = resource
         if resource is not None:


### PR DESCRIPTION
Currently, all pyvcloud Entity constructors expect one of href and resource variables to be populated. When both href and resource arguments are None, it fails at vCD rest-api calls instead of failing at pyvcloud level.

This change-set ensure that all constructors raise exception when both href and resource are found to be None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/196)
<!-- Reviewable:end -->
