### PR TITLE
Updating documentation of org:create_user()

### DIFF
--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -498,7 +498,8 @@ class Org(object):
         """Create User in the current Org.
 
         :param user_name: The username of the user
-        :param password: The password of the user
+        :param password: The password of the user (must be at least 6
+                characters long)
         :param role_href: The href of the user role
         :param full_name: The full name of the user
         :param description: The description for the User


### PR DESCRIPTION
Updating documentation of org:create_user() to reflect a subtle restriction on the 'password' param string.
Testing : not required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/237)
<!-- Reviewable:end -->
