### PR TITLE
VCDA-495: Add a sample application to illustrate on-boarding

### DIFF
--- a/examples/tenant-onboard.py
+++ b/examples/tenant-onboard.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the
+# Apache License, Version 2.0 (the "License").
+# You may not use this product except in compliance with the License.
+#
+# This product may include a number of subcomponents with
+# separate copyright notices and license terms. Your use of the source
+# code for the these subcomponents is subject to the terms and
+# conditions of the subcomponent's license, as noted in the LICENSE file.
+
+# Example procedure to onboard a tenant. This file reads the desired org,
+# user, catalog contents, network, and vapp(s) from a configuration file.
+# It adds anything that is missing.  If everything already exists, the
+# sample procedure does nothing.
+#
+# Usage: python3 tenant-onboard.py tenant.yaml
+
+from collections import namedtuple
+import requests
+import sys
+import time
+import yaml
+
+# Private utility functions.
+from tenantlib import handle_task
+
+from pyvcloud.vcd.client import BasicLoginCredentials
+from pyvcloud.vcd.client import Client
+from pyvcloud.vcd.client import FenceMode
+from pyvcloud.vcd.client import QueryResultFormat
+from pyvcloud.vcd.org import Org
+from pyvcloud.vcd.system import System
+from pyvcloud.vcd.utils import to_dict
+from pyvcloud.vcd.vdc import VDC
+
+# Collect arguments.
+if len(sys.argv) != 2:
+    print("Usage: python3 {0} config_file".format(sys.argv[0]))
+    sys.exit(1)
+config_yaml = sys.argv[1]
+
+# Load the YAML configuration and convert to an object with properties for
+# top-level entries.  Values are either scalar variables, dictionaries,
+# or lists depending on the structure of the YAML.
+with open(config_yaml, "r") as config_file:
+    config_dict = yaml.load(config_file)
+    cfg = namedtuple('ConfigObject', config_dict.keys())(**config_dict)
+
+# Disable warnings from self-signed certificates.
+requests.packages.urllib3.disable_warnings()
+
+# Login. SSL certificate verification is turned off to allow self-signed
+# certificates.  You should only do this in trusted environments.
+print("Logging in...")
+client = Client(cfg.vcd_host, verify_ssl_certs=False,
+                log_file='pyvcloud.log',
+                log_requests=True,
+                log_headers=True,
+                log_bodies=True)
+client.set_highest_supported_version()
+client.set_credentials(BasicLoginCredentials(cfg.vcd_admin_user,
+                       "System", cfg.vcd_admin_password))
+
+# Ensure the org exists.
+print("Fetching org...")
+try:
+    # This call gets a record that we can turn into an Org class. 
+    org_record = client.get_org_by_name(cfg.org)
+    org = Org(client, href = org_record.get('href'))
+    print("Org already exists: {0}".format(org.get_name()))
+except Exception:
+    print("Org does not exist, creating: {0}".format(cfg.org))
+    sys_admin_resource = client.get_admin()
+    system = System(client, admin_resource=sys_admin_resource)
+    admin_org_resource = system.create_org(cfg.org, "Test Org", True)
+    org_record = client.get_org_by_name(cfg.org)
+    org = Org(client, href = org_record.get('href'))
+    print("Org now exists: {0}".format(org.get_name()))
+
+# Ensure user exists on the org.
+try:
+    user_resource = org.get_user(cfg.user['name'])
+    print("User already exists: {0}".format(cfg.user['name']))
+except Exception:
+    print("User does not exist, creating: {0}".format(cfg.user['name']))
+    role_record = org.get_role_record(cfg.user['role'])
+    user_resource = org.create_user(user_name=cfg.user['name'],
+                             password=cfg.user['password'],
+                             role_href=role_record.get('href'))
+    print("User now exists: {0}".format(user_resource.get('name')))
+
+# Ensure VDC exists.  If we create it reload the org as it affects
+# org resource contents and future calls might fail otherwise. 
+try:
+    vdc_resource = org.get_vdc(cfg.vdc['vdc_name'])
+    vdc = VDC(client, resource=vdc_resource)
+    print("VDC already exists: {0}".format(vdc.name))
+except Exception:
+    print("VDC does not exist, creating: {0}".format(cfg.vdc['vdc_name']))
+    vdc_kwargs = cfg.vdc
+    admin_vdc_resource = org.create_org_vdc(**vdc_kwargs)
+    # The 'admin_vdc_resource' is not a task but an AdminVdc entity.  Tasks 
+    # are two levels down.  
+    handle_task(client, admin_vdc_resource.Tasks.Task[0])
+    org.reload()
+    vdc_resource = org.get_vdc(cfg.vdc['vdc_name'])
+    vdc = VDC(client, resource=vdc_resource)
+    print("VDC now exists: {0}".format(vdc.name))
+
+# Ensure the catalog exists.  For now we don't do anything special with
+# permissions.  As with VDC's we reload the org if we create a catalog
+# so that it's visible in future calls. 
+try:
+    catalog_resource = org.get_catalog_resource(cfg.catalog['name'])
+    print("Catalog already exists: {0}".format(cfg.catalog['name']))
+except Exception:
+    print("Catalog does not exist, creating: {0}".format(cfg.catalog['name']))
+    catalog_kwargs = cfg.catalog
+    catalog_resource = org.create_catalog(**catalog_kwargs)
+    org.reload()
+    print("Catalog now exists: {0}".format(catalog_resource.get('name')))
+
+# Check for catalog_items containing OVF templates in the catalog and 
+# upload them if they are missing.
+for catalog_item in cfg.catalog_items:
+    try:
+        catalog_item_resource = org.get_catalog_item(
+            catalog_item['catalog_name'], catalog_item['item_name'])
+        print("Catalog item exists: {0}".format(catalog_item['item_name']))
+    except Exception:
+        # Define a progress reporter to track upload, since it takes
+        # a while.
+        def progress_reporter(transferred, total):
+            print("{:,} of {:,} bytes, {:.0%}".format(
+                transferred, total, transferred / total))
+
+        print("Loading catalog item: catalog={0}, item={1}, file={2}".format(
+            catalog_item['catalog_name'], 
+            catalog_item['item_name'], 
+            catalog_item['file_name']))
+        catalog_item['callback'] = progress_reporter
+        org.upload_ovf(**catalog_item)
+        print("Upload completed")
+
+# Just because OVF templates are loaded does not mean they are usable yet.
+# We check to ensure they are in the resolved state; otherwise, we cannot
+# use them for vApps.  The following code loops until catalog items are
+# in the right state.
+print("Checking for unresolved templates")
+find_unresolved = True
+while find_unresolved:
+    find_unresolved = False
+    # Iterate over all the desired templates from the config file.
+    for catalog_item in cfg.catalog_items:
+        # Run a report query on this catalog item to find its state.
+        catalog_item_resource = org.get_catalog_item(
+            catalog_item['catalog_name'], catalog_item['item_name'])
+        resource_type = 'adminCatalogItem'
+        query = client.get_typed_query(
+            resource_type,
+            query_result_format=QueryResultFormat.ID_RECORDS,
+            qfilter="catalogName=={0};name=={1}".format(
+                catalog_item['catalog_name'], catalog_item['item_name']))
+        item_records = list(query.execute())
+        # Ensure we find the catalog item.
+        if len(item_records) == 0:
+            raise Exception("Catalog item not found: {0}".format(
+                catalog_item['item_name']))
+        else:
+            for item_record in item_records:
+                item_dict = to_dict(item_record, resource_type=resource_type)
+                # If the template exists but is not in the right
+                # state we need to wait.
+                if item_dict['status'] != "RESOLVED":
+                    print("Template unresolved: {0} {1} {2}".format(
+                        item_dict['catalogName'],
+                        item_dict['name'], item_dict['status']))
+                    find_unresolved = True
+                    time.sleep(3)
+
+print("No unresolved templates found")
+
+# Check for desired networks and create them if they don't exist.  
+# (We might add other kinds of networks later.)
+if cfg.networks.get("isolated"):
+    print("Checking isolated networks...")
+    for network in cfg.networks['isolated']:
+        isolated_network_list = vdc.list_orgvdc_network_resources(
+            name=network['network_name'], type=FenceMode.ISOLATED.value)
+        if len(isolated_network_list) > 0:
+            print("Isolated network exists: {0}".format(
+                network['network_name']))
+        else:
+            # Create the network in the vDC.
+            print("Network does not exist, creating: {0}".format(
+                network['network_name']))
+            network_resource = vdc.create_isolated_vdc_network(**network)
+            handle_task(client, network_resource.Tasks.Task[0])
+            print("Network created")
+
+            # Ensure the network is visible in the VDC.
+            network_exists = False
+            while not network_exists:
+                new_network_list = vdc.list_orgvdc_network_resources(
+                    name=network['network_name'], 
+                    type=FenceMode.ISOLATED.value)
+                if len(new_network_list) > 0:
+                    print("Isolated network is visible in VDC: {0}".format(
+                        network['network_name']))
+                    network_exists = True
+                else:
+                    print("Isolated network is not visible yet: {0}".format(
+                        network['network_name']))
+                    time.sleep(3)
+
+# Check for vApps and create them if they don't exist.  We have to
+# reload the VDC object so it has all the links to current vApps.
+vdc.reload()
+for vapp_cfg in cfg.vapps:
+    try:
+        vapp = vdc.get_vapp(vapp_cfg['name'])
+        print("vApp exists: {0}".format(vapp_cfg['name']))
+    except Exception:
+        print("vApp does not exist: name={0}".format(vapp_cfg['name']))
+        vapp_resource = vdc.instantiate_vapp(**vapp_cfg)
+        print("vApp instantiated")
+        # We don't track the task as instantiating a vApp takes a while.
+        # Uncomment below if you want to ensure the vApps are available.
+        # handle_task(client, vapp_resource.Tasks.Task[0])
+
+# Log out.
+print("All done!")
+client.logout()

