### PR TITLE
VCDA-635: Implement pyvcloud client to server API version compatibility

### DIFF
--- a/pyvcloud/system_test_framework/base_test.py
+++ b/pyvcloud/system_test_framework/base_test.py
@@ -1,9 +1,23 @@
-import os
+# VMware vCloud Director Python SDK
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+import os
 import unittest
-import yaml
 
 from pyvcloud.system_test_framework.environment import Environment
+import yaml
 
 
 class BaseTestCase(unittest.TestCase):

--- a/pyvcloud/system_test_framework/environment.py
+++ b/pyvcloud/system_test_framework/environment.py
@@ -1,3 +1,18 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 import warnings
 
@@ -77,6 +92,14 @@ class Environment(object):
            cls._config['connection']['disable_ssl_warnings']:
             requests.packages.urllib3.disable_warnings()
         cls._logger = cls.get_default_logger()
+
+    @classmethod
+    def get_config(cls):
+        """Get test configuration parameter dictionary.
+
+        :return: A dict containing configuration information
+        """
+        return cls._config
 
     @classmethod
     def get_default_logger(cls):

--- a/pyvcloud/system_test_framework/environment.py
+++ b/pyvcloud/system_test_framework/environment.py
@@ -616,7 +616,7 @@ class Environment(object):
         """
         if cls._sys_admin_client is not None:
             with warnings.catch_warnings():
-                warnings.simplefilter("ignore", ResourceWarning) # NOQA
+                warnings.simplefilter("ignore", ResourceWarning)  # NOQA
                 cls._sys_admin_client.logout()
                 cls._sys_admin_client = None
                 cls._pvdc_href = None

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -95,9 +95,10 @@ E_RASD = objectify.ElementMaker(
 
 
 API_CURRENT_VERSIONS = [
-    '5.5', '5.6', '6.0', '13.0', '17.0', '20.0', '21.0', '22.0', '23.0',
-    '24.0', '25.0', '26.0', '27.0', '28.0', '29.0', '30.0', '31.0'
+    '27.0', '28.0', '29.0', '30.0'
 ]
+
+API_DEFAULT_VERSION = '30.0'
 
 VCLOUD_STATUS_MAP = {
     -1: "Could not be created",
@@ -384,6 +385,7 @@ def _response_has_content(response):
 
 
 def _objectify_response(response, as_object=True):
+    """Convert response content to Python type."""
     if _response_has_content(response):
         if as_object:
             return objectify.fromstring(response.content)
@@ -480,13 +482,32 @@ class _TaskMonitor(object):
 
 
 class Client(object):
-    """A low-level interface to the vCloud Director REST API."""
+    """A low-level interface to the vCloud Director REST API.
+
+    Clients default to the production vCD API version as of the pyvcloud
+    module release and will try to negotiate down to a lower API version
+    that pyvcloud certifies if the vCD server is older. You can also set
+    the version explicitly using the api_version parameter or by calling
+    the set_highest_supported_version() method.
+
+    The log_file is set by the first client instantiated and will be
+    ignored in later clients.
+
+    :param str uri: A vCD server host name or connection URI
+    :param str api_version: The vCD API version to use
+    :param boolean verify_ssl_certs: If True validate server certificate;
+        False allows self-signed certificates
+    :param str log_file: Log file name or None, which suppresses logging
+    :param boolean log_request: If True log HTTP requests
+    :param boolean log_headers: If True log HTTP headers
+    :param boolean log_bodies: If True log HTTP bodies
+    """
 
     _REQUEST_ID_HDR_NAME = 'X-VMWARE-VCLOUD-REQUEST-ID'
 
     def __init__(self,
                  uri,
-                 api_version='6.0',
+                 api_version=None,
                  verify_ssl_certs=True,
                  log_file=None,
                  log_requests=False,
@@ -504,7 +525,15 @@ class Client(object):
             else:
                 self._uri = 'https://' + self._uri
 
-        self._api_version = api_version
+        # If user provides API version we accept it, otherwise use default
+        # and set negotiation flag.
+        if api_version is None:
+            self._api_version = API_DEFAULT_VERSION
+            self._negotiate_api_version = True
+        else:
+            self._api_version = api_version
+            self._negotiate_api_version = False
+
         self._session_endpoints = None
         self._session = None
         self._query_list_map = None
@@ -514,7 +543,7 @@ class Client(object):
         self._logger = logging.getLogger(__name__)
         self._logger.setLevel(logging.DEBUG)
         # This makes sure that we don't append a new handler to the logger
-        # everytime we create a new client.
+        # every time we create a new client.
         if not self._logger.handlers:
             if log_file is not None:
                 handler = logging.FileHandler(log_file)
@@ -540,58 +569,122 @@ class Client(object):
     def _get_response_request_id(self, response):
         return response.headers[self._REQUEST_ID_HDR_NAME]
 
-    def get_supported_versions(self):
-        new_session = requests.Session()
-        response = self._do_request_prim(
-            'GET', self._uri + '/versions', new_session, accept_type='')
-        sc = response.status_code
-        if sc != 200:
-            raise VcdException('Unable to get supported API versions.')
-        return objectify.fromstring(response.content)
+    def get_api_version(self):
+        """Return vCD API version pyvcloud is using."""
+        return self._api_version
 
-    def set_highest_supported_version(self):
+    def get_supported_versions_list(self):
+        """Return non-deprecated server API versions as iterable list.
+
+        :return: List of str sorted in numerical order
+        """
         versions = self.get_supported_versions()
         active_versions = []
         for version in versions.VersionInfo:
             if not hasattr(version, 'deprecated') or \
                version.get('deprecated') == 'false':
-                active_versions.append(float(version.Version))
-        active_versions.sort()
+                active_versions.append(str(version.Version))
+        active_versions.sort(key=lambda x: float(x))
+        return active_versions
+
+    def get_supported_versions(self):
+        """Return non-deprecated API versions on vCD server.
+
+        :return: A :class:`lxml.objectify.ObjectifiedElement` object
+             representing vCD supported versions
+        """
+        with requests.Session() as new_session:
+            # Use with block to avoid leaking socket connections.
+            response = self._do_request_prim(
+                'GET', self._uri + '/versions', new_session, accept_type='')
+            sc = response.status_code
+            if sc != 200:
+                raise VcdException('Unable to get supported API versions.')
+            return objectify.fromstring(response.content)
+
+    def set_highest_supported_version(self):
+        """Set the client API version to the highest server API version.
+
+        This call is intended to make it easy to work with new vCD
+        features before they are officially supported in pyvcloud.
+        Production applications should either use the default pyvcloud API
+        version or set the API version explicitly to freeze compatibility.
+        """
+        active_versions = self.get_supported_versions_list()
         self._api_version = active_versions[-1]
+        self._negotiate_api_version = False
         self._logger.debug('API versions supported: %s' % active_versions)
         self._logger.debug(
-            'API version set to highest supported: %s' % self._api_version)
+            'API version set to: %s' % self._api_version)
         return self._api_version
 
     def set_credentials(self, creds):
-        """Sets the credentials used for authentication."""
+        """Set credentials and authenticate to create a new session.
+
+        This call will automatically negotiate the server API version if
+        it was not set previously. Note that the method may generate
+        exceptions from the underlying socket connection, which we pass
+        up unchanged to the client.
+
+        :param BasicLoginCredentials creds: Credentials containing org, user,
+            and password
+        """
+        # If we need to negotiate the server API level find the highest
+        # server version that pyvcloud supports.
+        if self._negotiate_api_version:
+            self._logger.debug("Negotiating API version")
+            active_versions = self.get_supported_versions_list()
+            self._logger.debug('API versions supported: %s' % active_versions)
+            for version in reversed(active_versions):
+                if version in API_CURRENT_VERSIONS:
+                    self._api_version = version
+                    self._negotiate_api_version = False
+                    self._logger.debug(
+                        'API version negotiated to: %s' % self._api_version)
+                    break
+
+            # Still need to negotiate?  That means we didn't find a
+            # suitable version.
+            if self._negotiate_api_version:
+                raise VcdException(
+                    "Unable to find a supported API version in " +
+                    " available server versions: {0}".format(active_versions))
+
+        # We can now proceed to login. Ensure we close session if
+        # any exception is thrown to avoid leaking a socket connection.
+        self._logger.debug('API version in use: %s' % self._api_version)
         new_session = requests.Session()
-        response = self._do_request_prim(
-            'POST',
-            self._uri + '/sessions',
-            new_session,
-            auth=('%s@%s' % (creds.user, creds.org), creds.password))
-        sc = response.status_code
-        if sc != 200:
-            r = None
-            try:
-                r = _objectify_response(response)
-            except Exception:
-                pass
-            if r is not None:
-                self._response_code_to_exception(
-                    sc,
-                    self._get_response_request_id(response), r)
-            else:
-                raise VcdException('Login failed.')
+        try:
+            response = self._do_request_prim(
+                'POST',
+                self._uri + '/sessions',
+                new_session,
+                auth=('%s@%s' % (creds.user, creds.org), creds.password))
 
-        session = objectify.fromstring(response.content)
-        self._session_endpoints = _get_session_endpoints(session)
+            sc = response.status_code
+            if sc != 200:
+                r = None
+                try:
+                    r = _objectify_response(response)
+                except Exception:
+                    pass
+                if r is not None:
+                    self._response_code_to_exception(
+                        sc,
+                        self._get_response_request_id(response), r)
+                else:
+                    raise VcdException('Login failed.')
 
-        self._session = new_session
-        self._session.headers['x-vcloud-authorization'] = \
-            response.headers['x-vcloud-authorization']
-        self._is_sysadmin = self._is_sys_admin(session.get('org'))
+            session = objectify.fromstring(response.content)
+            self._session_endpoints = _get_session_endpoints(session)
+
+            self._session = new_session
+            self._session.headers['x-vcloud-authorization'] = \
+                response.headers['x-vcloud-authorization']
+            self._is_sysadmin = self._is_sys_admin(session.get('org'))
+        except Exception:
+            new_session.close()
+            raise
 
     def rehydrate(self, state):
         self._session = requests.Session()
@@ -625,10 +718,22 @@ class Client(object):
         return session
 
     def logout(self):
-        uri = self._uri + '/session'
-        result = self._do_request('DELETE', uri)
-        self._session.close()
-        return result
+        """Destroy the server session and deallocate local resources.
+
+        This method is idempotent. Reusing a client after logout will
+        result in undefined behavior.
+
+        :return: Response from successful /DELETE operation or None
+             if session does not exist"
+        """
+        if self._session is None:
+            return None
+        else:
+            uri = self._uri + '/session'
+            result = self._do_request('DELETE', uri)
+            self._session.close()
+            self._session = None
+            return result
 
     def _is_sys_admin(self, logged_in_org):
         if logged_in_org.lower() == 'system':

--- a/pyvcloud/vcd/test.py
+++ b/pyvcloud/vcd/test.py
@@ -59,5 +59,5 @@ class TestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore", ResourceWarning) # NOQA
+            warnings.simplefilter("ignore", ResourceWarning)  # NOQA
             cls.client.logout()

--- a/system_tests/client_tests.py
+++ b/system_tests/client_tests.py
@@ -139,20 +139,20 @@ class TestClient(BaseTestCase):
         self._client.logout()
 
         # Should not be possible to reuse after logout.
-        exception = None
+        unreachable_code = False
         try:
             self._client.get_org_list()
             # Can't use self.fail() as we have a general exception trap
             # around this block.
-            exception = Exception("Org list succeeded after session logout!")
+            unreachable_code = True
         except Exception:
             # We don't care about exception; reuse behavior is undefined.
             self._logger.debug(
                 "Received exception after reusing logged out session",
                 exc_info=True)
 
-        if exception is not None:
-            raise exception
+        if unreachable_code:
+            self.fail("Org list succeeded after session logout!")
 
     def test_0070_flag_invalid_credentials(self):
         """Invalid credentials result in a VcdException."""
@@ -161,13 +161,13 @@ class TestClient(BaseTestCase):
         creds = client.BasicLoginCredentials(self._user, self._org, '!!!')
         try:
             self._client.set_credentials(creds)
-            raise Exception("Login succeeded with bad password")
+            self.fail("Login succeeded with bad password")
         except VcdException:
             self._logger.debug("Received expected exception", exc_info=True)
 
     def test_0080_flag_invalid_host(self):
         """Invalid host results in an exception."""
-        exception = None
+        unreachable_code = False
         try:
             self._client = client.Client(
                 "invalid.host.com",
@@ -177,14 +177,13 @@ class TestClient(BaseTestCase):
                 self._org,
                 self._pass)
             self._client.set_credentials(creds)
-            exception = Exception("Login succeeded with bad host")
         except Exception:
             # We don't care about the exact exception as request/urllib
             # handling is implementation-dependent and may change.
             self._logger.debug("Received expected exception", exc_info=True)
 
-        if exception is not None:
-            raise exception
+        if unreachable_code:
+            raise Exception("Login succeeded with bad host")
 
     def _create_client(self, api_version):
         """Create client with/without API version.

