### PR TITLE
Add ability to create, list and remove NAT routed networks

### DIFF
--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -266,6 +266,69 @@ class VApp(object):
                 RelationType.EDIT, EntityType.NETWORK_CONNECTION_SECTION.value,
                 self.resource.Children.Vm[0].NetworkConnectionSection)
 
+    def attach_network_to_vm(self, vm_name, network_name, connection_index,
+                             connections_primary_index=None,
+                             ip_allocation_mode='DHCP', mac_address=None,
+                             ip_address=None):
+        """Attach a single vm to a virtual network.
+
+        :param vm_name: (str): The name of the vm that the network will be
+                               attached to.
+        :param network_name: (str): The network name to connect the VM to.
+        :param connection_index: (str): Virtual slot number associated with
+                                        this NIC. First slot number is 0.
+        :param connections_primary_index: (str): Virtual slot number associated
+                                                 with the NIC that should be
+                                                 considered this virtual
+                                                 machine's primary network
+                                                 connection. Default slot 0.
+        :param ip_allocation_mode: (str, optional): IP address allocation
+                                                    mode for this connection.
+
+            * One of:
+             - POOL (A static IP address is allocated automatically from a
+                     pool of addresses.)
+             - DHCP (The IP address is obtained from a DHCP service.)
+             - MANUAL (The IP address is assigned manually in the IpAddress
+                       element.)
+             - NONE (No IP addressing mode specified.)
+
+        :param mac_address: (str):    the MAC address associated with the NIC.
+        :param ip_address: (str):     the IP address assigned to this NIC.
+        :return:  A :class:`lxml.objectify.StringElement` object representing
+            the asynchronous task that is connecting the vm to the network.
+        :raises: Exception: If the named VM cannot be located or another error
+                            occured.
+
+        """
+        if self.resource is None:
+            self.resource = self.client.get_resource(self.href)
+
+        vm = self.get_vm(vm_name)
+
+        new_connection = E.NetworkConnection(
+            E.NetworkConnectionIndex(connection_index),
+            network=network_name
+        )
+        if ip_address and ip_allocation_mode == 'MANUAL':
+            new_connection.append(E.IpAddress(ip_address))
+        new_connection.append(E.IsConnected('true'))
+        new_connection.append(E.IpAddressAllocationMode(
+            ip_allocation_mode.upper()))
+
+        if mac_address:
+            new_connection.append(E.MACAddress(mac_address))
+
+        new_connection_section = E.NetworkConnectionSection(
+            E_OVF.Info(),
+            E.PrimaryNetworkConnectionIndex(connection_index),
+            new_connection)
+
+        return self.client.put_linked_resource(
+            vm.NetworkConnectionSection,
+            RelationType.EDIT, EntityType.NETWORK_CONNECTION_SECTION.value,
+            new_connection_section)
+
     def attach_disk_to_vm(self, disk_href, vm_name):
         """Attach the independent disk to the VM with the given name.
 
@@ -518,6 +581,18 @@ class VApp(object):
                 ip_allocation_mode = spec['ip_allocation_mode']
             else:
                 ip_allocation_mode = 'DHCP'
+
+            new_connection = E.NetworkConnection(
+                E.NetworkConnectionIndex(primary_index),
+                network=spec['network']
+            )
+
+            if spec['ip_address'] and ip_allocation_mode == 'MANUAL':
+                new_connection.append(E.IpAddress(spec['ip_address']))
+                new_connection.append(E.IsConnected(True))
+                new_connection.append(E.IpAddressAllocationMode(
+                    ip_allocation_mode.upper()))
+
             vm_instantiation_param.append(
                 E.NetworkConnectionSection(
                     E_OVF.Info(),

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -400,6 +400,36 @@ class VDC(object):
                 })
         return edge_gateways
 
+    def create_edge_gateway(self,
+                            name,
+                            gatewayBackingConfig='full',
+                            gatewayInterfaces=[]):
+        """Request the creation of an Edge Gateway.
+
+        :param name: (str): The name of the new edge gateway.
+
+        :return:  A :class:`lxml.objectify.StringElement` object containing
+            the sparse representation of the new disk and the asynchronus task
+            that is creating the disk.
+        """
+        if self.resource is None:
+            self.resource = self.client.get_resource(self.href)
+
+        gw_interfaces = []
+        for interface in gatewayInterfaces:
+            gw_interfaces.append(E.GatewayInterface(name=interface))
+
+        edge_gateway = E.EdgeGateway(
+            E.GatewayConfigurationType(
+                E.GatewayBackingConfig(gatewayBackingConfig),
+                E.GatewayInterfaces(gw_interfaces)),
+            name=name
+        )
+
+        return self.client.post_linked_resource(
+            self.resource, RelationType.ADD,
+            EntityType.EDGE_GATEWAY.value, edge_gateway)
+
     def create_disk(self,
                     name,
                     size,
@@ -855,6 +885,112 @@ class VDC(object):
             self.resource, RelationType.ADD, EntityType.ORG_VDC_NETWORK.value,
             request_payload)
 
+    def create_natrouted_vdc_network(self,
+                                     network_name,
+                                     gateway_name,
+                                     gateway_ip,
+                                     netmask,
+                                     description=None,
+                                     primary_dns_ip=None,
+                                     secondary_dns_ip=None,
+                                     dns_suffix=None,
+                                     ip_range_start=None,
+                                     ip_range_end=None,
+                                     is_dhcp_enabled=None,
+                                     default_lease_time=None,
+                                     max_lease_time=None,
+                                     dhcp_ip_range_start=None,
+                                     dhcp_ip_range_end=None,
+                                     is_shared=None):
+        """Create a new natRouted OrgVdc network in this vdc.
+
+        :param network_name: (str): Name of the new network.
+        :param gateway_name: (str): The name of an existing edge Gateway
+                                    appliance that will manage the virtual
+                                    network.
+        :param gateway_ip: (str): IP address of the gateway of the new network.
+        :param netmask: (str): Network mask.
+        :param description: (str): Description of the new network.
+        :param primary_dns_ip: (str): IP address of primary DNS server.
+        :param secondary_dns_ip: (str): IP address of secondary DNS Server.
+        :param dns_suffix: (str): DNS suffix.
+        :param ip_range_start: (str): Start address of the IP ranges used for
+            static pool allocation in the network.
+        :param ip_range_end: (str): End address of the IP ranges used for
+            static pool allocation in the network.
+        :param is_dhcp_enabled: (bool): Is DHCP service enabled on the new
+            network.
+        :param default_lease_time: (int): Default lease in seconds for DHCP
+            addresses.
+        :param max_lease_time: (int): Max lease in seconds for DHCP addresses.
+        :param dhcp_ip_range_start: (str): Start address of the IP range
+            used for DHCP addresses.
+        :param dhcp_ip_range_end: (str): End address of the IP range used for
+            DHCP addresses.
+        :param is_shared: (bool): True, if the network is shared with other
+            vdc(s) in the organization, else False.
+
+        :return: A :class:`lxml.objectify.StringElement` object representing
+            a sparsely populated OrgVdcNetwork element.
+        """
+        if self.resource is None:
+            self.resource = self.client.get_resource(self.href)
+
+        request_payload = E.OrgVdcNetwork(name=network_name)
+        if description is not None:
+            request_payload.append(E.Description(description))
+
+        vdc_network_configuration = E.Configuration()
+        ip_scope = E.IpScope()
+        ip_scope.append(E.IsInherited('false'))
+        ip_scope.append(E.Gateway(gateway_ip))
+        ip_scope.append(E.Netmask(netmask))
+        if primary_dns_ip is not None:
+            ip_scope.append(E.Dns1(primary_dns_ip))
+        if secondary_dns_ip is not None:
+            ip_scope.append(E.Dns2(secondary_dns_ip))
+        if dns_suffix is not None:
+            ip_scope.append(E.DnsSuffix(dns_suffix))
+        if ip_range_start is not None and ip_range_end is not None:
+            ip_range = E.IpRange()
+            ip_range.append(E.StartAddress(ip_range_start))
+            ip_range.append(E.EndAddress(ip_range_end))
+            ip_scope.append(E.IpRanges(ip_range))
+        vdc_network_configuration.append(E.IpScopes(ip_scope))
+        vdc_network_configuration.append(
+            E.FenceMode(FenceMode.NAT_ROUTED.value))
+        request_payload.append(vdc_network_configuration)
+
+        # list_edge_gateways
+        gws = self.list_edge_gateways()
+        gateway_href = None
+        for gw in gws:
+            if gw['name'] == gateway_name:
+                gateway_href = gw['href']
+        request_payload.append(E.EdgeGateway(name=gateway_name,
+                                             href=gateway_href))
+
+        dhcp_service = E.DhcpService()
+        if is_dhcp_enabled is not None:
+            dhcp_service.append(E.IsEnabled(is_dhcp_enabled))
+        if default_lease_time is not None:
+            dhcp_service.append(E.DefaultLeaseTime(str(default_lease_time)))
+        if max_lease_time is not None:
+            dhcp_service.append(E.MaxLeaseTime(str(max_lease_time)))
+        if dhcp_ip_range_start is not None and dhcp_ip_range_end is not None:
+            dhcp_ip_range = E.IpRange()
+            dhcp_ip_range.append(E.StartAddress(dhcp_ip_range_start))
+            dhcp_ip_range.append(E.EndAddress(dhcp_ip_range_end))
+            dhcp_service.append(dhcp_ip_range)
+        request_payload.append(E.ServiceConfig(dhcp_service))
+
+        if is_shared is not None:
+            request_payload.append(E.IsShared(is_shared))
+
+        return self.client.post_linked_resource(
+            self.resource, RelationType.ADD, EntityType.ORG_VDC_NETWORK.value,
+            request_payload)
+
     def create_isolated_vdc_network(self,
                                     network_name,
                                     gateway_ip,
@@ -1012,6 +1148,15 @@ class VDC(object):
         return self.list_orgvdc_network_resources(
             type=FenceMode.ISOLATED.value)
 
+    def list_orgvdc_natrouted_networks(self):
+        """Fetch all isolated orgvdc networks in the current vdc.
+
+        :return:  A list of :class:`lxml.objectify.StringElement` objects
+            representing all isolated orgvdc network resources.
+        """
+        return self.list_orgvdc_network_resources(
+            type=FenceMode.NAT_ROUTED.value)
+
     def get_direct_orgvdc_network(self, name):
         """Retrieve a directly connected orgvdc network in the current vdc.
 