--- a/examples/tenant-remove.py
+++ b/examples/tenant-remove.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the
+# Apache License, Version 2.0 (the "License").
+# You may not use this product except in compliance with the License.
+#
+# This product may include a number of subcomponents with
+# separate copyright notices and license terms. Your use of the source
+# code for the these subcomponents is subject to the terms and
+# conditions of the subcomponent's license, as noted in the LICENSE file.
+
+# Example procedure to remove a tenant. This file tears down the Org specified
+# in the config file supplied as an argument.  If the Org does not exist it
+# does nothing.
+#
+# Usage: python3 tenant-remove.py tenant.yaml
+
+from collections import namedtuple
+import requests
+import sys
+import yaml
+
+# Private utility functions.
+from tenantlib import handle_task
+
+from pyvcloud.vcd.client import BasicLoginCredentials
+from pyvcloud.vcd.client import Client
+from pyvcloud.vcd.system import System
+
+# Collect arguments.
+if len(sys.argv) != 2:
+    print("Usage: python3 {0} config_file".format(sys.argv[0]))
+    sys.exit(1)
+config_yaml = sys.argv[1]
+
+# Load the YAML configuration and convert to an object with properties.
+with open(config_yaml, "r") as config_file:
+    config_dict = yaml.load(config_file)
+    cfg = namedtuple('ConfigObject', config_dict.keys())(**config_dict)
+
+# Disable warnings from self-signed certificates.
+requests.packages.urllib3.disable_warnings()
+
+# Login. SSL certificate verification is turned off to allow self-signed
+# certificates.  You should only do this in trusted environments.
+print("Logging in...")
+client = Client(cfg.vcd_host, verify_ssl_certs=False,
+                log_file='pyvcloud.log',
+                log_requests=True,
+                log_headers=True,
+                log_bodies=True)
+client.set_highest_supported_version()
+client.set_credentials(BasicLoginCredentials(cfg.vcd_admin_user, "System",
+                       cfg.vcd_admin_password))
+
+# Load the org.  If it does not exist, there's nothing to do.
+print("Fetching Org...")
+try:
+    org_record = client.get_org_by_name(cfg.org)
+except Exception:
+    print("Org does not exist, nothing to be done")
+    sys.exit(0)
+
+# Delete the org.
+print("Org exists, deleting: {0}".format(cfg.org))
+sys_admin_resource = client.get_admin()
+system = System(client, admin_resource=sys_admin_resource)
+resource = system.delete_org(cfg.org, True, True)
+handle_task(client, resource)
+print("Deleted the org...")
+
+# Log out.
+print("All done!")
+client.logout()