--- a/system_tests/client_tests.py
+++ b/system_tests/client_tests.py
@@ -1,0 +1,209 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.environment import Environment
+
+import pyvcloud.vcd.client as client
+from pyvcloud.vcd.exceptions import VcdException
+
+
+class TestClient(BaseTestCase):
+    """Test pyvcloud client module functions.
+
+    Test cases in this module do not have ordering dependencies, hence
+    all setup is accomplished using Python unittest setUp and tearDown
+    methods.
+    """
+
+    # Test configuration parameters and logger for output.
+    _config = None
+    _host = None
+    _org = None
+    _user = None
+    _pass = None
+
+    _logger = None
+
+    # Temporary client, logged out if found.
+    _client = None
+
+    def setUp(self):
+        self._config = Environment._config
+        self._host = self._config['vcd']['host']
+        self._org = self._config['vcd']['sys_org_name']
+        self._user = self._config['vcd']['sys_admin_username']
+        self._pass = self._config['vcd']['sys_admin_pass']
+
+        self._logger = Environment.get_default_logger()
+
+    def tearDown(self):
+        """Log out client connection if allocated."""
+        if self._client is not None:
+            try:
+                self._logger.debug("Logging out client automatically")
+                self._client.logout()
+            except Exception:
+                self._logger.warning("Client logout failed", exc_info=True)
+
+    def test_0010_use_default_api_version(self):
+        """Client defaults to highest server API version supported by pyvcloud.
+
+        This case must deal with the possibility that the server API level
+        is lower than the client in which case we'll get the highest level
+        available on the server.
+        """
+        self._client = self._create_client_with_credentials(api_version=None)
+        client_version = self._client.get_api_version()
+        server_versions = self._client.get_supported_versions_list()
+        self.assertTrue(
+            client_version in server_versions,
+            msg="Client version must be in server versions")
+
+        if client.API_DEFAULT_VERSION != self._client.get_api_version():
+            # Server must be a lower version.
+            self.assertEqual(client_version, server_versions[-1])
+
+    def test_0020_change_api_version(self):
+        """User can set API client to any supported server API version."""
+        # First find the server versions.
+        self._client = self._create_client_with_credentials(None)
+        server_versions = self._client.get_supported_versions_list()
+        self._client.logout()
+
+        # Now prove we can login to any of them.
+        for version in server_versions:
+            self._client = self._create_client_with_credentials(version)
+            self._logger.debug(
+                "Logged in with server API version: {0}".format(version))
+            self._client.logout()
+
+    def test_0030_server_highest_version(self):
+        """User can set connection to highest supported server version."""
+        self._client = self._create_client(None)
+        self._client.set_highest_supported_version()
+        creds = client.BasicLoginCredentials(self._user, self._org, self._pass)
+        self._client.set_credentials(creds)
+        server_versions = self._client.get_supported_versions_list()
+
+        self.assertEqual(
+            self._client.get_api_version(),
+            server_versions[-1],
+            msg="Client version must be at highest server version level")
+
+    def test_0040_flag_invalid_server_api(self):
+        """Client returns an exception if user sets invalid server API."""
+        try:
+            self._client = self._create_client_with_credentials('99.99')
+            raise Exception("Login succeeded with bad API version")
+        except VcdException:
+            self._logger.debug("Received expected exception", exc_info=True)
+
+    def test_0050_set_logging_parameters(self):
+        """User can set logging parameters to force request logs.
+
+        Resetting parameters does not change logging because there's only
+        a single appender and it's already set by time this case runs. For
+        now we just confirm that nothing breaks when these parameters are
+        set.
+        """
+        self._client = client.Client(
+            self._host,
+            verify_ssl_certs=False,
+            log_file='test_0050_set_logging_parameters.log',
+            log_requests=True,
+            log_headers=True,
+            log_bodies=True)
+        creds = client.BasicLoginCredentials(self._user, self._org, self._pass)
+        self._client.set_credentials(creds)
+
+    def test_0060_no_reuse_after_logout(self):
+        """Client cannot be reused after logout."""
+        self._client = self._create_client_with_credentials(None)
+        self._logger.debug("Issuing org list request to prove liveness")
+        self._client.get_org_list()
+        self._client.logout()
+
+        # Should not be possible to reuse after logout.
+        exception = None
+        try:
+            self._client.get_org_list()
+            exception = Exception("Org list succeeded after session logout!")
+        except Exception:
+            # We don't care about exception; reuse behavior is undefined.
+            self._logger.debug(
+                "Received exception after reusing logged out session",
+                exc_info=True)
+
+        if exception is not None:
+            raise exception
+
+    def test_0070_flag_invalid_credentials(self):
+        """Invalid credentials result in a VcdException."""
+        self._logger.debug("TEST: test_0070_flag_invalid_credentials")
+        self._client = self._create_client(None)
+        creds = client.BasicLoginCredentials(self._user, self._org, '!!!')
+        try:
+            self._client.set_credentials(creds)
+            raise Exception("Login succeeded with bad password")
+        except VcdException:
+            self._logger.debug("Received expected exception", exc_info=True)
+
+    def test_0080_flag_invalid_host(self):
+        """Invalid host results in an exception."""
+        exception = None
+        try:
+            self._client = client.Client(
+                "invalid.host.com",
+                verify_ssl_certs=False)
+            creds = client.BasicLoginCredentials(
+                self._user,
+                self._org,
+                self._pass)
+            self._client.set_credentials(creds)
+            exception = Exception("Login succeeded with bad host")
+        except Exception:
+            # We don't care about the exact exception as request/urllib
+            # handling is implementation-dependent and may change.
+            self._logger.debug("Received expected exception", exc_info=True)
+
+        if exception is not None:
+            raise exception
+
+    def _create_client(self, api_version):
+        """Create client with/without explicit API version."""
+        if api_version is None:
+            return client.Client(
+                self._host,
+                verify_ssl_certs=False)
+        else:
+            return client.Client(
+                self._host,
+                api_version=api_version,
+                verify_ssl_certs=False)
+
+    def _create_client_with_credentials(self, api_version):
+        """Create client with[out] explicit API version and login."""
+        new_client = self._create_client(api_version)
+        creds = client.BasicLoginCredentials(
+            self._user, self._org, self._pass)
+        new_client.set_credentials(creds)
+        return new_client
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/system_tests/client_tests.py
+++ b/system_tests/client_tests.py
@@ -94,7 +94,7 @@ class TestClient(BaseTestCase):
 
     def test_0030_server_highest_version(self):
         """User can set connection to highest supported server version."""
