### PR TITLE
[VCDA-603] Catalog sharing fix for system tests,

### DIFF
--- a/pyvcloud/system_test_framework/environment.py
+++ b/pyvcloud/system_test_framework/environment.py
@@ -519,7 +519,7 @@ class Environment(object):
                         catalog_name=catalog_name)
                     return
             raise EntityNotFoundException('Catalog ' + catalog_name +
-                                          'doesn\'t exists.')
+                                          'doesn\'t exist.')
         finally:
             catalog_author_client.logout()
 

--- a/pyvcloud/system_test_framework/environment.py
+++ b/pyvcloud/system_test_framework/environment.py
@@ -87,8 +87,6 @@ class Environment(object):
         :param object config_data: a PyYAML object that contains the yaml
             representation of configuration data read from the configuration
             file.
-
-        :return: Nothing
         """
         cls._config = config_data
         if not cls._config['connection']['verify'] and \
@@ -100,7 +98,7 @@ class Environment(object):
     def get_config(cls):
         """Get test configuration parameter dictionary.
 
-        :return: A dict containing configuration information.
+        :return: a dict containing configuration information.
 
         :rtype: dict
         """
@@ -137,20 +135,18 @@ class Environment(object):
     def _basic_check(cls):
         """Does basic sanity check for configuration and sys admin client.
 
-        :return: Nothing
-
         :raises: Exception: if the basic configuration is missing.
         """
         if cls._config is None:
             raise Exception('Missing base configuration.')
         if cls._sys_admin_client is None:
-            cls.get_sys_admin_client()
+            cls._sys_admin_client = cls.get_sys_admin_client()
 
     @classmethod
     def get_sys_admin_client(cls):
-        """Returns the sys admin client, creates one if required.
+        """Creates a sys admin client.
 
-        :return: the sys admin client.
+        :return: a sys admin client.
 
         :rtype: pyvcloud.vcd.client.Client
 
@@ -159,15 +155,10 @@ class Environment(object):
         if cls._config is None:
             raise Exception('Missing base configuration.')
 
-        if cls._sys_admin_client is None:
-            org = cls._config['vcd']['sys_org_name']
-            password = cls._config['vcd']['sys_admin_pass']
-            username = cls._config['vcd']['sys_admin_username']
-            cls._sys_admin_client = cls.get_client(org=org,
-                                                   username=username,
-                                                   password=password)
-
-        return cls._sys_admin_client
+        org = cls._config['vcd']['sys_org_name']
+        password = cls._config['vcd']['sys_admin_pass']
+        username = cls._config['vcd']['sys_admin_username']
+        return cls.get_client(org=org, username=username, password=password)
 
     @classmethod
     def get_client_in_default_org(cls, role):
@@ -205,7 +196,7 @@ class Environment(object):
         :param str username: username of the user.
         :param str password: password of the user.
 
-        :return: A :class:  object.
+        :return: a client.
 
         :rtype: pyvcloud.vcd.client.Client
 
@@ -232,8 +223,6 @@ class Environment(object):
         """Attaches VC and NSX to vCD as per configuration file.
 
         If VC is already attached no further action is taken.
-
-        :return: Nothing
         """
         cls._basic_check()
         platform = Platform(cls._sys_admin_client)
@@ -261,8 +250,6 @@ class Environment(object):
 
         Skips creating one, if such a pvdc already exists. Also stores the
         href and name of the provider vdc as class variables for future use.
-
-        :return: Nothing
         """
         cls._basic_check()
         pvdc_name = cls._config['vcd']['default_pvdc_name']
@@ -292,8 +279,6 @@ class Environment(object):
 
         Skips creating one, if such an org already exists. Also stores the
         href of the org as class variable for future use.
-
-        :return: Nothing
         """
         cls._basic_check()
         system = System(cls._sys_admin_client,
@@ -322,8 +307,6 @@ class Environment(object):
         """Creates users for each of the roles in CommonRoles.
 
         Skips creating users which are already present in the organization.
-
-        :return: Nothing
 
         :raises: Exception: if the class variable _org_href is not populated.
         """
@@ -358,9 +341,7 @@ class Environment(object):
         """Creates an org vdc with the name specified in the config file.
 
         Skips creating one, if such an org vdc already exists. Also stores the
-            href of the org vdc as class variable for future use.
-
-        :return: Nothing
+        href of the org vdc as class variable for future use.
 
         :raises: Exception: if the class variable _org_href or _pvdc_name
             is not populated.
@@ -451,8 +432,6 @@ class Environment(object):
         configuration file, skips creating one, if such a network already
         exists.
 
-        :return: Nothing
-
         :raises: Exception: if the class variable _ovdc_href is not populated.
         """
         cls._basic_check()
@@ -486,8 +465,6 @@ class Environment(object):
 
         Skips creating one, if such a catalog already exists.
 
-        :return: Nothing
-
         :raises: Exception: if the class variable _org_href is not populated.
         """
         cls._basic_check()
