### PR TITLE
[VCDA-707] Fixed security hole in tarfile.extractall() related to directory walking.

### DIFF
--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -40,6 +40,7 @@ from pyvcloud.vcd.exceptions import InvalidParameterException
 from pyvcloud.vcd.exceptions import UploadException
 from pyvcloud.vcd.system import System
 from pyvcloud.vcd.utils import get_admin_href
+from pyvcloud.vcd.utils import get_safe_members_in_tar_file
 from pyvcloud.vcd.utils import to_dict
 
 DEFAULT_CHUNK_SIZE = 1024 * 1024
@@ -575,7 +576,8 @@ class Org(object):
         try:
             tempdir = tempfile.mkdtemp(dir='.')
             ova = tarfile.open(file_name)
-            ova.extractall(path=tempdir)
+            ova.extractall(path=tempdir,
+                           members=get_safe_members_in_tar_file(ova))
             ova.close()
             ovf_file = None
             extracted_files = os.listdir(tempdir)

--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -693,9 +693,9 @@ def get_safe_members_in_tar_file(tarfile):
         if _badpath(finfo.name, base):
             print(finfo.name + ' is blocked: illegal path.')
         elif finfo.issym() and _badlink(finfo, base):
-            print(finfo.name + ' is blocked: Hard link to ' + finfo.linkname)
-        elif finfo.islnk() and _badlink(finfo, base):
             print(finfo.name + ' is blocked: Symlink to ' + finfo.linkname)
+        elif finfo.islnk() and _badlink(finfo, base):
+            print(finfo.name + ' is blocked: Hard link to ' + finfo.linkname)
         else:
             result.append(finfo)
     return result

--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from os.path import abspath
+from os.path import dirname
+from os.path import join as joinpath
+from os.path import realpath
+
 import humanfriendly
 from lxml import etree
 from lxml.objectify import NoneElement
@@ -641,3 +646,56 @@ def get_admin_extension_href(href):
         return href.replace('/api/admin/', '/api/admin/extension/')
     else:
         return href.replace('/api/', '/api/admin/extension/')
+
+
+def _badpath(path, base):
+    """Determines if a given file path is under a given base path or not.
+
+    :param str path: file path where the file will be extracted to.
+    :param str base: path to the current working directory.
+
+    :return: False, if the path is under the given base, else True.
+
+    :rtype: bool
+    """
+    # joinpath will ignore base if path is absolute
+    return not realpath(abspath(joinpath(base, path))).startswith(base)
+
+
+def _badlink(info, base):
+    """Determine if a given link is under a given base path or not.
+
+    :param TarInfo info: file that is going to be extracted.
+    :param str base: path to the current working directory.
+
+    :return: False, if the path is under the given base, else True.
+
+    :rtype: bool
+    """
+    # Links are interpreted relative to the directory containing the link
+    tip = realpath(abspath(joinpath(base, dirname(info.name))))
+    return _badpath(info.linkname, base=tip)
+
+
+def get_safe_members_in_tar_file(tarfile):
+    """Retrieve members of a tar file that are safe to extract.
+
+    :param Tarfile tarfile: the archive that has been opened as a TarFile
+        object.
+
+    :return: list of members in the archive that are safe to extract.
+
+    :rtype: list
+    """
+    base = realpath(abspath(('.')))
+    result = []
+    for finfo in tarfile.getmembers():
+        if _badpath(finfo.name, base):
+            print(finfo.name + ' is blocked: illegal path.')
+        elif finfo.issym() and _badlink(finfo, base):
+            print(finfo.name + ' is blocked: Hard link to ' + finfo.linkname)
+        elif finfo.islnk() and _badlink(finfo, base):
+            print(finfo.name + ' is blocked: Symlink to ' + finfo.linkname)
+        else:
+            result.append(finfo)
+    return result


### PR DESCRIPTION
Issue : https://docs.python.org/3/library/tarfile.html#tarfile.TarFile.extractall
Fix is outlined at https://stackoverflow.com/questions/10060069/safely-extract-zip-or-tar-using-python/10077309#10077309

tarfile.extractall() method doesn't check for the presence of directory meta info hidden in file names of the archive members. As a result, malicious tar files can be used to extract payload into directories other than the target directory.

As a fix we filter out non safe members of archives before extracting them.

Testing Done:
1. Created an archive containing a file named "\\..\\1.txt". If this archive is extracted on windows, it will extract the text file in the root directory.
2. Wrote a a sample script to extract this tarfile with and without the filter we wrote.

Without filter : File gets extracted in the root folder. 
With filter : We get expected error message.

````
C:\Users\sena\Desktop\test>python extract.py attack_test.tar
\..\1.txt is blocked: illegal path.
````

Also tried out the extraction script on a regular ova file and the extraction went on without any hiccups

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/268)
<!-- Reviewable:end -->