-        self._client = self._create_client(None)
+        self._client = client.Client(self._host, verify_ssl_certs=False)
         self._client.set_highest_supported_version()
         creds = client.BasicLoginCredentials(self._user, self._org, self._pass)
         self._client.set_credentials(creds)
@@ -157,7 +157,7 @@ class TestClient(BaseTestCase):
     def test_0070_flag_invalid_credentials(self):
         """Invalid credentials result in a VcdException."""
         self._logger.debug("TEST: test_0070_flag_invalid_credentials")
-        self._client = self._create_client(None)
+        self._client = client.Client(self._host, verify_ssl_certs=False)
         creds = client.BasicLoginCredentials(self._user, self._org, '!!!')
         try:
             self._client.set_credentials(creds)
@@ -185,28 +185,12 @@ class TestClient(BaseTestCase):
         if unreachable_code:
             raise Exception("Login succeeded with bad host")
 
-    def _create_client(self, api_version):
-        """Create client with/without API version.
-
-        :param api_version: If set create a client with the version set;
-            otherwise create a client with unset version that will
-            auto-negotiate.
-        """
-        if api_version is None:
-            # This client auto-negotiates.
-            return client.Client(
-                self._host,
-                verify_ssl_certs=False)
-        else:
-            # This client sets the version explicitly.
-            return client.Client(
-                self._host,
-                api_version=api_version,
-                verify_ssl_certs=False)
-
     def _create_client_with_credentials(self, api_version):
         """Create client with[out] explicit API version and login."""
