### PR TITLE
[VCDA-592] Fix for vcd-cli issue 234. Added system tests for API extension methods. 

### DIFF
--- a/pyvcloud/vcd/api_extension.py
+++ b/pyvcloud/vcd/api_extension.py
@@ -43,7 +43,7 @@ class APIExtension(object):
         :rtype: dict
         """
         query = self.client.get_typed_query(
-            ResourceType.ADMIN_SERVICE,
+            ResourceType.ADMIN_SERVICE.value,
             query_result_format=QueryResultFormat.ID_RECORDS)
         return [to_dict(r, self.ATTRIBUTES) for r in query.execute()]
 
@@ -61,7 +61,7 @@ class APIExtension(object):
         :rtype: dict
         """
         ext = self.client.get_typed_query(
-            ResourceType.ADMIN_SERVICE,
+            ResourceType.ADMIN_SERVICE.value,
             qfilter='name==%s;namespace==%s' % (name, namespace
                                                 if namespace else name),
             query_result_format=QueryResultFormat.ID_RECORDS).find_unique()
@@ -77,7 +77,7 @@ class APIExtension(object):
         :rtype: generator object
         """
         return self.client.get_typed_query(
-            ResourceType.API_FILTER,
+            ResourceType.API_FILTER.value,
             equality_filter=('service', service_id),
             query_result_format=QueryResultFormat.ID_RECORDS).execute()
 
@@ -149,7 +149,7 @@ class APIExtension(object):
         :rtype: lxml.objectify.ObjectifiedElement
         """
         record = self.client.get_typed_query(
-            ResourceType.ADMIN_SERVICE,
+            ResourceType.ADMIN_SERVICE.value,
             qfilter='name==%s;namespace==%s' % (name, namespace
                                                 if namespace else name),
             query_result_format=QueryResultFormat.RECORDS).find_unique()

--- a/pyvcloud/vcd/api_extension.py
+++ b/pyvcloud/vcd/api_extension.py
@@ -18,6 +18,8 @@ from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.client import RelationType
 from pyvcloud.vcd.client import ResourceType
+from pyvcloud.vcd.exceptions import MissingRecordException
+from pyvcloud.vcd.exceptions import MultipleRecordsException
 from pyvcloud.vcd.utils import to_dict
 
 
@@ -47,25 +49,71 @@ class APIExtension(object):
             query_result_format=QueryResultFormat.ID_RECORDS)
         return [to_dict(r, self.ATTRIBUTES) for r in query.execute()]
 
-    def get_extension(self, name, namespace=None):
-        """Fetch info about a particular API extension.
+    def _get_extension_record(self,
+                              name,
+                              namespace=None,
+                              format=QueryResultFormat.ID_RECORDS):
+        """Fetch info about a particular API extension service as a record.
 
         :param str name: the name of the extension service whose info we want
             to retrieve.
-        :param str namespace: the namespace of the extension service. If not
-            specified (i.e. = None), we will use the value passed in the
-            `name` parameter.
+        :param str namespace: the namespace of the extension service.
+        :param format QueryResultFormat: dictates whether id or href should be
+            part of the returned record. By default id is returned.
 
-        :return: information about the extension.
+        :return: the extension service record.
+
+        :rtype: generator object that returns lxml.objectify.ObjectifiedElement
+            object containing AdminServiceRecord XML data representing the
+            service.
+
+        :raises MissingRecordException: if a service with the given name and
+            namespace couldn't be found.
+        :raise MultipleRecordsException: if more than one service with the
+            given name and namespace are found.
+        """
+        qfilter = 'name==%s' % name
+        if namespace is not None:
+            qfilter += ';namespace==%s' % namespace
+        try:
+            ext = self.client.get_typed_query(
+                ResourceType.ADMIN_SERVICE.value,
+                qfilter=qfilter,
+                query_result_format=format).find_unique()
+        except MissingRecordException as e:
+            msg = 'API Extension service (name:' + name
+            if namespace is not None:
+                msg += ', namespace:' + namespace
+            msg += ') not found.'
+            raise MissingRecordException(msg)
+        except MultipleRecordsException as e:
+            msg = 'Found multiple API Extension service with (name:' + name
+            if namespace is not None:
+                msg += ', namespace:' + namespace + ').'
+            else:
+                msg += '). Consider providing value for the namespace.'
+            raise MultipleRecordsException(msg)
+
+        return ext
+
+    def get_extension(self, name, namespace=None):
+        """Fetch info about a particular API extension service.
+
+        :param str name: the name of the extension service whose info we want
+            to retrieve.
+        :param str namespace: the namespace of the extension service.
+
+        :return: information about the extension service.
 
         :rtype: dict