@@ -519,8 +496,6 @@ class Environment(object):
     def share_catalog(cls):
         """Shares the test catalog with all members in the test organization.
 
-        :return: Nothing
-
         :raises: Exception: if the class variable _org_href is not populated.
         :raises: EntityNotFoundException: if the catalog in question is
             missing.
@@ -530,26 +505,29 @@ class Environment(object):
             raise Exception('Org ' + cls._config['vcd']['default_org_name'] +
                             ' doesn\'t exist.')
 
-        org = Org(cls._sys_admin_client, href=cls._org_href)
-        catalog_name = cls._config['vcd']['default_catalog_name']
-        catalog_records = org.list_catalogs()
-        for catalog_record in catalog_records:
-            if catalog_record.get('name').lower() == catalog_name.lower():
-                cls._logger.debug('Sharing catalog ' + catalog_name +
-                                  ' to all members of org ' + org.get_name())
-                org.share_catalog_with_org_members(catalog_name=catalog_name)
-                return
-
-        raise EntityNotFoundException('Catalog ' + catalog_name + 'doesn\'t'
-                                      'exists.')
+        try:
+            catalog_author_client = Environment.get_client_in_default_org(
+                CommonRoles.CATALOG_AUTHOR)
+            org = Org(catalog_author_client, href=cls._org_href)
+            catalog_name = cls._config['vcd']['default_catalog_name']
+            catalog_records = org.list_catalogs()
+            for catalog_record in catalog_records:
+                if catalog_record.get('name') == catalog_name:
+                    cls._logger.debug('Sharing catalog ' + catalog_name + ' to'
+                                      ' all members of org ' + org.get_name())
+                    org.share_catalog_with_org_members(
+                        catalog_name=catalog_name)
+                    return
+            raise EntityNotFoundException('Catalog ' + catalog_name +
+                                          'doesn\'t exists.')
+        finally:
+            catalog_author_client.logout()
 
     @classmethod
     def upload_template(cls):
         """Uploads the test template to the test catalog.
 
         If template already exists in the catalog then skips uploading it.
-
-        :return: Nothing
 
         :raises: Exception: if the class variable _org_href is not populated.
         """
@@ -576,6 +554,7 @@ class Environment(object):
                               ' to catalog ' + catalog_name + '.')
             org.upload_ovf(catalog_name=catalog_name, file_name=template_name)
 
+            # wait for the template import to finish in vCD.
             catalog_item = org.get_catalog_item(name=catalog_name,
                                                 item_name=template_name)
             template = catalog_author_client.get_resource(
@@ -591,8 +570,6 @@ class Environment(object):
 
         This template will be used to create the test vApp. if the vApp already
         exists then skips creating it.
-
-        :return: Nothing
 
         :raises: Exception: if the class variable _ovdc_href is not populated.
         """
@@ -627,10 +604,7 @@ class Environment(object):
 
     @classmethod
     def cleanup(cls):
-        """Cleans up the various class variables.
-
-        :return: Nothing
-        """
+        """Cleans up the various class variables."""
         if cls._sys_admin_client is not None:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", ResourceWarning)  # NOQA

--- a/system_tests/catalog_tests.py
+++ b/system_tests/catalog_tests.py
@@ -66,20 +66,17 @@ class TestCatalog(BaseTestCase):
         into the spool area(transfer folder) but it doesn't wait for the
         import of the template as catalog item to finish.
 
-        :param org: An object of :class:`lxml.objectify.StringElement`that
-            describes the organization which contains the catalog to which
-            the templates will be uploaded to.
-        :param catalog_name: (str): Name of the catalog to which the template
-            will be uploaded to.
-        :param template_name: (str): Name of the catalog item which represents
-            the uploaded template
-        :param template_file_name: (str): Name of the local template file which
+        :param pyvcloud.vcd.org.Org org: the organization which contains the
+            catalog to which the templates will be uploaded to.
+        :param str catalog_name: name of the catalog to which the template will
+            be uploaded to.
+        :param str template_name: name of the catalog item which represents the
+            uploaded template
+        :param str template_file_name: name of the local template file which
             will be uploaded.
 
-        :return: Nothing
-
-        :raises: EntityNotFoundException: If the catalog is not found.
-        :raises: InternalServerException: If template already exists in vCD.
+        :raises: EntityNotFoundException: if the catalog is not found.
+        :raises: InternalServerException: if template already exists in vCD.
         """
         bytes_uploaded = -1
         logger = Environment.get_default_logger()
@@ -94,19 +91,16 @@ class TestCatalog(BaseTestCase):
                                  template_name):
         """Helper method to block until a template is imported in vCD.
 