@@ -1046,6 +1191,23 @@ class VDC(object):
                 'OrgVdc network with name \'%s\' not found.' % name)
         return result[0]
 
+    def get_natrouted_orgvdc_network(self, name):
+        """Retrieve a natRouted orgvdc network in the current vdc.
+
+        :param name: (str): Name of the orgvdc network we want to retrieve.
+
+        :return:  A :class:`lxml.objectify.StringElement` object representing
+            a natRouted orgvdc network resource.
+
+        :raises: Exception: If orgvdc network with the given name is not found.
+        """
+        result = self.list_orgvdc_network_resources(
+            name=name, type=FenceMode.NAT_ROUTED.value)
+        if len(result) == 0:
+            raise Exception(
+                'OrgVdc network with name \'%s\' not found.' % name)
+        return result[0]
+
     def delete_direct_orgvdc_network(self, name, force=False):
         """Delete a directly connected orgvdc network in the current vdc.
 
@@ -1077,5 +1239,22 @@ class VDC(object):
         :raises: Exception: If orgvdc network with the given name is not found.
         """
         net_resource = self.get_isolated_orgvdc_network(name)
+        return self.client.delete_resource(
+            net_resource.get('href'), force=force)
+
+    def delete_natrouted_orgvdc_network(self, name, force=False):
+        """Delete an isolated orgvdc network in the current vdc.
+
+        :param name: (str): Name of the orgvdc network to be deleted.
+        :param force: (bool): If True, will instruct vcd to force delete
+            the network, ignoring whether it's connected to a vm or vapp
+            network or not.
+
+        :return:  A :class:`lxml.objectify.StringElement` object describing
+            the asynchronous task that's deleting the network.
+
+        :raises: Exception: If orgvdc network with the given name is not found.
+        """
+        net_resource = self.get_natrouted_orgvdc_network(name)
         return self.client.delete_resource(
             net_resource.get('href'), force=force)

