### PR TITLE
[VCDA-750] Restore access to org vdc network related workflows for non admin users while using api version <= 29.0

### DIFF
--- a/pyvcloud/system_test_framework/environment.py
+++ b/pyvcloud/system_test_framework/environment.py
@@ -17,7 +17,6 @@ import logging
 import warnings
 
 from flufl.enum import Enum
-from pyvcloud.system_test_framework.utils import create_vapp_from_template
 import requests
 
 from pyvcloud.vcd.client import BasicLoginCredentials
@@ -445,18 +444,18 @@ class Environment(object):
                             ' doesn\'t exist.')
 
         vdc = VDC(cls._sys_admin_client, href=cls._ovdc_href)
-        net_name = cls._config['vcd']['default_ovdc_network_name']
-        records = vdc.list_orgvdc_network_records()
+        expected_net_name = cls._config['vcd']['default_ovdc_network_name']
+        records_dict = vdc.list_orgvdc_network_records()
 
-        for record in records:
-            if record.get('name').lower() == net_name.lower():
+        for net_name in records_dict.keys():
+            if net_name.lower() == expected_net_name.lower():
                 cls._logger.debug(
-                    'Reusing existing org-vdc network ' + net_name)
+                    'Reusing existing org-vdc network ' + expected_net_name)
                 return
 
-        cls._logger.debug('Creating org-vdc network ' + net_name)
+        cls._logger.debug('Creating org-vdc network ' + expected_net_name)
         result = vdc.create_isolated_vdc_network(
-            network_name=net_name,
+            network_name=expected_net_name,
             gateway_ip=cls._config['vcd']['default_ovdc_network_gateway_ip'],
             netmask=cls._config['vcd']['default_ovdc_network_gateway_netmask'])
 

--- a/pyvcloud/system_test_framework/utils.py
+++ b/pyvcloud/system_test_framework/utils.py
@@ -37,6 +37,7 @@ def create_empty_vapp(client, vdc, name, description):
 
     return vapp_sparse_resouce.get('href')
 
+
 def create_vapp_from_template(client, vdc, name, catalog_name, template_name):
     """Helper method to create a vApp from template.
 
@@ -62,6 +63,7 @@ def create_vapp_from_template(client, vdc, name, catalog_name, template_name):
         vapp_sparse_resouce.Tasks.Task[0])
 
     return vapp_sparse_resouce.get('href')
+
 
 def create_customized_vapp_from_template(client, vdc, name, catalog_name,
                                          template_name, description=None,
@@ -110,6 +112,7 @@ def create_customized_vapp_from_template(client, vdc, name, catalog_name,
         vapp_sparse_resouce.Tasks.Task[0])
 
     return vapp_sparse_resouce.get('href')
+
 
 def create_independent_disk(client, vdc, name, size, description):
     """Helper method to create an independent disk in a given orgVDC.

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -1388,6 +1388,8 @@ class _AbstractQuery(object):
         """
         query_href = self._find_query_uri(self._query_result_format)
         if query_href is None:
+            self._client._logger.warn('Unable to locate query href for \'%s\''
+                                      ' query.' % self._query_result_format)
             return []
         query_uri = self._build_query_uri(
             query_href,

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -913,8 +913,8 @@ class VApp(object):
                   href=find_link(self.resource,
                                  RelationType.UP,
                                  EntityType.VDC.value).href)
-        orgvdc_network_href = vdc.get_orgvdc_network_record_by_name(
-            orgvdc_network_name).get('href')
+        orgvdc_network_href = vdc.get_orgvdc_network_admin_href_by_name(
+            orgvdc_network_name)
 
         network_configuration_section = \
             deepcopy(self.resource.NetworkConfigSection)

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -1080,8 +1080,8 @@ class VDC(object):
 
         :rtype: dict
         """
-        # TODO(): We should remove this hack and defualt to ORG_VDC_NETWORK
-        # once vCD 9.0 reches EOL. We are forced to use OrgNetwork typed
+        # TODO(): We should remove this hack and default to ORG_VDC_NETWORK
+        # once vCD 9.0 reaches EOL. We are forced to use OrgNetwork typed
         # query instead of OrgVdcNetwork typed query because for vCD api
         # v29.0 and lower the link for the former is missing from /api/query
         use_hack = False
