### PR TITLE
Fixed server API version bug and added stable system tests

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -625,9 +625,13 @@ class Client(object):
         versions = self.get_supported_versions()
         active_versions = []
         for version in versions.VersionInfo:
+            # Versions must be explicitly assigned as text values using the
+            # .text property. Otherwise lxml will return "corrected" numbers
+            # that drop non-sigificant digits. For example, 5.10 becomes
+            # 5.1.  This transformation corrupts the version.
             if not hasattr(version, 'deprecated') or \
                version.get('deprecated') == 'false':
-                active_versions.append(str(version.Version))
+                active_versions.append(str(version.Version.text))
         active_versions.sort(key=StrictVersion)
         return active_versions
 

--- a/system_tests/client_tests.py
+++ b/system_tests/client_tests.py
@@ -86,9 +86,9 @@ class TestClient(BaseTestCase):
 
         # Now prove we can login to any of them.
         for version in server_versions:
-            self._client = self._create_client_with_credentials(version)
             self._logger.debug(
-                "Logged in with server API version: {0}".format(version))
+                "Login using server API version {0}".format(version))
+            self._client = self._create_client_with_credentials(version)
             self._client.logout()
 
     def test_0030_server_highest_version(self):

--- a/system_tests/run_system_tests.sh
+++ b/system_tests/run_system_tests.sh
@@ -30,10 +30,14 @@ cd $SRCROOT
 
 # If there are tests to run use those. Otherwise use stable tests. 
 STABLE_TESTS="client_tests.py \
+api_extension_tests.py \
+catalog_tests \
 idisk_tests.py \
+network_tests.py \
+org_tests.py \
 search_tests.py \
 vapp_tests.py \
-catalog_tests"
+vm_tests.py"
 
 if [ $# == 0 ]; then
   echo "No tests provided, will run stable list: ${STABLE_TESTS}"


### PR DESCRIPTION
Fixed a bug affecting connections to vCD 9.1 and below in which lmxl was
silently converting version 5.10 to 5.1 thereby causing the client to return
an incorrect list of supported versions. Added 5 new tests to the stable
list in run_system_tests.sh.

Reviewers: @rocknes 
