### PR TITLE
[VCDA-549] Fix query service in pyvcloud to accomodate filtering names with commas

### DIFF
--- a/pyvcloud/vcd/api_extension.py
+++ b/pyvcloud/vcd/api_extension.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import urllib
+
 from pyvcloud.vcd.client import E_VMEXT
 from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import QueryResultFormat
@@ -74,9 +76,9 @@ class APIExtension(object):
         :raise MultipleRecordsException: if more than one service with the
             given name and namespace are found.
         """
-        qfilter = 'name==%s' % name
+        qfilter = 'name==%s' % urllib.parse.quote_plus(name)
         if namespace is not None:
-            qfilter += ';namespace==%s' % namespace
+            qfilter += ';namespace==%s' % urllib.parse.quote_plus(namespace)
         try:
             ext = self.client.get_typed_query(
                 ResourceType.ADMIN_SERVICE.value,

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -1363,7 +1363,7 @@ class _AbstractQuery(object):
                 self._filter = ''
             self._filter += equality_filter[0]
             self._filter += '=='
-            self._filter += urllib.parse.quote_plus(equality_filter[1])
+            self._filter += urllib.parse.quote(equality_filter[1])
 
         self._sort_desc = sort_desc
         self._sort_asc = sort_asc

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -1199,16 +1199,25 @@ class Client(object):
                         sort_asc=None,
                         sort_desc=None,
                         fields=None):
-        """Issue a query using vCD query API.
+        """Issue a typed query using vCD query API.
 
         :param str query_type_name: name of the entity, which should be a
-            string listed in ResourceType enum.
+            string listed in ResourceType enum values.
         :param QueryResultFormat query_result_format: format of query result.
         :param int page_size: number of entries per page.
         :param include_links: (not used).
-        :param str qfilter: query filter expression, e.g., 'numberOfCpus=gt=4'.
-        :param str equality_filter: a field name and a value to filter
-            output; appends to qfilter if present.
+        :param str qfilter: filter expression for the query. Is normally made
+            up of sub expressions, where each sub-expression is of the form
+            <filter name><operator><value>. Few of the allowed operators are
+            == for equality, =lt= for less than, =gt= for greater than etc.
+            Multiple sub expression can be joined using logical AND i.e. ;
+            logical OR i.e. , etc. Each value in query string must be
+            url-encoded. E.g. 'numberOfCpus=gt=4' , 'name==abc%20def'.
+        :param tuple equality_filter: a special filter that will be logically
+            AND-ed to qfilter, with the operator being ==. The first element in
+            the tuple is treated as filter name, while the second element is
+            treated as value. There is no need to url-encode the value in this
+            case.
         :param str sort_asc: if 'name' field is present in the result sort
             ascending by that field.
         :param str sort_desc: if 'name' field is present in the result sort
@@ -1341,7 +1350,7 @@ class _AbstractQuery(object):
             AND-ed to query filter. The first element in the tuple is treated
             as key, while the second element is treated as value. There is no
             need to url-encode the value, this function will do that the final
-            query url is constructed
+            query url is constructed.
         :param str sort_asc: sort results by attribute-name in ascending order.
             attribute-name cannot include metadata.
         :param str sort_desc: sort results by attribute-name in descending
@@ -1447,7 +1456,7 @@ class _AbstractQuery(object):
             # values, i.e. the value after each ==.
             uri += '&filterEncoded=true&filter='
             # Need to encode the value of filter param again to escape special
-            # characters like ',', ';' which has special meaning in context of
+            # characters like ',', ';' which have special meaning in context of
             # query filter.
             uri += urllib.parse.quote(qfilter)
 

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -901,13 +901,10 @@ class Client(object):
             self._logger.debug('Request headers: %s, %s' % (session.headers,
                                                             headers))
         if self._log_bodies and data is not None:
-            if sys.version_info[0] < 3:
+            if isinstance(data, str):
                 d = data
             else:
-                if isinstance(data, str):
-                    d = data
-                else:
-                    d = data.decode(self.fsencoding)
+                d = data.decode(self.fsencoding)
             self._logger.debug('Request body: %s' % d)
         if self._log_requests or self._log_headers or self._log_bodies:
             self._logger.debug(
@@ -915,13 +912,10 @@ class Client(object):
         if self._log_headers:
             self._logger.debug('Response headers: %s' % response.headers)
         if self._log_bodies and _response_has_content(response):
-            if sys.version_info[0] < 3:
+            if isinstance(response.content, str):
                 d = response.content
             else:
-                if isinstance(response.content, str):
-                    d = response.content
-                else:
-                    d = response.content.decode(self.fsencoding)
+                d = response.content.decode(self.fsencoding)
             self._logger.debug('Response body: %s' % d)
         return response
 
@@ -1170,11 +1164,11 @@ class Client(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        resource_type = 'user'
+        resource_type = ResourceType.USER.value
         org_filter = None
         if self.is_sysadmin():
-            resource_type = 'adminUser'
-            org_filter = 'org==%s' % org_href
+            resource_type = ResourceType.ADMIN_USER.value
+            org_filter = 'org==%s' % urllib.parse.quote_plus(org_href)
         query = self.get_typed_query(
             resource_type,
             query_result_format=QueryResultFormat.REFERENCES,
@@ -1209,8 +1203,7 @@ class Client(object):
 
         :param str query_type_name: name of the entity, which should be a
             string listed in ResourceType enum.
-        :param tuple query_result_format: tuple value from QueryResultFormat
-            enum.
+        :param QueryResultFormat query_result_format: format of query result.
         :param int page_size: number of entries per page.
         :param include_links: (not used).
         :param str qfilter: query filter expression, e.g., 'numberOfCpus=gt=4'.
@@ -1334,6 +1327,28 @@ class _AbstractQuery(object):
                  sort_asc=None,
                  sort_desc=None,
                  fields=None):
+        """Constructor for _AbstractQuery object.
+
+        :param QueryResultFormat query_result_format: format of query result.
+        :param pyvcloud.vcd.client.Client client: the client that will be used
+            to make REST calls to vCD.
+        :param int page_size:
+        :param bool include_links: if True, query result will include links in
+            the body.
+        :param str qfilter: filter expression for the query. The values in the
+            query string must be url-encoded.
+        :param tuple equality_filter: a special filter that will be logically
+            AND-ed to query filter. The first element in the tuple is treated
+            as key, while the second element is treated as value. There is no
+            need to url-encode the value, this function will do that the final
+            query url is constructed
+        :param str sort_asc: sort results by attribute-name in ascending order.
+            attribute-name cannot include metadata.
+        :param str sort_desc: sort results by attribute-name in descending
+            order. attribute-name cannot include metadata.
+        :param str fields: comma-separated list of attribute names or metadata
+            key names to return
+        """
         self._client = client
         self._query_result_format = query_result_format
         self._page_size = page_size
@@ -1348,10 +1363,7 @@ class _AbstractQuery(object):
                 self._filter = ''
             self._filter += equality_filter[0]
             self._filter += '=='
-            if sys.version_info[0] < 3:
-                self._filter += urllib.quote(equality_filter[1])
-            else:
-                self._filter += urllib.parse.quote(equality_filter[1])
+            self._filter += urllib.parse.quote_plus(equality_filter[1])
 
         self._sort_desc = sort_desc
         self._sort_asc = sort_asc
@@ -1402,19 +1414,13 @@ class _AbstractQuery(object):
 
         # Make sure we got at least one result record
         try:
-            if sys.version_info[0] < 3:
-                item = query_results.next()
-            else:
-                item = next(query_results)
+            item = next(query_results)
         except StopIteration:
             raise MissingRecordException()
 
         # Make sure we didn't get more than one result record
         try:
-            if sys.version_info[0] < 3:
-                query_results.next()
-            else:
-                next(query_results)
+            next(query_results)
             raise MultipleRecordsException()
         except StopIteration:
             pass
@@ -1437,10 +1443,13 @@ class _AbstractQuery(object):
             uri += str(page_size)
 
         if qfilter is not None:
-            # filterEncoded=true allows VCD to properly
-            # parse encoded '==' in the filter parameter.
+            # filterEncoded=true directs vCD to decode the individual filter
+            # values, i.e. the value after each ==.
             uri += '&filterEncoded=true&filter='
-            uri += qfilter
+            # Need to encode the value of filter param again to escape special
+            # characters like ',', ';' which has special meaning in context of
+            # query filter.
+            uri += urllib.parse.quote(qfilter)
 
         if fields is not None:
             uri += '&fields='

--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -20,6 +20,7 @@ import tarfile
 import tempfile
 import time
 import traceback
+import urllib
 
 from lxml import etree
 from lxml import objectify
@@ -970,11 +971,12 @@ class Org(object):
         """
         if self.resource is None:
             self.reload()