+
+        :raises MissingRecordException: if a service with the given name and
+            namespace couldn't be found.
+        :raise MultipleRecordsException: if more than one service with the
+            given name and namespace are found.
         """
-        ext = self.client.get_typed_query(
-            ResourceType.ADMIN_SERVICE.value,
-            qfilter='name==%s;namespace==%s' % (name, namespace
-                                                if namespace else name),
-            query_result_format=QueryResultFormat.ID_RECORDS).find_unique()
-        return to_dict(ext, self.ATTRIBUTES)
+        ext_record = self._get_extension_record(name, namespace)
+        return to_dict(ext_record, self.ATTRIBUTES)
 
     def get_api_filters(self, service_id):
         """Fetch the API filters defined for the service.
@@ -93,6 +141,11 @@ class APIExtension(object):
         :return: information about the extension.
 
         :rtype: dict
+
+        :raises MissingRecordException: if a service with the given name and
+            namespace couldn't be found.
+        :raise MultipleRecordsException: if more than one service with the
+            given name and namespace are found.
         """
         ext = self.get_extension(name, namespace)
         filters = self.get_api_filters(ext['id'])
@@ -103,7 +156,7 @@ class APIExtension(object):
         return ext
 
     def add_extension(self, name, namespace, routing_key, exchange, patterns):
-        """Add an API extension.
+        """Add an API extension service.
 
         :param str name: name of the new API extension service.
         :param str namespace: namespace of the new API extension service.
@@ -143,21 +196,25 @@ class APIExtension(object):
             `name` parameter.
         :param bool enabled: flag to enable or disable the extension.
 
-        :return: object containing EntityType.ADMIN_SERVICE XML data
-            representing the updated API extension.
+        :return: href of the service being enabled/disabled.
 
-        :rtype: lxml.objectify.ObjectifiedElement
+        :rtype: str
+
+        :raises MissingRecordException: if a service with the given name and
+            namespace couldn't be found.
+        :raise MultipleRecordsException: if more than one service with the
+            given name and namespace are found.
         """
-        record = self.client.get_typed_query(
-            ResourceType.ADMIN_SERVICE.value,
-            qfilter='name==%s;namespace==%s' % (name, namespace
-                                                if namespace else name),
-            query_result_format=QueryResultFormat.RECORDS).find_unique()
+        record = self._get_extension_record(name=name,
+                                            namespace=namespace,
+                                            format=QueryResultFormat.RECORDS)
+
         params = E_VMEXT.Service({'name': name})
         params.append(E_VMEXT.Namespace(record.get('namespace')))
         params.append(E_VMEXT.Enabled('true' if enabled else 'false'))
         params.append(E_VMEXT.RoutingKey(record.get('routingKey')))
         params.append(E_VMEXT.Exchange(record.get('exchange')))
+
         self.client.put_resource(record.get('href'), params, None)
         return record.get('href')
 
@@ -169,6 +226,11 @@ class APIExtension(object):
         :param str namespace: the namespace of the extension service. If not
             specified (i.e. = None), we will use the value passed in the
             `name` parameter.
