### PR TITLE
Temporary workaround in orgVDC system test to avoid bug 2191368

### DIFF
--- a/system_tests/run_system_tests.sh
+++ b/system_tests/run_system_tests.sh
@@ -37,6 +37,7 @@ network_tests.py \
 org_tests.py \
 search_tests.py \
 vapp_tests.py \
+vdc_tests.py \
 vm_tests.py"
 
 if [ $# == 0 ]; then

--- a/system_tests/vdc_tests.py
+++ b/system_tests/vdc_tests.py
@@ -220,6 +220,15 @@ class TestOrgVDC(BaseTestCase):
         control_access = vdc.unshare_from_org_members()
         self.assertEqual(control_access.IsSharedToEveryone.text, 'false')
 
+        # re-share, before perofrming any other ACL operation to avoid
+        # https://bugzilla.eng.vmware.com/show_bug.cgi?id=2191368
+        logger.debug('Re-sharing vdc ' + vdc_name + ' with everyone in the ' +
+                     'org')
+        vdc.reload()
+        control_access = vdc.share_with_org_members()
+        self.assertEqual(control_access.IsSharedToEveryone.text, 'true')
+        self.assertEqual(control_access.EveryoneAccessLevel.text, 'ReadOnly')
+
         # remove the last access setting
         logger.debug('Removing the last remaining access control from'
                      ' vdc ' + vdc_name)


### PR DESCRIPTION
* Added extra code in vdc_tests.py to avoid triggering bug 2191368 in vCD
* Added vdc_tests.py to the list of stable test


n.b. bug 2191368 - HTTP 500/NPE generated by vCD when a user tries to remove ACL rules from an unshared orgVDC.