### PR TITLE
[VCDA-691] Fixed orgvdc network access for non admin users

### DIFF
--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -909,18 +909,12 @@ class VApp(object):
         :raises: InvalidStateException: if the vApp is already connected to the
             org vdc network.
         """
-        vdc = VDC(
-            self.client,
-            href=find_link(self.resource, RelationType.UP,
-                           EntityType.VDC.value).href)
-        orgvdc_networks = \
-            vdc.list_orgvdc_network_resources(orgvdc_network_name)
-        if len(orgvdc_networks) == 0:
-            raise EntityNotFoundException(
-                "Org vdc network \'%s\' does not exist in vdc "
-                "\'%s\'" % (orgvdc_network_name,
-                            vdc.get_resource().get('name')))
-        orgvdc_network_href = orgvdc_networks[0].get('href')
+        vdc = VDC(self.client,
+                  href=find_link(self.resource,
+                                 RelationType.UP,
+                                 EntityType.VDC.value).href)
+        orgvdc_network_href = vdc.get_orgvdc_network_record_by_name(
+            orgvdc_network_name).get('href')
 
         network_configuration_section = \
             deepcopy(self.resource.NetworkConfigSection)

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -21,7 +21,9 @@ from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import FenceMode
 from pyvcloud.vcd.client import find_link
 from pyvcloud.vcd.client import NSMAP
+from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.client import RelationType
+from pyvcloud.vcd.client import ResourceType
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import InvalidParameterException
 from pyvcloud.vcd.exceptions import MultipleRecordsException
@@ -1063,25 +1065,47 @@ class VDC(object):
             request_payload)
 
     def list_orgvdc_network_records(self):
-        """Fetch all the orgvdc networks in the current vdc.
+        """Fetch all orgvdc networks in the current vdc.
 
-        :return: a list of lxml.objectify.ObjectifiedElement objects, where
-            each object contains OrgVdcNetworkRecord XML element which
-            represents an org vdc network record.
+        :return: org vdc network data in form of
+            lxml.objectify.ObjectifiedElement objects, where each object
+            contains OrgVdcNetworkRecord XML element.
 
-        :rtype: list
+        :rtype: generator object
         """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        resource_type = ResourceType.ORG_VDC_NETWORK.value
+        vdc_filter = None
+        if self.client.is_sysadmin():
+            vdc_filter = 'vdc==%s' % self.href
 
-        records = self.client.get_linked_resource(
-            self.resource, RelationType.ORG_VDC_NETWORKS,
-            EntityType.RECORDS.value)
+        query = self.client.get_typed_query(
+            resource_type,
+            query_result_format=QueryResultFormat.RECORDS,
+            qfilter=vdc_filter)
+        records = query.execute()
 
-        if hasattr(records, 'OrgVdcNetworkRecord'):
-            return records.OrgVdcNetworkRecord
-        else:
-            return []
+        return records
+
+    def get_orgvdc_network_record_by_name(self, orgvdc_network_name):
+        """Fetch the orgvdc network identified by it's name in the current vdc.
+
+        :return: orgvdc network data in form of OrgVdcNetworkRecord XML
+            element.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+
+        :raises: EntityNotFoundException: if the named org vdc network cannot
+            be located.
+        """
+        records = self.list_orgvdc_network_records()
+
+        for record in records:
+            if orgvdc_network_name == record.get('name'):
+                return record
+
+        raise EntityNotFoundException(
+            "Org vdc network \'%s\' does not exist in vdc \'%s\'" %
+            (orgvdc_network_name, self.get_resource().get('name')))
 
     def list_orgvdc_network_resources(self, name=None, type=None):
         """Fetch orgvdc networks with filtering by name and type.

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -347,31 +347,26 @@ class TestVApp(BaseTestCase):
         This test passes if the connect and disconnect to orgvdc network
         operations are successful.
         """
-        try:
-            logger = Environment.get_default_logger()
-            client = Environment.get_client_in_default_org(
-                CommonRoles.ORGANIZATION_ADMINISTRATOR)
+        logger = Environment.get_default_logger()
 
-            network_name = Environment.get_default_orgvdc_network_name()
+        network_name = Environment.get_default_orgvdc_network_name()
 
-            vapp_name = TestVApp._customized_vapp_name
-            vapp = Environment.get_vapp_in_test_vdc(
-                client=client, vapp_name=vapp_name)
+        vapp_name = TestVApp._customized_vapp_name
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVapp._client, vapp_name=vapp_name)
 
-            logger.debug('Connecting vApp ' + vapp_name +
-                         ' to orgvdc network ' + network_name)
-            task = vapp.connect_org_vdc_network(network_name)
-            result = client.get_task_monitor().wait_for_success(task)
-            self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        logger.debug('Connecting vApp ' + vapp_name +
+                     ' to orgvdc network ' + network_name)
+        task = vapp.connect_org_vdc_network(network_name)
+        result = TestVApp._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
-            logger.debug('Disconnecting vApp ' + vapp_name +
-                         ' to orgvdc network ' + network_name)
-            vapp.reload()
-            task = vapp.disconnect_org_vdc_network(network_name)
-            result = client.get_task_monitor().wait_for_success(task)
-            self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
-        finally:
-            client.logout()
+        logger.debug('Disconnecting vApp ' + vapp_name +
+                     ' to orgvdc network ' + network_name)
+        vapp.reload()
+        task = vapp.disconnect_org_vdc_network(network_name)
+        result = TestVApp._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
     def test_0070_vapp_acl(self):
         """Test the method related to access control list in vapp.py.


### PR DESCRIPTION
Non admin users don't have enough rights to issue a GET call on network resources. As a result vApp attach to network method fails to translate an orgvdc network name to href.

* Added a new method to allow non admin users to retrieve href of orgvdc networks without issuing a GET request against the network resource.
* Updated the vApp test to test 'connect vapp to network' to run in a non admin user context.

Ran vapp_tests system test to make sure that the changes work as intended and don't introduce any regressions.