### PR TITLE
Only show VAPP entity types, per intention of example

### DIFF
--- a/examples/list-vapps.py
+++ b/examples/list-vapps.py
@@ -17,6 +17,7 @@
 import sys
 from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
+from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.vdc import VDC
 import requests
@@ -54,7 +55,7 @@ print("Fetching VDC...")
 vdc_resource = org.get_vdc(vdc)
 vdc = VDC(client, resource=vdc_resource)
 print("Fetching vApps....")
-vapps = vdc.list_resources()
+vapps = vdc.list_resources(EntityType.VAPP)
 for vapp in vapps:
     print(vapp.get('name'))
 


### PR DESCRIPTION
The example script is `list-vapps` but it was listing **all** resources in the VDC. This commit limits the resources fetched and displayed to only those with entity type 'vApp' (aka `EntityType.VAPP`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/218)
<!-- Reviewable:end -->
