### PR TITLE
vcd-cli 210: Fixed KeyError and added system test for search

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -162,6 +162,8 @@ class RelationType(Enum):
 
 
 class ResourceType(Enum):
+    """Contains resource type names."""
+
     ACL_RULE = 'aclRule'
     ADMIN_API_DEFINITION = 'adminApiDefinition'
     ADMIN_ALLOCATED_EXTERNAL_ADDRESS = 'adminAllocatedExternalAddress'
@@ -984,6 +986,24 @@ class Client(object):
                         sort_asc=None,
                         sort_desc=None,
                         fields=None):
+        """Issue a query using vCD query API.
+
+        :param query_type_name str: Name of the entity, which should be a
+            string listed in ResourceType enum
+        :param query_result_format (str, str): Tuple value from
+            QueryResultFormat enum
+        :param page_size int: Number of entries per page
+        :param include_links: (Not used)
+        :param qfilter str: Query filter expression, e.g., numberOfCpus=gt=4
+        :param equality_filter: A field name and a value to filter
+            output; appends to qfilter if present
+        :param sort_asc str: If name present sort ascending by that field
+        :param sort_desc str: If name present sort descending by that field
+        :param fields str: Comma separated list of fields to return
+
+        :return: A query object that runs the query when execute()
+            method is called
+        """
         return _TypedQuery(
             query_type_name,
             self,
@@ -1069,6 +1089,8 @@ class Link(object):
 
 
 class _AbstractQuery(object):
+    """Implements internal query object representation."""
+
     def __init__(self,
                  query_result_format,
                  client,
@@ -1104,8 +1126,15 @@ class _AbstractQuery(object):
         self.fields = fields
 
     def execute(self):
+        """Executes query and returns results.
+
+        :returns: A generator to returns results
+        """
+        query_href = self._find_query_uri(self._query_result_format)
+        if query_href is None:
+            return []
         query_uri = self._build_query_uri(
-            self._find_query_uri(self._query_result_format),
+            query_href,
             self._page,
             self._page_size,
             self._filter,
@@ -1222,5 +1251,6 @@ class _TypedQuery(_AbstractQuery):
         query_href = \
             self. \
             _client. \
-            _get_query_list_map()[(query_media_type, self._query_type_name)]
+            _get_query_list_map().get(
+                (query_media_type, self._query_type_name))
         return query_href

--- a/system_tests/README.md
+++ b/system_tests/README.md
@@ -5,7 +5,7 @@
 This directory contains system tests that exercise pyvcloud API functions. 
 You can run tests individually as follows.
 
-1. Fill in required values in base_config.yaml.  
+1. Fill in required values in `base_config.yaml`.  
 2. Execute the test as a Python unit test, e.g.: 
 ```
 python3 -m unittest idisk_tests.py
@@ -13,9 +13,9 @@ python3 -m unittest idisk_tests.py
 
 To run system tests in a build, follow the steps below.
 
-1. Copy ../examples/vcd_connection.sample to vcd_connection and fill in 
+1. Copy `../examples/vcd_connection.sample` to `vcd_connection` and fill in 
 connection data.
-2. Export VCD_CONNECTION, e.g., `export VDC_CONNECTION=$PWD/VCD_CONNECTION`
+2. Export `VCD_CONNECTION`, e.g., `export VDC_CONNECTION=$PWD/vcd_connection`
 3. Execute the script as follows: `./run_system_tests.sh`
 
 This will run a default list of tests.  You can specify different tests 
@@ -24,32 +24,54 @@ by listing the file names on the command line, e.g.,
 
 ## Writing New Tests
 
-System tests are based on Python unittest but depend on a customized test
-superclass named BaseTestCase because we need a working vCD installation
-to do anything useful.  BaseTestCase calls the Environment class to set up
-basic fixtures automatically before the test runs.  It creates fixtures
-if they are missing; otherwise it reuses what is already there. 
+System tests are based on the [Python unittest framework](https://docs.python.org/3/library/unittest.html) 
+but depend on a customized test superclass named BaseTestCase because we
+need a working vCD installation to do anything useful.  BaseTestCase calls
+the Environment class to set up basic fixtures such as a test org, users, or
+VDC automatically before the test runs.  It creates fixtures if
+they are missing; otherwise it reuses what is already there.  Both of
+these classes may be found in the `pyvcloud.system_test_framework` module.
 
-You can also call Environment yourself to get usable references to users,
-test orgs, vapps and the like for your test code.
+Parameters for the test are supplied by file `base_config.yml`, which
+is located in the `system_tests` directory. You can copy this file to
+another location to set custom values and tell BaseTestCase where it is 
+located using the `VCD_TEST_BASE_CONFIG_FILE` environmental variable. 
 
-Here's a short description of how to develop a new test. 
+Here's a short description of steps to develop a new test. 
 
-Step 1: Start by copying an existing test to a new name such as my_test.py.
+Step 1: Start by copying an existing test to a new name such as `my_test.py`.
 
-Step 2: Trim out extraneous code and add your own test cases.  Name the
-cases to ensure they run in order.  We typically write tests to be
-order-dependent as it allows us to share complex state across test cases.
-Put in a docstring to describe what each test case is doing.
+Step 2: Trim out extraneous code and add your own test cases.
+We typically write tests to be order-dependent as it allows us to share
+complex state across test cases.  Minimum method naming and documentation
+conventions are as follows:
+
+* Name test case methods with a number to ensure run order plus a meaningful suffix such as `test_0030_get_disk_by_id`. 
+* Add a docstring that summarizes what the case verifies.
+* Private helper methods should be preceded with underscore, e.g., `_setup_stuff`.
 
 Step 3: Add setup and teardown as test cases at the start and end of the
 test to set up and remove specialized fixtures required for your test.
-You can skip this if no extra setup is required beyond what BaseTestCase
-gives you for free.
+(You can skip this if no extra setup is required beyond what BaseTestCase
+gives you for free.)  The conventional names are as follows:
 
-Warning: If you unittest setup and teardown methods be aware that
-these run on every case.  If they do anything complex your test will be
-very slow.
+* `test_0000_setup` -- Create custom state required for test
+* `def test_9999_teardown` -- Remove custom state
+
+To make tests easier to debug you can add the @developerModeAware tag
+to the teardown method so that it does not run when developer mode is
+set in the `base_config.yaml` file, thereby leaving state in place for
+you to look at later.  Here's an example:
+
+```
+@developerModeAware
+def test_9999_teardown(self):
+"""Remove stuff, etc."""
+```
+
+Note: You can also use the standard Python unittest `setUp()` and
+`tearDown()` methods.  Bear in mind that these run for each test method,
+so if they construct or remove state your test may run very slowly.
 
 Step 4: Use calls to Environment class methods to get references required
 for testing.  For example, the following code fetches an Org admin client
@@ -64,13 +86,21 @@ The Environment methods are easy to understand.  Have a look through
 the class to find what you need and add extra methods if you discover
 something useful is missing. 
 
-Step 5: Fill out values in the base_config.yaml file to tell your
+You can also access `base_config.yml` parameter values directly, as 
+shown in the following example: 
+
+```
+vcd_host = Environment._config['vcd']['host']
+sysadmin = Environment._config['vcd']['sys_admin_username']
+```
+
+Step 5: Fill out values in the `base_config.yaml` file to tell your
 test where vCD is located and set other details necessary for operation.
 Basic tests just need vCD host and admin credentials to run; more complex
 tests will require more.
 
-Step 6: Run your test!  You can use the run_system_tests.sh script
-described above or invoke your test manually as shown below.
+Step 6: Run your test!  You can use the `run_system_tests.sh` script
+described above or invoke your test directly as shown below.
 
 ```
 # Set location of config if it's something other than base_config.yaml.
@@ -78,4 +108,4 @@ export VCD_TEST_BASE_CONFIG_FILE=my_base_config.yaml
 python3 -m unittest my_test.py
 ```
 
-Before checking in, please run flake8 and correct any errors you find.  
+Step 7: Before checking in, run flake8 and correct any errors you find.  

--- a/system_tests/README.md
+++ b/system_tests/README.md
@@ -1,4 +1,6 @@
-## pyvcloud System Tests
+# pyvcloud System Tests
+
+## Running Tests
 
 This directory contains system tests that exercise pyvcloud API functions. 
 You can run tests individually as follows.
@@ -14,7 +16,66 @@ To run system tests in a build, follow the steps below.
 1. Copy ../examples/vcd_connection.sample to vcd_connection and fill in 
 connection data.
 2. Export VCD_CONNECTION, e.g., `export VDC_CONNECTION=$PWD/VCD_CONNECTION`
-3. Execute the script as follows: `run_system_tests.sh`
+3. Execute the script as follows: `./run_system_tests.sh`
 
 This will run a default list of tests.  You can specify different tests 
-by listing the file names on the command line. 
+by listing the file names on the command line, e.g.,
+`./run_system_tests.sh my_test.py`.
+
+## Writing New Tests
+
+System tests are based on Python unittest but depend on a customized test
+superclass named BaseTestCase because we need a working vCD installation
+to do anything useful.  BaseTestCase calls the Environment class to set up
+basic fixtures automatically before the test runs.  It creates fixtures
+if they are missing; otherwise it reuses what is already there. 
+
+You can also call Environment yourself to get usable references to users,
+test orgs, vapps and the like for your test code.
+
+Here's a short description of how to develop a new test. 
+
+Step 1: Start by copying an existing test to a new name such as my_test.py.
+
+Step 2: Trim out extraneous code and add your own test cases.  Name the
+cases to ensure they run in order.  We typically write tests to be
+order-dependent as it allows us to share complex state across test cases.
+Put in a docstring to describe what each test case is doing.
+
+Step 3: Add setup and teardown as test cases at the start and end of the
+test to set up and remove specialized fixtures required for your test.
+You can skip this if no extra setup is required beyond what BaseTestCase
+gives you for free.
+
+Warning: If you unittest setup and teardown methods be aware that
+these run on every case.  If they do anything complex your test will be
+very slow.
+
+Step 4: Use calls to Environment class methods to get references required
+for testing.  For example, the following code fetches an Org admin client
+object:
+
+```
+org_admin_client = Environment.get_client_in_default_org(
+    CommonRoles.ORGANIZATION_ADMINISTRATOR)
+```
+
+The Environment methods are easy to understand.  Have a look through
+the class to find what you need and add extra methods if you discover
+something useful is missing. 
+
+Step 5: Fill out values in the base_config.yaml file to tell your
+test where vCD is located and set other details necessary for operation.
+Basic tests just need vCD host and admin credentials to run; more complex
+tests will require more.
+
+Step 6: Run your test!  You can use the run_system_tests.sh script
+described above or invoke your test manually as shown below.
+
+```
+# Set location of config if it's something other than base_config.yaml.
+export VCD_TEST_BASE_CONFIG_FILE=my_base_config.yaml
+python3 -m unittest my_test.py
+```
+
+Before checking in, please run flake8 and correct any errors you find.  

--- a/system_tests/search_tests.py
+++ b/system_tests/search_tests.py
@@ -1,0 +1,140 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.environment import CommonRoles
+from pyvcloud.system_test_framework.environment import Environment
+
+from pyvcloud.vcd.client import QueryResultFormat
+from pyvcloud.vcd.client import ResourceType
+from pyvcloud.vcd.client import RESOURCE_TYPES
+from pyvcloud.vcd.utils import to_dict
+
+
+class TestSearch(BaseTestCase):
+    """Test pyvcloud search functions"""
+
+    def setUp(self):
+        """Store list of result formats."""
+        self._result_formats = [r for r in QueryResultFormat]
+
+    def test_0010_find_existing_with_admin(self):
+        """Find entities with admin account with optional filter parameters"""
+        resource_type_cc = 'organization'
+        client = Environment.get_sys_admin_client()
+        # Fetch all orgs.
+        q1 = client.get_typed_query(
+            resource_type_cc,
+            query_result_format=QueryResultFormat.ID_RECORDS,
+            qfilter=None)
+        q1_records = list(q1.execute())
+        self.assertTrue(
+            len(q1_records) > 0,
+            msg="Find at least one organization")
+        for r in q1_records:
+            r_dict = to_dict(r, resource_type=resource_type_cc)
+            name0 = r_dict['name']
+            break
+
+        # Find the org again using an equality filter.
+        eq_filter = ('name', name0)
+        q2 = client.get_typed_query(
+            resource_type_cc,
+            query_result_format=QueryResultFormat.ID_RECORDS,
+            equality_filter=eq_filter)
+        q2_records = list(q2.execute())
+        self.assertEqual(
+            1, len(q2_records),
+            msg="Find org with equality filter")
+
+        # Find the org again using a query filter string
+        q3 = client.get_typed_query(
+            resource_type_cc,
+            query_result_format=QueryResultFormat.ID_RECORDS,
+            qfilter="name=={0}".format(name0))
+        q3_records = list(q3.execute())
+        self.assertEqual(1, len(q3_records), msg="Find org with query filter")
+
+    def test_0020_find_existing_with_org_user(self):
+        """Find entities with low-privilege org user"""
+        client = Environment.get_client_in_default_org(
+            CommonRoles.CATALOG_AUTHOR)
+        q1 = client.get_typed_query(
+            ResourceType.CATALOG.value,
+            query_result_format=QueryResultFormat.ID_RECORDS)
+        q1_records = list(q1.execute())
+        self.assertTrue(len(q1_records) > 0,
+                        msg="Find at least one catalog item")
+
+    def test_0030_find_non_existing(self):
+        """Verify that we return nothing if no entities exist"""
+        client = Environment.get_client_in_default_org(CommonRoles.VAPP_USER)
+        for format in self._result_formats:
+            print("FORMAT: {0}".format(format))
+            # Use the generator directly.
+            q1 = client.get_typed_query(
+                ResourceType.ORGANIZATION.value,
+                query_result_format=QueryResultFormat.ID_RECORDS)
+            count = 0
+            for item in q1.execute():
+                count += 1
+            self.assertEqual(0, count, "Should not find orgs via generator")
+            # Try a list.
+            q1_records = list(q1.execute())
+            self.assertEqual(
+                0, len(q1_records),
+                "Should not find any orgs via list")
+
+    def test_0040_check_all_resource_types(self):
+        """Loop through all resource types to prove we can search on them"""
+        client = Environment.get_client_in_default_org(
+            CommonRoles.ORGANIZATION_ADMINISTRATOR)
+        for resource_type in RESOURCE_TYPES:
+            q1 = client.get_typed_query(
+                resource_type,
+                query_result_format=QueryResultFormat.ID_RECORDS)
+            q1_records = list(q1.execute())
+            self.assertTrue(len(q1_records) >= 0, "Should get a list")
+
+    def test_0050_check_result_formats(self):
+        """Verify we get expected results for all result formats"""
+        client = Environment.get_client_in_default_org(
+            CommonRoles.ORGANIZATION_ADMINISTRATOR)
+        for format in self._result_formats:
+            # Ensure format works with generator.
+            print("FORMAT: {0}".format(format))
+            q1 = client.get_typed_query(
+                ResourceType.USER.value,
+                query_result_format=format)
+            count = 0
+            for result in q1.execute():
+                count += 1
+            self.assertTrue(
+                count >= 4,
+                "Expect at least 4 users from generator: {0}".format(format))
+
+            # Ensure format works with list built over generator.
+            q2 = client.get_typed_query(
+                ResourceType.USER.value,
+                query_result_format=format)
+            q2_result = list(q2.execute())
+            self.assertTrue(
+                len(q2_result) >= 4,
+                "Expect at least 4 users from list: {0}".format(format))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixed KeyError that appears if you search for an entity type that has
no corresponding entities. Added docstring to Client.get_typed_query
method to make it clearer what arguments do. Implemented system test for
search to verify fix as well common search API usage.  Updated README.md
in system_tests directory to explain how to develop new tests.

(This arose in vcd-cli testing, hence the reference to a vcd-cli issue.)

Reviewers: @ckolovson, @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/245)
<!-- Reviewable:end -->
