### PR TITLE
[VCDA-708] CVE-2017-18342 : Replace yaml.load() with yaml.safe_load()

### DIFF
--- a/pyvcloud/system_test_framework/base_test.py
+++ b/pyvcloud/system_test_framework/base_test.py
@@ -29,7 +29,7 @@ class BaseTestCase(unittest.TestCase):
         if 'VCD_TEST_BASE_CONFIG_FILE' in os.environ:
             cls._config_file = os.environ['VCD_TEST_BASE_CONFIG_FILE']
         with open(cls._config_file, 'r') as f:
-            cls._config_yaml = yaml.load(f)
+            cls._config_yaml = yaml.safe_load(f)
 
         Environment.init(cls._config_yaml)
         Environment.attach_vc()

--- a/pyvcloud/vcd/test.py
+++ b/pyvcloud/vcd/test.py
@@ -32,7 +32,7 @@ class TestCase(unittest.TestCase):
         if 'VCD_TEST_CONFIG_FILE' in os.environ:
             config_file = os.environ['VCD_TEST_CONFIG_FILE']
         with open(config_file, 'r') as f:
-            cls.config = yaml.load(f)
+            cls.config = yaml.safe_load(f)
         if not cls.config['vcd']['verify'] and \
                 cls.config['vcd']['disable_ssl_warnings']:
             requests.packages.urllib3.disable_warnings()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flufl.enum >= 4.1.1
 humanfriendly >= 4.8
 lxml >= 3.4.1
-PyYAML >= 3.10
+PyYAML >= 3.10, <= 3.13
 pygments >= 2.2.0
 requests >= 2.18.4


### PR DESCRIPTION
Fix  for CVE-2017-18342 http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-18342

Restricted dependency on PyYAML to >=3.10 and <=3.13
Replaced instances of yaml.load() to yaml.safe_load()

Pulled a fresh copy of pyvcloud from github and checked,
1. Correct version of PyYAML is being installed as part of setup
2. Ran all pyvcloud system tests to make sure that the yaml.safe_load() didn't cause any regressions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/266)
<!-- Reviewable:end -->