+
+        :raises MissingRecordException: if a service with the given name and
+            namespace couldn't be found.
+        :raise MultipleRecordsException: if more than one service with the
+            given name and namespace are found.
         """
         href = self.enable_extension(name, enabled=False, namespace=namespace)
         return self.client.delete_resource(href)

--- a/system_tests/api_extension_tests.py
+++ b/system_tests/api_extension_tests.py
@@ -1,0 +1,236 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from uuid import uuid1
+
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.environment import developerModeAware
+from pyvcloud.system_test_framework.environment import Environment
+
+from pyvcloud.vcd.api_extension import APIExtension
+from pyvcloud.vcd.exceptions import MissingRecordException
+from pyvcloud.vcd.exceptions import MultipleRecordsException
+
+
+class TestApiExtension(BaseTestCase):
+    """Test vCD api extension feature implemented in pyvcloud."""
+
+    # All tests in this module should be run as System Administrator
+    _client = None
+    _service1_href = None
+    _service2_href = None
+
+    _service_name = 'service' + str(uuid1())
+    _service1_namespace = 'namespace1_' + str(uuid1())
+    _service2_namespace = 'namespace2_' + str(uuid1())
+    _service_routing_key = 'key_' + str(uuid1())
+    _service_exchange = 'exchange_' + str(uuid1())
+    _service_patterns = ['/api/bogus1', '/api/bogus2', '/api/bogus3']
+
+    _non_existent_service_name = '_non_existent_service_' +\
+        str(uuid1())
+    _non_existent_service_namespace = \
+        '_non_existent_service_namespace_' + str(uuid1())
+
+    def test_0000_setup(self):
+        """Setup an api extension service required by the other tests.
+
+        Register two services as per the configuration stated above. Tests
+        APIExtension.add_extension() method.
+
+        This test passes if service hrefs are not None.
+        """
+        logger = Environment.get_default_logger()
+        TestApiExtension._client = Environment.get_sys_admin_client()
+        api_extension = APIExtension(TestApiExtension._client)
+
+        # Create two services with same name but diffent namespaces
+        logger.debug('Registering service (name:' +
+                     TestApiExtension._service_name + ', namespace:' +
+                     TestApiExtension._service1_namespace + ').')
+        registered_extension = api_extension.add_extension(
+            name=TestApiExtension._service_name,
+            namespace=TestApiExtension._service1_namespace,
+            routing_key=TestApiExtension._service_routing_key,
+            exchange=TestApiExtension._service_exchange,
+            patterns=TestApiExtension._service_patterns)
+
+        TestApiExtension._service1_href = registered_extension.get('href')
+        self.assertIsNotNone(TestApiExtension._service1_href)
+
+        logger.debug('Registering service (name:' +
+                     TestApiExtension._service_name + ', namespace:' +
+                     TestApiExtension._service2_namespace + ').')
+        registered_extension = api_extension.add_extension(
+            name=TestApiExtension._service_name,
+            namespace=TestApiExtension._service2_namespace,
+            routing_key=TestApiExtension._service_routing_key,
+            exchange=TestApiExtension._service_exchange,
+            patterns=TestApiExtension._service_patterns)
+
+        TestApiExtension._service2_href = registered_extension.get('href')
+        self.assertIsNotNone(TestApiExtension._service2_href)
+
+    def _check_service_details(self, service, expected_namespace):
+        self.assertIsNotNone(service)
+        self.assertEqual(service['name'], TestApiExtension._service_name)
+        self.assertEqual(service['namespace'], expected_namespace)
+        self.assertEqual(service['routingKey'],
+                         TestApiExtension._service_routing_key)
+        self.assertEqual(service['exchange'],
+                         TestApiExtension._service_exchange)
+
+        expected_filter_patterns = TestApiExtension._service_patterns
+        for i in range(1, len(expected_filter_patterns) + 1):
+            self.assertIn(service['filter_' + str(i)],
+                          expected_filter_patterns)
+
+    def test_0010_list_service(self):
+        """Test the  method APIExtension.list_extensions().
+
+        This test passes if the a list of dictionary of size >= 2 is returned
+        by the method. And the dictionary contains information about the
+        service registered during setup.
+        """
+        api_extension = APIExtension(TestApiExtension._client)
+        service_list = api_extension.list_extensions()
+        self.assertTrue(len(service_list) >= 2)
+
+    def test_0020_get_service_info(self):
+        """Test the  method APIExtension.get_extension_info().
+
+        Invoke the method with the name and namespace of the first service
+        created in setup. A call to APIExtension.get_extension_info() also
+        tests APIExtension.get_extension() and APIExtension.get_api_filters().
+
+        This test passes if the service detail retrieved by the method is
+        not None, and the details are correct.
+        """
+        api_extension = APIExtension(TestApiExtension._client)
+        service = api_extension.get_extension_info(
+            name=TestApiExtension._service_name,
+            namespace=TestApiExtension._service1_namespace)
+        self._check_service_details(service,
+                                    TestApiExtension._service1_namespace)
+
+    def test_0030_get_service_info_with_invalid_name(self):
+        """Test the  method APIExtension.get_extension_info().
+
+        Invoke the method with an invalid service name.
+
+        This test passes if the an MissingRecordException is raised by the
+        method.
+        """
+        api_extension = APIExtension(TestApiExtension._client)
+        try:
+            api_extension.get_extension_info(
+                name=TestApiExtension._non_existent_service_name)
+            self.fail('Should not be able to fetch service ' +
+                      TestApiExtension._non_existent_service_name)
+        except MissingRecordException as e:
+            pass
+
+    def test_0040_get_service_info_with_no_namespace(self):
+        """Test the  method APIExtension.get_extension_info().
+
+        Invoke the method with the name of the first service created in setup,
+        but don't send the namespace.
+
+        This test passes if the an MultipleRecordsException is raised by the
+        method.
+        """
+        api_extension = APIExtension(TestApiExtension._client)
+        try:
+            api_extension.get_extension_info(
+                name=TestApiExtension._service_name)
+            self.fail('Should not be able to fetch service ' +
+                      TestApiExtension._service_name +
+                      ' with an empty namespace.')
+        except MultipleRecordsException as e:
+            pass
+
+    def test_0050_get_service_info_with_invalid_namespace(self):
+        """Test the  method APIExtension.get_extension_info().
+
+        Invoke the method with the name of the service created in setup, but an
+        invalid namespace.
+
+        This test passes if the an empty dictionary is returned by the method.
+        """
+        api_extension = APIExtension(TestApiExtension._client)
+        try:
+            api_extension.get_extension_info(
+                name=TestApiExtension._service_name,
+                namespace=TestApiExtension._non_existent_service_namespace)
+            self.fail('Should not be able to fetch service ' +
+                      TestApiExtension._non_existent_service_name)
+        except MissingRecordException as e:
+            pass
+
+    def test_0060_enable_disable_service(self):
+        """Test the  method APIExtension.enable_extension().
+
+        This test passes if the href returned after each execution of the
+        method matches the service href.
+        """
+        logger = Environment.get_default_logger()
+        api_extension = APIExtension(TestApiExtension._client)
+
+        logger.debug('Disabling service (name:' +
+                     TestApiExtension._service_name + ', namespace:' +
+                     TestApiExtension._service1_namespace + ').')
+        href = api_extension.enable_extension(
+            name=TestApiExtension._service_name,
+            namespace=TestApiExtension._service1_namespace,
+            enabled=False)
+        self.assertEqual(href, TestApiExtension._service1_href)
+
+        logger.debug('Re-enabling service (name:' +
+                     TestApiExtension._service_name + ', namespace:' +
+                     TestApiExtension._service1_namespace + ').')
+        href = api_extension.enable_extension(
+            name=TestApiExtension._service_name,
+            namespace=TestApiExtension._service1_namespace,
+            enabled=True)
+        self.assertEqual(href, TestApiExtension._service1_href)
+
+    @developerModeAware
+    def test_9998_teardown(self):
+        """Test the method APIExtension.delete_extension().
+
+        Invoke the method for the service created during setup.
+
+        This test passes if no errors are generated while deleting the service.
+        """
+        logger = Environment.get_default_logger()
+        api_extension = APIExtension(TestApiExtension._client)
+
+        logger.debug('Deleting service (name:' +
+                     TestApiExtension._service_name + ', namespace:' +
+                     TestApiExtension._service1_namespace + ').')
+        api_extension.delete_extension(
+            name=TestApiExtension._service_name,
+            namespace=TestApiExtension._service1_namespace)
+
+        logger.debug('Deleting service (name:' +
+                     TestApiExtension._service_name + ', namespace:' +
+                     TestApiExtension._service1_namespace + ').')
+        api_extension.delete_extension(
+            name=TestApiExtension._service_name,
+            namespace=TestApiExtension._service2_namespace)
+
+    def test_9999_cleanup(self):
+        """Release all resources held by this object for testing purposes."""
+        TestApiExtension._client.logout()


### PR DESCRIPTION
During refactoring of api_extension.py a regression was introduced as a result of which
vcd system extension [info/enable/delete] commands are failing.

* This change list fixes the bug by sending the correct string for the underlying typed query that fetches all the api extension services.

*Additionally, the code in api_extension.py has been refactored/enhanced to deal with missing namespaces, multiple services with same name etc.

* Added system test for api_extension methods.

Testing : Ran the system tests and they were successful.