-        resource_type = 'user'
+        resource_type = ResourceType.USER.value
         org_filter = None
         if self.client.is_sysadmin():
-            resource_type = 'adminUser'
-            org_filter = 'org==%s' % self.resource.get('href')
+            resource_type = ResourceType.ADMIN_USER.value
+            org_filter = 'org==%s' % \
+                urllib.parse.quote_plus(self.resource.get('href'))
         query = self.client.get_typed_query(
             resource_type,
             query_result_format=QueryResultFormat.RECORDS,
@@ -1078,11 +1080,12 @@ class Org(object):
             self.reload()
 
         org_filter = None
-        resource_type = 'role'
+        resource_type = ResourceType.ROLE.value
 
         if self.client.is_sysadmin():
-            resource_type = 'adminRole'
-            org_filter = 'org==%s' % self.resource.get('href')
+            resource_type = ResourceType.ADMIN_ROLE.value
+            org_filter = 'org==%s' % \
+                urllib.parse.quote_plus(self.resource.get('href'))
 
         query = self.client.get_typed_query(
             resource_type,
@@ -1191,7 +1194,7 @@ class Org(object):
         if self.resource is None:
             self.reload()
 
-        resource_type = 'right'
+        resource_type = ResourceType.RIGHT.value
         query = self.client.get_typed_query(
             resource_type,
             query_result_format=QueryResultFormat.RECORDS,

--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from urllib import parse
 import uuid
 
 from pyvcloud.vcd.client import E
@@ -136,11 +135,11 @@ class Platform(object):
         :raises: EntityNotFoundException: If the named vxlan_network_pool
             cannot be found.
         """
-        query_filter = 'name==%s' % parse.quote_plus(vxlan_network_pool_name)
+        name_filter = ('name', vxlan_network_pool_name)
         query = self.client.get_typed_query(
             ResourceType.NETWORK_POOL,
             query_result_format=QueryResultFormat.RECORDS,
-            qfilter=query_filter)
+            equality_filter=name_filter)
         records = list(query.execute())
         vxlan_network_pool_record = None
         for record in records:
@@ -168,11 +167,11 @@ class Platform(object):
         :raises: EntityNotFoundException: if the named resource cannot be
             found.
         """
-        query_filter = 'name==%s' % parse.quote_plus(resource_name)
+        name_filter = ('name', resource_name)
         record = self.client.get_typed_query(
             resource_type.value,
             query_result_format=QueryResultFormat.REFERENCES,
-            qfilter=query_filter).find_unique()
+            equality_filter=name_filter).find_unique()
         if resource_name == record.get('name'):
             return record
         else:
@@ -393,10 +392,11 @@ class Platform(object):
         vc_name = pvdc_ext_resource.VimServer.get('name')
 
         # find the RPs in use that are associated with the backing VC
+        name_filter = ('vcName', vc_name)
         query = self.client.get_typed_query(
             ResourceType.RESOURCE_POOL.value,
             query_result_format=QueryResultFormat.RECORDS,
-            qfilter='vcName==%s' % vc_name)
+            equality_filter=name_filter)
         res_pools_in_use = {}
         for res_pool in list(query.execute()):
             res_pools_in_use[res_pool.get('name')] = res_pool.get('moref')

--- a/pyvcloud/vcd/system.py
+++ b/pyvcloud/vcd/system.py
@@ -122,14 +122,15 @@ class System(object):
 
         :rtype: list
         """
+        name_filter = None
         if name is not None:
-            query_filter = 'name==%s' % name
-        else:
-            query_filter = None
+            name_filter = ('name', name)
+
         q = self.client.get_typed_query(
             'providerVdcStorageProfile',
             query_result_format=QueryResultFormat.RECORDS,
-            qfilter=query_filter)
+            equality_filter=name_filter)
+
         return list(q.execute())
 
     def get_provider_vdc_storage_profile(self, name):

--- a/pyvcloud/vcd/task.py
+++ b/pyvcloud/vcd/task.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import urllib
+
 from pyvcloud.vcd.client import E
 from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import find_link
@@ -120,7 +122,7 @@ class Task(object):
         """
         query_filter = ''
         for f in filter_status_list:
-            query_filter += 'status==%s,' % f
+            query_filter += 'status==%s,' % urllib.parse.quote_plus(f)
         if len(query_filter) > 0:
             query_filter = query_filter[:-1]
         sort_asc = None

--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -542,8 +542,8 @@ def to_dict(obj, attributes=None, resource_type=None, exclude=['href',
     :param lxml.objectify.ObjectifiedElement obj:
     :param list attributes: list of attributes we want to extract from the XML
         object.
-    :param resource_type: type of resource in the param obj. Acceptable values
-        are listed in the enum pyvcloud.vcd.client.ResourceType.
+    :param str resource_type: type of resource in the param obj. Acceptable
+        values are listed in the enum pyvcloud.vcd.client.ResourceType.
     :param list exclude: list of attributes that should be excluded from the
         dictionary.
 

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -1083,12 +1083,12 @@ class VDC(object):
         :rtype: generator object
         """
         resource_type = ResourceType.ORG_VDC_NETWORK.value
-        vdc_filter = 'vdc==%s' % self.href
+        vdc_filter = ('vdc', self.href)
 
         query = self.client.get_typed_query(
             resource_type,
             query_result_format=QueryResultFormat.RECORDS,
-            qfilter=vdc_filter)
+            equality_filter=vdc_filter)
         records = query.execute()
 
         return records


### PR DESCRIPTION
The core issue in this case was that the filter value in the query uri wasn't being uri encoded properly.
We were encoding the individual filter sub expression values, but leaving out encoding the whole filter params value.

Have made changes in the code, to make sure that,
1. all values in the qfilter param are properly uri encoded.
2. the value in equality_filter tuple is properly uri encoded.
3. the final filter param value is properly encoded.

Also did some cleanup of the code
* Replaced hard coded resource type  strings with their ResourceType enum counterparts.
* Removed dead code related to python 2.

Ran the following tests,
api_extension_tests, catalog_tests, cleanup_test, client_tests, idisk_tests, network_tests, org_tests, vapp_tests, vc_tests, vdc_tests
All test passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/282)
<!-- Reviewable:end -->
