### PR TITLE
Fixed catalog delete operation for vCD 9.0.

### DIFF
--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -114,9 +114,10 @@ class Org(object):
         :raises: sub-class of VcdResponseException: if the REST call is not
             successful.
         """
-        catalog_resource = self.get_catalog(name)
+        catalog_admin_resource = self.get_catalog(name=name,
+                                                  is_admin_operation=True)
         self.client.delete_linked_resource(
-            catalog_resource, RelationType.REMOVE, media_type=None)
+            catalog_admin_resource, RelationType.REMOVE, media_type=None)
 
     def list_catalogs(self):
         """List all catalogs in the organization.


### PR DESCRIPTION
vCD 9.0 and vCD 9.5 behave differently when the following api call is made to them using api v29.0.
/api/catalog/{id}

vCD 9.0 doesn't return the "remove" link, while vCD 9.5 does. Our implementation of Org.delete_catalog() depends on the link. As a result all catalog delete operations were failing against vCD 9.0.

As a fix we have now moved to the admin version of the href for delete operations.
/ap/admin/catalog/{id}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/259)
<!-- Reviewable:end -->