--- a/examples/tenant.yaml
+++ b/examples/tenant.yaml
@@ -1,0 +1,90 @@
+##########################
+# CONNECTION INFORMATION #
+##########################
+
+# Fill in the vCloud Dirctor host and sysadmin information here.  This 
+# account will be used to issue tenant setup commands. 
+vcd_host: "192.168.120.5"
+vcd_admin_user: "administrator"
+vcd_admin_password: "********"
+
+#####################
+# TENANT DEFINITION #
+#####################
+
+# NOTE: Generally speaking the properties that define entities like orgs, 
+# VDCs, and the like are the same as pyvcloud API arguments.  You can add
+# more properties so long as they match the APIs in which they are used.
+
+# Name of the org we would like to see. 
+org: "Test1"
+
+# A user that we will create. 
+user: 
+  name: "user1"
+  password: "********"
+  role: "Organization Administrator"
+
+# A VDC that we will create.  The provider_vdc_name, network_pool_name, 
+# and storage profile should match your installation. 
+vdc: 
+  vdc_name: "VDC-A"
+  description: "Test VDC A"
+  provider_vdc_name: "pvdc-2018-02-08-03-10-22.938"
+  network_pool_name: "pvdc-2018-02-08-03-10-22.938-VXLAN-NP"
+  storage_profiles:
+    - name: "*"
+      enabled: True
+      units: "MB"
+      limit: 100000
+      default: True
+  network_quota: 100
+
+# A catalog that we will create. 
+catalog: 
+  name: "Test-Catalog"
+  description: "A test catalog"
+
+# One or more items that will be loaded in the catalog. Specify the full
+# path of files. 
+catalog_items: 
+  - item_name: "Photon-1"
+    description: "Photon 1 VM"
+    catalog_name: "Test-Catalog"
+    file_name: "/home/admin/ovf/photon-custom-hw11-1.0-62c543d.ova"
+  - item_name: "Tiny-Linux"
+    description: "Tiny Linux VM"
+    catalog_name: "Test-Catalog"
+    file_name: "/home/admin/ovf/Tiny-Linux-VM.ova"
+
+# One or more networks that we would like to create.  In this example only 
+# isolated networks are included. 
+networks:
+  isolated:
+    - network_name: "isolated-network-1"
+      gateway_ip: "192.168.10.1" 
+      netmask: "255.255.255.0"
+      description: "Isolated network"
+      ip_range_start: "192.168.10.100"
+      ip_range_end: "192.168.10.149"
+
+# One or more vApps we would like to create.  The catalog, template, and 
+# network must match names previously defined in this file or that already
+# exist in vCD. 
+vapps: 
+  - name: "vApp-Photon-1"
+    catalog: "Test-Catalog"
+    template: "Photon-1"
+    network: "isolated-network-1"
+    ip_allocation_mode: "pool"
+    accept_all_eulas: "True"
+    password: "secret"
+    vm_name: "Demo-VM"
+    hostname: "Demo-Host"
+  - name: "vApp-Tiny-Linux"
+    catalog: "Test-Catalog"
+    template: "Tiny-Linux"
+    network: "isolated-network-1"
+    accept_all_eulas: "True"
+    vm_name: "Tiny-VM"
+    hostname: "Tiny-Host"