-        :param client: An object of :class: `pyvcloud.vcd.client.Client` that
-            would be used to make ReST calls to vCD.
-        :param org: An object of :class:`lxml.objectify.StringElement`that
-            describes the organization, which the templates is being imported
-            into.
-        :param catalog_name: (str): Name of the catalog to which the template
-            is being imported.
-        :param template_name: (str): Name of the catalog item which represents
-            the uploaded template.
+        :param pyvcloud.vcd.client.Client client: the client that would be used
+            to make ReST calls to vCD.
+        :param pyvcloud.vcd.org.Org org: the organization which contains the
+            catalog to which the templates will be uploaded to.
+        :param str catalog_name: name of the catalog to which the template is
+            being imported.
+        :param str template_name: (str): Name of the catalog item which
+            represents the uploaded template.
 
-        :return: Nothing
-
-        :raises: EntityNotFoundException: If the catalog/item is not found.
+        :raises: EntityNotFoundException: if the catalog/item is not found.
         """
         logger = Environment.get_default_logger()
         logger.debug('Importing template : ' + template_name + ' in vCD')
@@ -124,8 +118,7 @@ class TestCatalog(BaseTestCase):
         Upload an ova template to catalog. The template doesn't have
         ovf:chunkSize param in it's descriptor(ovf file).
 
-        This test passes if the upload succeeds and no exceptions are
-        raised.
+        This test passes if the upload succeeds and no exceptions are raised.
         """
         org = Environment.get_test_org(TestCatalog._client)
 
@@ -146,8 +139,7 @@ class TestCatalog(BaseTestCase):
         Upload an ova template to catalog. The template *has* ovf:chunkSize
         param in it's descriptor(ovf file).
 
-        This test passes if the upload succeeds and no exceptions are
-        raised.
+        This test passes if the upload succeeds and no exceptions are raised.
         """
         org = Environment.get_test_org(TestCatalog._client)
 
@@ -196,7 +188,7 @@ class TestCatalog(BaseTestCase):
     def test_0040_list_catalog(self):
         """Test the method org.list_catalog().
 
-        Fetches all catalogs in the current organization
+        Fetches all catalogs in the current organization.
 
         This test passes if the catalog created in test_0000_setup is present
         in the retrieved list of catalogs.
@@ -465,9 +457,9 @@ class TestCatalog(BaseTestCase):
         """Test the  method delete_catalog_item() and delete_catalog().
 
         Invoke the methods for templates and catalogs created by setup. This
-        test should be run as org admin, since a failure in any of the
-        previous tests might leave the catalog stranded with an user other
-        than the one who created the catalog in first place.
+        test should be run as org admin, since a failure in any of the previous
+        tests might leave the catalog stranded with an user other than the one
+        who created the catalog in first place.
 
         This test passes if none of the delete operations generate any
         exceptions.

--- a/system_tests/cleanup_test.py
+++ b/system_tests/cleanup_test.py
@@ -17,20 +17,33 @@ from pyvcloud.system_test_framework.environment import Environment
 from pyvcloud.vcd.client import TaskStatus
 from pyvcloud.vcd.system import System
 
+
 class TestCleanup(BaseTestCase):
-    """Special test you can run to clean up the test environment after 
-       a successful tests"""
+    """Special test to clean up the test environment.
+
+    Usually run after a successful test run.
+    """
 
     def test_cleanup(self):
-        """Get the test Org and delete it"""
-        client = Environment.get_sys_admin_client()
-        test_org = Environment.get_test_org(client)
+        """Get the test Org and delete it."""
+        client = None
+        try:
+            logger = Environment.get_default_logger()
+            client = Environment.get_sys_admin_client()
+            test_org = Environment.get_test_org(client)
 
-        print("Deleting test org: {0}".format(test_org.get_name()))
-        sys_admin_resource = client.get_admin()
-        system = System(client, admin_resource=sys_admin_resource)
-        task = system.delete_org(test_org.get_name(), True, True)
+            logger.debug('Deleting test org: {0}'.format(test_org.get_name()))
+            sys_admin_resource = client.get_admin()
+            system = System(client, admin_resource=sys_admin_resource)
+            task = system.delete_org(test_org.get_name(), True, True)
 
-        # Track the task to completion. 
-        task = client.get_task_monitor().wait_for_success(task)
-        self.assertEqual(task.get('status'), TaskStatus.SUCCESS.value)
+            # Track the task to completion.
+            result = client.get_task_monitor().wait_for_success(task)
+            self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        finally:
+            if client is not None:
+                client.logout()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/system_tests/client_tests.py
+++ b/system_tests/client_tests.py
@@ -25,9 +25,8 @@ from pyvcloud.vcd.exceptions import VcdException
 class TestClient(BaseTestCase):
     """Test pyvcloud client module functions.
 
