### PR TITLE
Add attach_network_to_vm method

### DIFF
--- a/tests/config.yml
+++ b/tests/config.yml
@@ -27,3 +27,4 @@ vcd:
   ip_allocation_mode: dhcp
   extension_name: cse
   vcenter: vc1
+  vapp_network: net2

--- a/tests/vcd_vapp.py
+++ b/tests/vcd_vapp.py
@@ -34,8 +34,7 @@ class TestVApp(TestCase):
             self.config['vcd']['vapp'],
             self.config['vcd']['catalog'],
             self.config['vcd']['template'],
-            network='net2',
-            fence_mode='natRouted',
+            network=self.config['vcd']['vapp_network'],
             deploy=False,
             power_on=False)
         task = self.client.get_task_monitor().wait_for_status(
@@ -60,7 +59,7 @@ class TestVApp(TestCase):
         vapp = vdc.get_vapp(self.config['vcd']['vapp'])
         assert self.config['vcd']['vapp'] == vapp.get('name')
         result = vdc.reconfigure_vapp_network(self.config['vcd']['vapp'],
-                                              'net2',
+                                              self.config['vcd']['vapp_network'],
                                               self.config['vcd']['fence_mode'])
         task = self.client.get_task_monitor().wait_for_status(
             task=result,


### PR DESCRIPTION
This method makes it possible to attach a network to virtual machines
inside a vapp. A unit test has also been added and a hardcoded parameter, also used for other tests, has been made configurable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/242)
<!-- Reviewable:end -->