--- a/examples/tenantlib.py
+++ b/examples/tenantlib.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+#
+# This product is licensed to you under the
+# Apache License, Version 2.0 (the "License").
+# You may not use this product except in compliance with the License.
+#
+# This product may include a number of subcomponents with
+# separate copyright notices and license terms. Your use of the source
+# code for the these subcomponents is subject to the terms and
+# conditions of the subcomponent's license, as noted in the LICENSE file.
+
+# Useful library functions for tenant onboarding and removal.
+
+from lxml.objectify import ObjectifiedElement
+
+from pyvcloud.vcd.client import NSMAP
+from pyvcloud.vcd.client import TaskStatus
+from pyvcloud.vcd.utils import extract_id
+
+
+def handle_task(client, obj):
+    """Track a task to completion.
+
+    :param client: The client.
+    :type client: Client
+    :param obj: XML representation of an entity with a task in it
+    :type obj: ObjectifiedElement
+    """
+    if 'task_href' in obj:
+        obj = client.get_resource(obj.get('task_href'))
+    if isinstance(obj, ObjectifiedElement):
+        if obj.tag == '{' + NSMAP['vcloud'] + '}Task':
+            # Track task output.
+            obj = client.get_resource(obj.get('href'))
+            task = client.get_task_monitor().wait_for_status(
+                task=obj,
+                timeout=60,
+                poll_frequency=5,
+                fail_on_statuses=None,
+                expected_target_statuses=[
+                    TaskStatus.SUCCESS, TaskStatus.ABORTED,
+                    TaskStatus.ERROR, TaskStatus.CANCELED
+                ],
+                callback=_task_callback)
+            if task.get('status') == TaskStatus.ERROR.value:
+                text = 'task: %s, result: %s, message: %s' % \
+                       (extract_id(task.get('id')),
+                        task.get('status'),
+                        task.Error.get('message'))
+                print(text)
+                raise Exception("Operation failed!")
+            else:
+                text = 'task: %s, %s, result: %s' % \
+                       (extract_id(task.get('id')),
+                        task.get('operation'),
+                        task.get('status'))
+                print(text)
+    else:
+        # No task to handle.
+        pass
+
+
+def _task_callback(task):
+    """Print task status.
+
+    :param task: XML representation of a task resource
+    :type task: lxml.objectify.ObjectifiedElement
+    """
+    message = '{0}: {1}, status: {2}'.format(
+        task.get('operationName'), task.get('operation'), task.get('status'))
+    if hasattr(task, 'Progress'):
+        message += ', progress: %s%%' % task.Progress
+    print(message)


### PR DESCRIPTION
Created a sample script tenant-onboard.py that reads org information
from a .yaml configuration and then creates everything it finds in vCD.
If run again, the script creates anything missing and leaves existing
entities alone. Script tenant-remove.py removes the org. Sample org
information is included in tenant.yaml.

@pacogomez, @sahithi, @anusuyar

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/202)
<!-- Reviewable:end -->