-    Test cases in this module do not have ordering dependencies, hence
-    all setup is accomplished using Python unittest setUp and tearDown
-    methods.
+    Test cases in this module do not have ordering dependencies, hence all
+    setup is accomplished using Python unittest setUp and tearDown methods.
     """
 
     # Test configuration parameters and logger for output.
@@ -63,8 +62,8 @@ class TestClient(BaseTestCase):
     def test_0010_use_default_api_version(self):
         """Client defaults to highest server API version supported by pyvcloud.
 
-        This case must deal with the possibility that the server API level
-        is lower than the client in which case we'll get the highest level
+        This case must deal with the possibility that the server API level is
+        lower than the client in which case we'll get the highest level
         available on the server.
         """
         self._client = self._create_client_with_credentials(api_version=None)

--- a/system_tests/idisk_tests.py
+++ b/system_tests/idisk_tests.py
@@ -11,6 +11,7 @@ from pyvcloud.vcd.client import TaskStatus
 class TestDisk(BaseTestCase):
     """Test independent disk functionalities implemented in pyvcloud."""
 
+    _test_runner_role = CommonRoles.VAPP_AUTHOR
     _client = None
 
     _idisk1_name = 'test_idisk'
@@ -34,14 +35,14 @@ class TestDisk(BaseTestCase):
     def test_0000_setup(self):
         """Setup the independent disks for the other tests in this module.
 
-        Create three independent disks as per the configuration stated
-            above. In case the disks exist, re-use them.
+        Create three independent disks as per the configuration stated above.
+        In case the disks exist, re-use them.
 
         This test passes if all the three disk ids are not None.
         """
         logger = Environment.get_default_logger()
         TestDisk._client = Environment.get_client_in_default_org(
-            CommonRoles.CATALOG_AUTHOR)
+            TestDisk._test_runner_role)
         vdc = Environment.get_test_vdc(TestDisk._client)
 
         disks = vdc.get_disks()
@@ -107,7 +108,7 @@ class TestDisk(BaseTestCase):
         """Test the  method vdc.get_disks().
 
         This test passes if all the expected disk names are in the list of
-            disk returned by vdc.det_disks()
+        disk returned by vdc.det_disks()
         """
         vdc = Environment.get_test_vdc(TestDisk._client)
         disks = vdc.get_disks()
@@ -129,8 +130,8 @@ class TestDisk(BaseTestCase):
 
         Invoke the method with the name of the first independent disk.
 
-        This test passes if the disk returned by the method is nor None,
-            and it's name matches the expected name of the disk.
+        This test passes if the disk returned by the method is nor None, and
+        it's name matches the expected name of the disk.
         """
         vdc = Environment.get_test_vdc(TestDisk._client)
 
@@ -144,8 +145,8 @@ class TestDisk(BaseTestCase):
 
         Invoke the method with the id of the second independent disk.
 
-        This test passes if the disk returned by the method is nor None,
-            and it's id matches the expected id of the disk.
+        This test passes if the disk returned by the method is nor None, and
+        it's id matches the expected id of the disk.
         """
         vdc = Environment.get_test_vdc(TestDisk._client)
 
@@ -156,12 +157,12 @@ class TestDisk(BaseTestCase):
     def test_0040_change_idisk_owner(self):
         """Test the  method vdc.change_disk_owner().
 
-        Invoke the method for the third independent disk, to make vapp_user
-            the owner of the disk. Revert back teh ownership to catalog_author
-            once the test is over.
+        Invoke the method for the third independent disk, to make vapp_user the
+        owner of the disk. Revert back the ownership to the original owner once
+        the test is over.
 
-        This test passes if the disk states it's owner as vapp_user after
-            the method call.
+        This test passes if the disk states it's owner as vapp_user after the
+        method call.
         """
         org_admin_client = Environment.get_client_in_default_org(
             CommonRoles.ORGANIZATION_ADMINISTRATOR)
@@ -181,9 +182,9 @@ class TestDisk(BaseTestCase):
             new_owner_name = disk_resource.Owner.User.get('name')
             self.assertEqual(new_owner_name, username)
 
-            # Revert ownership to catalog author
+            # Revert ownership to original owner
             username = Environment.get_username_for_role_in_test_org(
-                CommonRoles.CATALOG_AUTHOR)
+                TestDisk._test_runner_role)
             user_resource = org.get_user(username)
 
             vdc.change_disk_owner(
@@ -199,8 +200,8 @@ class TestDisk(BaseTestCase):
     def test_0050_attach_disk_to_vm_in_vapp(self):
         """Test the  method vapp.attach_disk_to_vm().
 
-        Invoke the method for the second independent disk, to attach it to
-            the default test vm available in the Environment.
+        Invoke the method for the second independent disk, and attach it to the
+        default test vm available in the Environment.
 
         This test passes if the disk attachment task succeeds.
         """
@@ -224,9 +225,9 @@ class TestDisk(BaseTestCase):
         """Test the  method vapp.detach_disk_to_vm().
 
         Invoke the method for the second independent disk, to detach it from
