### PR TITLE
VCDA-454: Updated copyrights for release

### DIFF
--- a/examples/list-vapps.py
+++ b/examples/list-vapps.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Pyvcloud Examples
 #
-# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # This product is licensed to you under the
 # Apache License, Version 2.0 (the "License").

--- a/pyvcloud/vcd/acl.py
+++ b/pyvcloud/vcd/acl.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyvcloud/vcd/amqp.py
+++ b/pyvcloud/vcd/amqp.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyvcloud/vcd/extension.py
+++ b/pyvcloud/vcd/extension.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyvcloud/vcd/role.py
+++ b/pyvcloud/vcd/role.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyvcloud/vcd/system.py
+++ b/pyvcloud/vcd/system.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyvcloud/vcd/task.py
+++ b/pyvcloud/vcd/task.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyvcloud/vcd/test.py
+++ b/pyvcloud/vcd/test.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -1,5 +1,5 @@
 # VMware vCloud Python SDK
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 # VMware vCloud Python SDK
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # VMware vCloud Python SDK
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2017 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/vcd_catalog.py
+++ b/tests/vcd_catalog.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/vcd_catalog_setup.py
+++ b/tests/vcd_catalog_setup.py
@@ -1,3 +1,18 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import unittest
 import yaml

--- a/tests/vcd_catalog_teardown.py
+++ b/tests/vcd_catalog_teardown.py
@@ -1,3 +1,18 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import unittest
 import yaml

--- a/tests/vcd_catalog_update.py
+++ b/tests/vcd_catalog_update.py
@@ -1,3 +1,18 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import unittest
 import yaml

--- a/tests/vcd_disk.py
+++ b/tests/vcd_disk.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/vcd_edge_gateway.py
+++ b/tests/vcd_edge_gateway.py
@@ -1,3 +1,18 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 
 from pyvcloud.vcd.org import Org

--- a/tests/vcd_ext.py
+++ b/tests/vcd_ext.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/vcd_login.py
+++ b/tests/vcd_login.py
@@ -1,3 +1,18 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import unittest
 import yaml

--- a/tests/vcd_network.py
+++ b/tests/vcd_network.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/vcd_role_right.py
+++ b/tests/vcd_role_right.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/vcd_storage_profile.py
+++ b/tests/vcd_storage_profile.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/tests/vcd_system.py
+++ b/tests/vcd_system.py
@@ -1,3 +1,18 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 
 from pyvcloud.vcd.system import System

--- a/tests/vcd_user.py
+++ b/tests/vcd_user.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/vcd_vapp.py
+++ b/tests/vcd_vapp.py
@@ -1,3 +1,18 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 
 from pyvcloud.vcd.client import NSMAP

--- a/tests/vcd_vapp_vm.py
+++ b/tests/vcd_vapp_vm.py
@@ -1,3 +1,18 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import unittest
 import yaml

--- a/tests/vcd_vdc.py
+++ b/tests/vcd_vdc.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/vcd_vm.py
+++ b/tests/vcd_vm.py
@@ -1,5 +1,5 @@
 # VMware vCloud Director Python SDK
-# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+# Copyright (c) 2017-2018 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updated .py file copyright dates to most recent commit and extended back
in one case to first known commit from git log. Copyright dates follow
earliest-latest date convention.

Reviewers: @pacogomez @anusuyar @sahithi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/204)
<!-- Reviewable:end -->