--- a/system_tests/network_tests.py
+++ b/system_tests/network_tests.py
@@ -1,0 +1,129 @@
+import os
+import random
+import shutil
+import string
+import tempfile
+import unittest
+
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.environment import CommonRoles
+from pyvcloud.system_test_framework.environment import developerModeAware
+from pyvcloud.system_test_framework.environment import Environment
+
+from pyvcloud.vcd.exceptions import EntityNotFoundException
+from pyvcloud.vcd.platform import Platform
+from pyvcloud.vcd.client import TaskStatus
+
+
+class TestNetwork(BaseTestCase):
+    """Test network functionalities implemented in pyvcloud."""
+
+    _client = None
+    _test_runner_role = CommonRoles.ORGANIZATION_ADMINISTRATOR
+
+    _test_direct_network_name = 'test-direct-vdc-network'
+    _test_direct_network_parent_network = 'test-parent-network'
+
+    _test_isolated_network_name = 'test-second-isolated-vdc-network'
+    _test_isolated_network_gateway_ip = '10.1.2.1'
+    _test_isolated_network_gateway_netmask = '255.255.255.0'
+
+    _test_natrouted_network_name = 'test-natrouted-vdc-network'
+    _test_natrouted_network_gateway_name = 'test-vdc-gateway'
+    _test_natrouted_network_gateway_ip = '10.1.3.1'
+    _test_natrouted_network_gateway_netmask = '255.255.255.0'
+
+    def test_0000_setup(self):
+        """Setup the client required for the other tests in this module.
+        """
+        TestNetwork._client = Environment.get_client_in_default_org(
+            TestNetwork._test_runner_role)
+
+    def test_0010_create_direct_orgvdc_network(self):
+        vdc = Environment.get_test_vdc(TestNetwork._client)
+
+        result = vdc.create_directly_connected_vdc_network(
+            network_name=TestNetwork._test_direct_network_name,
+            parent_network_name=TestNetwork._test_direct_network_parent_network,
+            description='Dummy description')
+        task = client.get_task_monitor().wait_for_success(task=result.Tasks.Task[0])
+        self.assertEqual(task.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0020_create_isolated_orgvdc_network(self):
+        vdc = Environment.get_test_vdc(TestNetwork._client)
+
+        result = vdc.create_isolated_vdc_network(
+            network_name=TestNetwork._test_isolated_network_name,
+            gateway_ip=TestNetwork._test_isolated_network_gateway_ip,
+            netmask=TestNetwork._test_isolated_network_gateway_netmask,
+            description='Dummy description')
+        task = TestNetwork._client.get_task_monitor().wait_for_success(
+            task=result.Tasks.Task[0])
+        self.assertEqual(task.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0025_create_natrouted_orgvdc_network(self):
+        vdc = Environment.get_test_vdc(TestNetwork._client)
+
+        result = vdc.create_natrouted_vdc_network(
+            network_name=TestNetwork._test_natrouted_network_name,
+            gateway_name=TestNetwork._test_natrouted_network_gateway_name,
+            gateway_ip=TestNetwork._test_natrouted_network_gateway_ip,
+            netmask=TestNetwork._test_natrouted_network_gateway_netmask,
+            description='Dummy description')
+        task = TestNetwork._client.get_task_monitor().wait_for_success(
+            task=result.Tasks.Task[0])
+        self.assertEqual(task.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0030_list_external_networks(self):
+        vdc = Environment.get_test_vdc(TestNetwork._client)
+        platform = Platform(TestNetwork._client)
+        ext_net_refs = platform.list_external_networks()
+        self.assertTrue(len(ext_net_refs) > 0)
+
+    def test_0040_list_direct_orgvdc_networks(self):
+        vdc = Environment.get_test_vdc(TestNetwork._client)
+        result = vdc.list_orgvdc_direct_networks()
+        self.assertTrue(len(result) > 0)
+
+    def test_0050_list_isolated_orgvdc_networks(self):
+        vdc = Environment.get_test_vdc(TestNetwork._client)
+        result = vdc.list_orgvdc_isolated_networks()
+        self.assertTrue(len(result) > 0)
+
+    def test_0060_list_natrouted_orgvdc_networks(self):
+        vdc = Environment.get_test_vdc(TestNetwork._client)
+        result = vdc.list_orgvdc_natrouted_networks()
+        self.assertTrue(len(result) > 0)
+
+    def test_0190_delete_direct_orgvdc_networks(self):
+        vdc = Environment.get_test_vdc(TestNetwork._client)
+        result = vdc.delete_direct_orgvdc_network(
+            name=TestNetwork._test_direct_network_name, force=True)
+        task = TestNetwork._client.get_task_monitor().wait_for_success(
+            task=result)
+        self.assertEqual(task.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0200_delete_isolated_orgvdc_networks(self):
+        vdc = Environment.get_test_vdc(TestNetwork._client)
+        result = vdc.delete_isolated_orgvdc_network(
+            name=TestNetwork._test_isolated_network_name, force=True)
+        task = TestNetwork._client.get_task_monitor().wait_for_success(
+            task=result)
+        self.assertEqual(task.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_210_delete_natrouted_orgvdc_networks(self):
+        vdc = Environment.get_test_vdc(TestNetwork._client)
+
+        result = vdc.delete_natrouted_orgvdc_network(
+            name=TestNetwork._test_natrouted_network_name, force=True)
+        task = TestNetwork._client.get_task_monitor().wait_for_success(
+            task=result)
+        self.assertEqual(task.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_9999_cleanup(self):
+        """Release all resources held by this object for testing purposes."""
+        TestNetwork._client.logout()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/vcd_network.py
+++ b/tests/vcd_network.py
@@ -54,6 +54,23 @@ class TestNetwork(TestCase):
             task=result.Tasks.Task[0])
         assert task.get('status') == TaskStatus.SUCCESS.value
 
+    def test_025_create_natrouted_orgvdc_network(self):
+        org_record = self.client.get_org_by_name(
+            self.config['vcd']['org_name'])
+        org = Org(self.client, href=org_record.get('href'))
+        vdc_resource = org.get_vdc(self.config['vcd']['vdc_name'])
+        vdc = VDC(self.client, href=vdc_resource.get('href'))
+
+        result = vdc.create_natrouted_vdc_network(
+            network_name=self.config['vcd']['vdc_natrouted_network_name'],
+            gateway_name=self.config['vcd']['natrouted_network_gateway_name'],
+            gateway_ip=self.config['vcd']['natrouted_network_gateway_ip'],
+            netmask=self.config['vcd']['natrouted_network_gateway_netmask'],
+            description='Dummy description')
+        task = self.client.get_task_monitor().wait_for_success(
+            task=result.Tasks.Task[0])
+        assert task.get('status') == TaskStatus.SUCCESS.value
+
     def test_030_list_external_networks(self):
         platform = Platform(self.client)
         ext_net_refs = platform.list_external_networks()
@@ -79,6 +96,15 @@ class TestNetwork(TestCase):
         result = vdc.list_orgvdc_isolated_networks()
         assert len(result) > 0
 
+    def test_060_list_natrouted_orgvdc_networks(self):
+        org_record = self.client.get_org_by_name(
+            self.config['vcd']['org_name'])
+        org = Org(self.client, href=org_record.get('href'))
+        vdc_resource = org.get_vdc(self.config['vcd']['vdc_name'])
+        vdc = VDC(self.client, href=vdc_resource.get('href'))
+
+        result = vdc.list_orgvdc_natrouted_networks()
+
     def test_190_delete_direct_orgvdc_networks(self):
         org_record = self.client.get_org_by_name(
             self.config['vcd']['org_name'])
@@ -101,6 +127,19 @@ class TestNetwork(TestCase):
 
         result = vdc.delete_isolated_orgvdc_network(
             name=self.config['vcd']['vdc_isolated_network_name'], force=True)
+        task = self.client.get_task_monitor().wait_for_success(
+            task=result)
+        assert task.get('status') == TaskStatus.SUCCESS.value
+
+    def test_210_delete_natrouted_orgvdc_networks(self):
+        org_record = self.client.get_org_by_name(
+            self.config['vcd']['org_name'])
+        org = Org(self.client, href=org_record.get('href'))
+        vdc_resource = org.get_vdc(self.config['vcd']['vdc_name'])
+        vdc = VDC(self.client, href=vdc_resource.get('href'))
+
+        result = vdc.delete_natrouted_orgvdc_network(
+            name=self.config['vcd']['vdc_natrouted_network_name'], force=True)
         task = self.client.get_task_monitor().wait_for_success(
             task=result)
         assert task.get('status') == TaskStatus.SUCCESS.value

--- a/tests/vcd_vapp.py
+++ b/tests/vcd_vapp.py
@@ -241,7 +241,7 @@ class TestVApp(TestCase):
         assert found_disk
 
         # cleanup
-        self.test_100_delete_vapp()
+        self.test_1000_delete_vapp()
 
     def test_1000_delete_vapp(self):
         logged_in_org = self.client.get_org()

--- a/tox.ini
+++ b/tox.ini
@@ -13,5 +13,6 @@ deps =
     -rtest-requirements.txt
 
 [testenv:flake8]
+basepython = python3
 deps = {[testenv]deps}
 commands = flake8 pyvcloud/vcd


### PR DESCRIPTION
This pull request introduces the ability to create, list and remove NAT routed networks. The code is based on the methods for managing isolated networks. 

Unit tests are added to the tests/vcd_network.py file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/241)
<!-- Reviewable:end -->