-            the default test vm available in the Environment. we need to power
-            down the vm before running this test, and power it back on once the
-            test is over.
+        the default test vm available in the Environment. we need to power down
+        the vm before running this test, and power it back on once the test is
+        over.
 
         This test passes if the disk detachment task succeeds.
         """
@@ -274,12 +275,11 @@ class TestDisk(BaseTestCase):
     def test_0070_update_disk(self):
         """Test the  method vapp.update_disk().
 
-        Invoke the method for the first independent disk, to update it's
-            name, size and description. Revert the changes back once the test
-            is over.
+        Invoke the method for the first independent disk, to update it's name,
+        size and description. Revert the changes back once the test is over.
 
         This test passes if the updated disk's name, size and description
-            matches the expected values.
+        matches the expected values.
         """
         vdc = Environment.get_test_vdc(TestDisk._client)
 
@@ -298,7 +298,7 @@ class TestDisk(BaseTestCase):
         self.assertEqual(disk.get('size'), str(self._idisk1_new_size))
         self.assertEqual(disk.Description, self._idisk1_new_description)
 
-        # return disk 1 to original state
+        # return disk1 to original state
         result = vdc.update_disk(
             name=self._idisk1_new_name,
             new_name=self._idisk1_name,

--- a/system_tests/idisk_tests.py
+++ b/system_tests/idisk_tests.py
@@ -131,7 +131,7 @@ class TestDisk(BaseTestCase):
         Invoke the method with the name of the first independent disk.
 
         This test passes if the disk returned by the method is nor None, and
-        it's name matches the expected name of the disk.
+        its name matches the expected name of the disk.
         """
         vdc = Environment.get_test_vdc(TestDisk._client)
 
@@ -146,7 +146,7 @@ class TestDisk(BaseTestCase):
         Invoke the method with the id of the second independent disk.
 
         This test passes if the disk returned by the method is nor None, and
