### PR TITLE
[vcd-cli Issue 228] Added guard code to handle cases in list_vcenters() when vCD isn't connected to any vCenter.

### DIFF
--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -53,9 +53,14 @@ class Platform(object):
 
         :rtype: list
         """
-        return self.client.get_linked_resource(
-            self.extension.get_resource(), RelationType.DOWN,
-            EntityType.VIM_SERVER_REFS.value).VimServerReference
+        vim_server_references = self.client.get_linked_resource(
+            self.extension.get_resource(),
+            RelationType.DOWN,
+            EntityType.VIM_SERVER_REFS.value)
+        if hasattr(vim_server_references, 'VimServerReference'):
+            return vim_server_references.VimServerReference
+        else:
+            return []
 
     def get_vcenter(self, name):
         """Fetch a vCenter attached to the system by name.


### PR DESCRIPTION
When no vCenter servers are attached to vCD, attempt to invoke list_vcenters() function in platform.py will fail.

E.g.
(vcd-cli) C:\code\vcd-cli>vcd vc list
Usage: vcd vc list [OPTIONS]

Error: no such child: {http://www.vmware.com/vcloud/extension/v1.5}VimServerReference

Added guard code to avoid looking for the non-existent XML tags while looking for vCenter server references.

After fix,
(vcd-cli) C:\code\vcd-cli>vcd vc list

(vcd-cli) C:\code\vcd-cli>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/262)
<!-- Reviewable:end -->