-        new_client = self._create_client(api_version)
+        new_client = client.Client(
+            self._host,
+            api_version=api_version,
+            verify_ssl_certs=False)
         creds = client.BasicLoginCredentials(
             self._user, self._org, self._pass)
         new_client.set_credentials(creds)

--- a/system_tests/run_system_tests.sh
+++ b/system_tests/run_system_tests.sh
@@ -24,8 +24,11 @@
 set -e
 SCRIPT_DIR=`dirname $0`
 
-# If there are tests to run use those. Otherwise use default tests. 
-STABLE_TESTS="idisk_tests.py"
+# If there are tests to run use those. Otherwise use stable tests. 
+STABLE_TESTS="client_tests.py \
+idisk_tests.py \
+search_tests.py" 
+
 if [ $# == 0 ]; then
   echo "No tests provided, will run stable list: ${STABLE_TESTS}"
   TESTS=$STABLE_TESTS
@@ -60,4 +63,4 @@ echo "Generated parameter file: ${auto_base_config}"
 # Run the tests with the new file. From here on out all commands are logged. 
 set -x
 export VCD_TEST_BASE_CONFIG_FILE=${auto_base_config}
-python3 -m unittest $TESTS
+python3 -m unittest $TESTS -v

--- a/system_tests/run_system_tests.sh
+++ b/system_tests/run_system_tests.sh
@@ -27,7 +27,8 @@ SCRIPT_DIR=`dirname $0`
 # If there are tests to run use those. Otherwise use stable tests. 
 STABLE_TESTS="client_tests.py \
 idisk_tests.py \
-search_tests.py" 
+search_tests.py \
+vapp_tests.py"
 
 if [ $# == 0 ]; then
   echo "No tests provided, will run stable list: ${STABLE_TESTS}"


### PR DESCRIPTION
Adapted Client class to default to highest API version supported by
pyvcloud and negotiation down to a lower certified vCD API version if
necessary.  Restricted pyvcloud certified versions to vCD 8.20 up to
vCD 9.1 (current prod release).  Added method to get client version 
in effect and cleaned up selection of highest server version. 

Implemented client system test to check login and API versioning
behavior, added precise documentation for APIs related to login/logout,
and eliminated client socket leaks due to login failures.  Added new
client system test to stable test list in run_system_tests.sh.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/248)
<!-- Reviewable:end -->
