### PR TITLE
[VCDA-736] Remove creation of default vapp and vm from base test.

### DIFF
--- a/pyvcloud/system_test_framework/base_test.py
+++ b/pyvcloud/system_test_framework/base_test.py
@@ -41,7 +41,6 @@ class BaseTestCase(unittest.TestCase):
         Environment.create_catalog()
         Environment.share_catalog()
         Environment.upload_template()
-        Environment.instantiate_vapp()
 
     @classmethod
     def tearDownClass(cls):

--- a/pyvcloud/system_test_framework/utils.py
+++ b/pyvcloud/system_test_framework/utils.py
@@ -110,3 +110,24 @@ def create_customized_vapp_from_template(client, vdc, name, catalog_name,
         vapp_sparse_resouce.Tasks.Task[0])
 
     return vapp_sparse_resouce.get('href')
+
+def create_independent_disk(client, vdc, name, size, description):
+    """Helper method to create an independent disk in a given orgVDC.
+
+    :param pyvcloud.vcd.client.Client client: a client that would be used
+        to make ReST calls to vCD.
+    :param pyvcloud.vcd.vdc.VDC vdc: the vdc in which the disk will be
+        created.
+    :param str name: name of the disk to be created.
+    :param str size: size of the disk to be created in bytes.
+    :param str description: description of the disk to be created.
+
+    :return: id of the created independent disk.
+
+    :rtype: str
+    """
+    disk_sparse = vdc.create_disk(name=name, size=size,
+                                  description=description)
+    client.get_task_monitor().wait_for_success(disk_sparse.Tasks.Task[0])
+    # clip 'urn:vcloud:disk:' from the id returned by vCD.
+    return disk_sparse.get('id')[16:]

--- a/system_tests/idisk_tests.py
+++ b/system_tests/idisk_tests.py
@@ -217,7 +217,7 @@ class TestDisk(BaseTestCase):
         """Test the  method vapp.attach_disk_to_vm().
 
         Invoke the method for the second independent disk, and attach it to the
-        firt vm in the vApp created during setup. The vApp must be in deployed
+        first vm in the vApp created during setup. The vApp must be in deployed
         state before we try to attach the disk to it.
 
         This test passes if the disk attachment task succeeds.

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -36,7 +36,7 @@ class TestVM(BaseTestCase):
     _test_runner_role = CommonRoles.VAPP_AUTHOR
     _client = None
 
-    _test_vapp_name = 'tets_vApp_' + str(uuid1())
+    _test_vapp_name = 'test_vApp_' + str(uuid1())
     _test_vapp_first_vm_num_cpu = 2
     _test_vapp_first_vm_new_num_cpu = 4
     _test_vapp_first_vm_memory_size = 64  # MB


### PR DESCRIPTION
* Removed default vApp and vm creation steps from base test
* Made changes in idisk_tests.py to adjust to the removal of default vApp and vm in the test vdc.

Ran independent disk test suite to make sure no regression crept in , all tests ran successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/281)
<!-- Reviewable:end -->