@@ -1131,7 +1131,7 @@ class VDC(object):
         records_dict = self.list_orgvdc_network_records()
 
         # dictionary key presence checks are case sensitive so we need to
-        # iterante over the keys and manually check each one of them.
+        # iterate over the keys and manually check each one of them.
         for net_name in records_dict.keys():
             if orgvdc_network_name.lower() == net_name.lower():
                 return records_dict.get(net_name)

--- a/system_tests/network_tests.py
+++ b/system_tests/network_tests.py
@@ -150,33 +150,31 @@ class TestNetwork(BaseTestCase):
         except AccessForbiddenException as e:
             return
 
-    def test_0050_list_orgvdc_network_records_as_non_admin_user(self):
+    def test_0060_list_orgvdc_network_records_as_non_admin_user(self):
         """Test the method vdc.list_orgvdc_network_records().
 
         This test passes if the record of the network created during setup is
         present in the retrieved list of networks.
         """
         vdc = Environment.get_test_vdc(TestNetwork._vapp_author_client)
-        records = vdc.list_orgvdc_network_records()
-        for network_record in records:
-            if network_record.get('name') == \
-               TestNetwork._isolated_orgvdc_network_name:
+        records_dict = vdc.list_orgvdc_network_records()
+        for net_name in records_dict.keys():
+            if net_name == TestNetwork._isolated_orgvdc_network_name:
                 return
 
         self.fail('Retrieved list of orgvdc network records doesn\'t ' +
                   'contain ' + TestNetwork._isolated_orgvdc_network_name)
 
-    def test_0060_get_orgvdc_network_record_as_non_admin_user(self):
-        """Test the method vdc.get_orgvdc_network_record_by_name().
+    def test_0070_get_orgvdc_network_admin_href_as_non_admin_user(self):
+        """Test the method vdc.get_orgvdc_network_admin_href_by_name().
 
-        This test passes if the record of the network created during setup is
+        This test passes if the href of the network created during setup is
         retrieved successfully without any errors.
         """
         vdc = Environment.get_test_vdc(TestNetwork._vapp_author_client)
-        network_record = vdc.get_orgvdc_network_record_by_name(
+        href = vdc.get_orgvdc_network_admin_href_by_name(
             TestNetwork._isolated_orgvdc_network_name)
-        self.assertEqual(TestNetwork._isolated_orgvdc_network_name,
-                         network_record.get('name'))
+        self.assertIsNotNone(href)
 
     @developerModeAware
     def test_9998_teardown(self):

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -257,7 +257,7 @@ class TestVM(BaseTestCase):
         # TODO() : Use a vApp template in which vmware tools are installed
         # on the VM.
 
-        # The reboot operation will fail with the following message 
+        # The reboot operation will fail with the following message
         # -Failed to reboot guest os for the VM "testvm1-p2oH" as required VM
         # tools were found unavailable.
 
@@ -267,7 +267,7 @@ class TestVM(BaseTestCase):
         # result = TestVM._client.get_task_monitor().wait_for_success(task)
         # self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
-        # The shutdown operation will fail with the following message 
+        # The shutdown operation will fail with the following message
         # - Cannot complete operation because VMware Tools is not running in
         # this virtual machine.
 


### PR DESCRIPTION
For api version <=29.0, and non admin users, response to GET /api/query doesn't have the link to the typed query OrgVdcNetwork. This restricts those users from performing actions like attach an orgvdc network to a vApp. To solve this issue we will use the typed query OrgNetwork instead of OrgVdcNetwork, if the user in question is not an admin and the api version used is <=29.0.

Ran all system tests against
1. vCD 9.5 at api version 29.0 and api v31.0.
2. vCD 9.0 at api version 29.0.
Confirmed that all tests pass and the workflows in question have been unlocked for non admin users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/284)
<!-- Reviewable:end -->