-        it's id matches the expected id of the disk.
+        its id matches the expected id of the disk.
         """
         vdc = Environment.get_test_vdc(TestDisk._client)
 
@@ -161,7 +161,7 @@ class TestDisk(BaseTestCase):
         owner of the disk. Revert back the ownership to the original owner once
         the test is over.
 
-        This test passes if the disk states it's owner as vapp_user after the
+        This test passes if the disk states its owner as vapp_user after the
         method call.
         """
         org_admin_client = Environment.get_client_in_default_org(
@@ -275,7 +275,7 @@ class TestDisk(BaseTestCase):
     def test_0070_update_disk(self):
         """Test the  method vapp.update_disk().
 
-        Invoke the method for the first independent disk, to update it's name,
+        Invoke the method for the first independent disk, to update its name,
         size and description. Revert the changes back once the test is over.
 
         This test passes if the updated disk's name, size and description

--- a/system_tests/nsxt_tests.py
+++ b/system_tests/nsxt_tests.py
@@ -26,10 +26,10 @@ from pyvcloud.vcd.platform import Platform
 
 class TestNSXT(BaseTestCase):
 
-    def test_000_setup(self):
+    def test_0000_setup(self):
         TestNSXT._client = Environment.get_sys_admin_client()
 
-    def test_010_register_nsxt(self):
+    def test_0010_register_nsxt(self):
         """Client can register a new NSX-T mgr if none exists w/ same name."""
         platform = Platform(TestNSXT._client)
 
@@ -51,7 +51,7 @@ class TestNSXT(BaseTestCase):
             nsxt_manager_description=Environment._config['nsxt']['descrip'])
         assert Environment._config['nsxt']['manager_name'] == nsxt.get('name')
 
-    def test_020_list_nsxt_managers(self):
+    def test_0020_list_nsxt_managers(self):
         """Client can list NSX-T mgrs that have been registered."""
         platform = Platform(TestNSXT._client)
 
@@ -64,7 +64,7 @@ class TestNSXT(BaseTestCase):
 
         self.assertIn(manager_name, result)
 
-    def test_030_unregister_nsxt(self):
+    def test_0030_unregister_nsxt(self):
         """Client can unregister an NSX-T mgr."""
         platform = Platform(TestNSXT._client)
 
@@ -78,6 +78,10 @@ class TestNSXT(BaseTestCase):
             qfilter=query_filter)
         records = list(query.execute())
         self.assertTrue(len(records) == 0)
+
+    def test_9999_setup(self):
+        """Release all resources held by this object for testing purposes."""
+        TestNSXT._client.logout()
 
 
 if __name__ == '__main__':

--- a/system_tests/run_system_tests.sh
+++ b/system_tests/run_system_tests.sh
@@ -28,7 +28,8 @@ SCRIPT_DIR=`dirname $0`
 STABLE_TESTS="client_tests.py \
 idisk_tests.py \
 search_tests.py \
-vapp_tests.py"
+vapp_tests.py \
+catalog_tests"
 
 if [ $# == 0 ]; then
   echo "No tests provided, will run stable list: ${STABLE_TESTS}"

--- a/system_tests/search_tests.py
+++ b/system_tests/search_tests.py
@@ -24,7 +24,7 @@ from pyvcloud.vcd.client import ResourceType
 
 
 class TestSearch(BaseTestCase):
-    """Test pyvcloud search functions"""
+    """Test pyvcloud search functions."""
 
     def setUp(self):
         """Store list of result formats and init client variable."""
@@ -37,43 +37,49 @@ class TestSearch(BaseTestCase):
             self._client.logout()
 
     def test_0010_find_existing_with_admin(self):
-        """Find entities with admin account with optional filter parameters"""
+        """Find entities with admin account with optional filter parameters."""
         # Get admin client.  This will not be logged out to avoid messing
         # up Environment class.
-        admin_client = Environment.get_sys_admin_client()
-        resource_type_cc = 'organization'
-        # Fetch all orgs.
-        q1 = admin_client.get_typed_query(
-            resource_type_cc,
-            query_result_format=QueryResultFormat.ID_RECORDS,
-            qfilter=None)
-        q1_records = list(q1.execute())
-        self.assertTrue(
-            len(q1_records) > 0,
-            msg="Find at least one organization")
-        name0 = q1_records[0].get('name')
+        admin_client = None
+        try:
+            admin_client = Environment.get_sys_admin_client()
+            resource_type_cc = 'organization'
+            # Fetch all orgs.
+            q1 = admin_client.get_typed_query(
+                resource_type_cc,
+                query_result_format=QueryResultFormat.ID_RECORDS,
+                qfilter=None)
+            q1_records = list(q1.execute())
+            self.assertTrue(
+                len(q1_records) > 0,
+                msg="Find at least one organization")
+            name0 = q1_records[0].get('name')
 
-        # Find the org again using an equality filter.
-        eq_filter = ('name', name0)
-        q2 = admin_client.get_typed_query(
-            resource_type_cc,
-            query_result_format=QueryResultFormat.ID_RECORDS,
-            equality_filter=eq_filter)
-        q2_records = list(q2.execute())
-        self.assertEqual(
-            1, len(q2_records),
-            msg="Find org with equality filter")
+            # Find the org again using an equality filter.
+            eq_filter = ('name', name0)
+            q2 = admin_client.get_typed_query(
+                resource_type_cc,
+                query_result_format=QueryResultFormat.ID_RECORDS,
+                equality_filter=eq_filter)
+            q2_records = list(q2.execute())
+            self.assertEqual(
+                1, len(q2_records),
+                msg="Find org with equality filter")
 
-        # Find the org again using a query filter string
-        q3 = admin_client.get_typed_query(
-            resource_type_cc,
-            query_result_format=QueryResultFormat.ID_RECORDS,
-            qfilter="name=={0}".format(name0))
-        q3_records = list(q3.execute())
-        self.assertEqual(1, len(q3_records), msg="Find org with query filter")
+            # Find the org again using a query filter string
+            q3 = admin_client.get_typed_query(
+                resource_type_cc,
+                query_result_format=QueryResultFormat.ID_RECORDS,
+                qfilter="name=={0}".format(name0))
+            q3_records = list(q3.execute())
+            self.assertEqual(1, len(q3_records),
+                             msg="Find org with query filter")
+        finally:
+            if admin_client is not None:
+                admin_client.logout()
 
     def test_0020_find_existing_entities_with_org_user(self):
-        """Find entities with low-privilege org user"""
+        """Find entities with low-privilege org user."""
         self._client = Environment.get_client_in_default_org(
             CommonRoles.CATALOG_AUTHOR)
         q1 = self._client.get_typed_query(
@@ -84,7 +90,7 @@ class TestSearch(BaseTestCase):
                         msg="Find at least one catalog item")
 
     def test_0030_find_non_existing(self):
-        """Verify we return nothing if no entities exist"""
+        """Verify we return nothing if no entities exist."""
         self._client = Environment.get_client_in_default_org(
             CommonRoles.VAPP_USER)
         for format in self._result_formats:
@@ -103,7 +109,7 @@ class TestSearch(BaseTestCase):
                 "Should not find any orgs via list")
 
     def test_0040_check_all_resource_types(self):
-        """Verify that we can search on any resource type without error"""
+        """Verify that we can search on any resource type without error."""
         self._client = Environment.get_client_in_default_org(
             CommonRoles.ORGANIZATION_ADMINISTRATOR)
         resource_types = [r.value for r in ResourceType]
@@ -118,7 +124,7 @@ class TestSearch(BaseTestCase):
                 "Should get a list, even if tempty")
 
     def test_0050_check_result_formats(self):
-        """Verify we get expected results for all result formats"""
+        """Verify we get expected results for all result formats."""
         self._client = Environment.get_client_in_default_org(
             CommonRoles.ORGANIZATION_ADMINISTRATOR)
         for format in self._result_formats:
@@ -141,6 +147,7 @@ class TestSearch(BaseTestCase):
             self.assertTrue(
                 len(q2_result) >= 4,
                 "Expect at least 4 users from list: {0}".format(format))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -15,9 +15,7 @@ from pyvcloud.vcd.exceptions import EntityNotFoundException
 class TestVApp(BaseTestCase):
     """Test vApp functionalities implemented in pyvcloud."""
 
-    # TODO(VCDA-603) - Once the share catalog bug is fixed, the runner should
-    # be changed to vApp Author
-    _test_runner_role = CommonRoles.CATALOG_AUTHOR
+    _test_runner_role = CommonRoles.VAPP_AUTHOR
     _client = None
 
     _empty_vapp_name = 'empty_vApp'
@@ -46,7 +44,7 @@ class TestVApp(BaseTestCase):
         """Setup the vApps required for the other tests in this module.
 
         Create two vApps as per the configuration stated above. In case the
-           vApps exist, re-use them.
+        vApps exist, re-use them.
 
         This test passes if the two vApp hrefs are not None.
         """
@@ -88,12 +86,14 @@ class TestVApp(BaseTestCase):
     def _create_empty_vapp(self, client, vdc):
         """Helper method to create an empty vApp.
 
-        :param client: An object of :class: `pyvcloud.vcd.client.Client` that
-            would be used to make ReST calls to vCD.
-        :param vdc: An object of :class:`lxml.objectify.StringElement`
-            describing the vdc in which the vApp will be created.
+        :param pyvcloud.vcd.client.Client client: a client that would be used
+            to make ReST calls to vCD.
+        :param pyvcloud.vcd.vcd.VDC vdc: the vdc in which the vApp will be
+            created.
 
-        :return: (str): href of the created vApp
+        :return: href of the created vApp.
+
+        :rtype: str
         """
         logger = Environment.get_default_logger()
         logger.debug('Creating empty vApp.')
@@ -111,12 +111,14 @@ class TestVApp(BaseTestCase):
     def _create_customized_vapp_from_template(self, client, vdc):
         """Helper method to create a customized vApp from template.
 
-        :param client: An object of :class: `pyvcloud.vcd.client.Client` that
-            would be used to make ReST calls to vCD.
-        :param vdc: An object of :class:`lxml.objectify.StringElement`
-            describing the vdc in which the vApp will be created.
+        :param pyvcloud.vcd.client.Client client: a client that would be used
+            to make ReST calls to vCD.
+        :param pyvcloud.vcd.vcd.VDC vdc: the vdc in which the vApp will be
+            created.
 
-        :return: (str): href of the created vApp
+        :return: href of the created vApp.
+
+        :rtype: str
         """
         logger = Environment.get_default_logger()
         logger.debug('Creating customized vApp.')
@@ -144,8 +146,8 @@ class TestVApp(BaseTestCase):
     def test_0010_get_vapp(self):
         """Test the method vdc.get_vapp().
 
-        This test passes if the expected vApp can be successfully retrieved
-           by name.
+        This test passes if the expected vApp can be successfully retrieved by
+        name.
         """
         vdc = Environment.get_test_vdc(TestVApp._client)
         vapp_resource = vdc.get_vapp(TestVApp._customized_vapp_name)
@@ -155,7 +157,7 @@ class TestVApp(BaseTestCase):
         """Test the method vdc.get_vapp().
 
         This test passes if the non-existent vApp can't be successfully
-           retrieved by name.
+        retrieved by name.
         """
         vdc = Environment.get_test_vdc(TestVApp._client)
         try:
@@ -167,20 +169,22 @@ class TestVApp(BaseTestCase):
         self.fail('Should fail with EntityNotFoundException while fetching'
                   'vApp ' + TestVApp._non_existent_vapp_name)
 
-    def test_0020_add_delete_vm(self):
+    def test_0030_add_delete_vm(self):
         """Test the method vapp.add_vms() and vapp.delete_vms().
 
         This test passes if the supplied vm is sucessfully added to the vApp
-           and then successfully removed from the vApp.
+        and then successfully removed from the vApp.
         """
         logger = Environment.get_default_logger()
         vapp_name = TestVApp._empty_vapp_name
         vapp = Environment.get_vapp_in_test_vdc(
             client=TestVApp._client, vapp_name=vapp_name)
 
-        source_vapp_resource = Environment.get_default_vapp(TestVApp._client).\
-            get_resource()
-        source_vm_name = Environment.get_default_vm_name()
+        source_vapp_name = TestVApp._customized_vapp_name
+        source_vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._client, vapp_name=source_vapp_name)
+        source_vapp_resource = source_vapp.get_resource()
+        source_vm_name = TestVApp._customized_vapp_vm_name
         target_vm_name = TestVApp._additional_vm_name
         spec = {
             'vapp': source_vapp_resource,
@@ -203,12 +207,12 @@ class TestVApp(BaseTestCase):
         result = TestVApp._client.get_task_monitor().wait_for_success(task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
-    def test_0030_customized_vapp(self):
+    def test_0040_customized_vapp(self):
         """Test the correctness of the customization of vdc.instantiate_vapp().
 
         This test passes if the customized vApp is retrieved successfully
-           and it's verified that the vApp is correctly customized as per the
-           config in this file.
+        and it's verified that the vApp is correctly customized as per the
+        config in this file.
         """
         vapp_name = TestVApp._customized_vapp_name
         vapp = Environment.get_vapp_in_test_vdc(
@@ -259,12 +263,9 @@ class TestVApp(BaseTestCase):
     def _power_on_vapp_if_possible(self, client, vapp):
         """Power on a vApp if possible, else fail silently.
 
-        :param client: An object of :class: `pyvcloud.vcd.client.Client` that
-            would be used to make ReST calls to vCD.
-        :param vapp: An object of :class:`lxml.objectify.StringElement`
-            describing the vapp which we want to power on.
-
-        :return: Nothing
+        :param pyvcloud.vcd.client.Client client: a client would be used to
+            make ReST calls to vCD.
+        :param pyvcloud.vcd.vapp.VApp vapp: the vapp which we want to power on.
         """
         # TODO(VCDA-603) : update power_on to handle missing link exception
         try:
@@ -276,7 +277,7 @@ class TestVApp(BaseTestCase):
         except Exception as e:
             pass
 
-    def test_0040_vapp_power_options(self):
+    def test_0050_vapp_power_options(self):
         """Test the method related to power operations in vapp.py.
 
         This test passes if all the power operations are successful.
@@ -338,11 +339,11 @@ class TestVApp(BaseTestCase):
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
         # end state of vApp is deployed and partially powered on.
 
-    def test_0050_vapp_network_connection(self):
+    def test_0060_vapp_network_connection(self):
         """Test vapp.connect/disconnect_org_vdc_network().
 
         This test passes if the connect and disconnect to orgvdc network
-           operations are successful.
+        operations are successful.
         """
         try:
             logger = Environment.get_default_logger()
@@ -370,7 +371,7 @@ class TestVApp(BaseTestCase):
         finally:
             client.logout()
 
-    def test_0060_vapp_acl(self):
+    def test_0070_vapp_acl(self):
         """Test the method related to access control list in vapp.py.
 
         This test passes if all the acl operations are successful.
@@ -440,11 +441,10 @@ class TestVApp(BaseTestCase):
         control_access = vapp.remove_access_settings(remove_all=True)
         self.assertFalse(hasattr(control_access, 'AccessSettings'))
 
-    def test_0070_vapp_lease(self):
+    def test_0080_vapp_lease(self):
         """Test the method vapp.set_lease().
 
-        This test passes if the lease setting operation completes
-           successfully.
+        This test passes if the lease setting operation completes successfully.
         """
         vapp_name = TestVApp._empty_vapp_name
         vapp = Environment.get_vapp_in_test_vdc(
@@ -457,11 +457,11 @@ class TestVApp(BaseTestCase):
             wait_for_success(task=task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
-    def test_0080_change_vapp_owner(self):
+    def test_0090_change_vapp_owner(self):
         """Test the method vapp.change_owner().
 
-        This test passes if the owner of the vApp is successfuly changed
-           to the desired user.
+        This test passes if the owner of the vApp is successfuly changed to the
+        desired user.
         """
         try:
             logger = Environment.get_default_logger()
@@ -496,7 +496,7 @@ class TestVApp(BaseTestCase):
             org_admin_client.logout()
 
     @unittest.skip("Not enough documentation")
-    def test_0090_vapp_metadata(self):
+    def test_0100_vapp_metadata(self):
         """Test vapp.set/get_metadata()."""
         # TODO() - Unclear about the use of this feature, not enough
         # documentation in vapp.py


### PR DESCRIPTION
* Fixed catalog sharing issue in system tests. Now users other than catalog author can access the test catalog.
* Tests in idisk_tests.py and vapp_tests.py now now run in VAPP_AUTHOR context.
* System Admin client is no longer a singleton. Each call to get_sys_admin_client() will now generate a new client. Added fallout code to logout the aforementioned client in various test suites.
* Fixed documentation in system tests.
* Fixed flake8 errors in search, client and cleanup tests.

Ran all the tests
(pyvcloud) C:\code\pyvcloud\system_tests>python -m unittest idisk_tests.py client_tests.py vapp_tests.py catalog_tests.py cleanup_test.py -v
All of them succeeded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/257)
<!-- Reviewable:end -->
