### PR TITLE
[VCDA-762] Invalid Query will raise OperationNotSupportedException instead of silently returning empty list as result.

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -220,7 +220,7 @@ class ResourceType(Enum):
     ORG_VDC_NETWORK = 'orgVdcNetwork'
     ORG_VDC_RESOURCE_POOL_RELATION = 'orgVdcResourcePoolRelation'
     ORG_VDC_STORAGE_PROFILE = 'orgVdcStorageProfile'
-    PORT_GROUP = 'portGroup'
+    PORT_GROUP = 'portgroup'
     PROVIDER_VDC = 'providerVdc'
     PROVIDER_VDC_RESOURCE_POOL_RELATION = 'providerVdcResourcePoolRelation'
     PROVIDER_VDC_STORAGE_PROFILE = 'providerVdcStorageProfile'
@@ -1388,9 +1388,7 @@ class _AbstractQuery(object):
         """
         query_href = self._find_query_uri(self._query_result_format)
         if query_href is None:
-            self._client._logger.warn('Unable to locate query href for \'%s\''
-                                      ' query.' % self._query_result_format)
-            return []
+            raise OperationNotSupportedException('Unable to execute query.')
         query_uri = self._build_query_uri(
             query_href,
             self._page,
@@ -1508,4 +1506,8 @@ class _TypedQuery(_AbstractQuery):
             _client. \
             _get_query_list_map().get(
                 (query_media_type, self._query_type_name))
+        if query_href is None:
+            self._client._logger.warning(
+                'Unable to locate query href for \'%s\' typed query.' %
+                self._query_type_name)
         return query_href

--- a/system_tests/search_tests.py
+++ b/system_tests/search_tests.py
@@ -75,7 +75,7 @@ class TestSearch(BaseTestCase):
     def test_0020_find_existing_entities_with_org_user(self):
         """Find entities with low-privilege org user."""
         self._client = Environment.get_client_in_default_org(
-            CommonRoles.CATALOG_AUTHOR)
+            CommonRoles.VAPP_USER)
         q1 = self._client.get_typed_query(
             ResourceType.CATALOG.value,
             query_result_format=QueryResultFormat.ID_RECORDS)
@@ -86,7 +86,7 @@ class TestSearch(BaseTestCase):
     def test_0030_find_non_existing(self):
         """Verify we return nothing if no entities exist."""
         self._client = Environment.get_client_in_default_org(
-            CommonRoles.CATALOG_AUTHOR)
+            CommonRoles.VAPP_USER)
         for format in self._result_formats:
             q1 = self._client.get_typed_query(
                 ResourceType.CATALOG.value,

--- a/system_tests/search_tests.py
+++ b/system_tests/search_tests.py
@@ -21,6 +21,7 @@ from pyvcloud.system_test_framework.environment import Environment
 
 from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.client import ResourceType
+from pyvcloud.vcd.exceptions import OperationNotSupportedException
 
 
 class TestSearch(BaseTestCase):
@@ -38,45 +39,38 @@ class TestSearch(BaseTestCase):
 
     def test_0010_find_existing_with_admin(self):
         """Find entities with admin account with optional filter parameters."""
-        # Get admin client.  This will not be logged out to avoid messing
-        # up Environment class.
-        admin_client = None
-        try:
-            admin_client = Environment.get_sys_admin_client()
-            resource_type_cc = 'organization'
-            # Fetch all orgs.
-            q1 = admin_client.get_typed_query(
-                resource_type_cc,
-                query_result_format=QueryResultFormat.ID_RECORDS,
-                qfilter=None)
-            q1_records = list(q1.execute())
-            self.assertTrue(
-                len(q1_records) > 0,
-                msg="Find at least one organization")
-            name0 = q1_records[0].get('name')
+        self._client = Environment.get_sys_admin_client()
+        resource_type_cc = 'organization'
+        # Fetch all orgs.
+        q1 = self._client.get_typed_query(
+            resource_type_cc,
+            query_result_format=QueryResultFormat.ID_RECORDS,
+            qfilter=None)
+        q1_records = list(q1.execute())
+        self.assertTrue(
+            len(q1_records) > 0,
+            msg="Find at least one organization")
+        name0 = q1_records[0].get('name')
 
-            # Find the org again using an equality filter.
-            eq_filter = ('name', name0)
-            q2 = admin_client.get_typed_query(
-                resource_type_cc,
-                query_result_format=QueryResultFormat.ID_RECORDS,
-                equality_filter=eq_filter)
-            q2_records = list(q2.execute())
-            self.assertEqual(
-                1, len(q2_records),
-                msg="Find org with equality filter")
+        # Find the org again using an equality filter.
+        eq_filter = ('name', name0)
+        q2 = self._client.get_typed_query(
+            resource_type_cc,
+            query_result_format=QueryResultFormat.ID_RECORDS,
+            equality_filter=eq_filter)
+        q2_records = list(q2.execute())
+        self.assertEqual(
+            1, len(q2_records),
+            msg="Find org with equality filter")
 
-            # Find the org again using a query filter string
-            q3 = admin_client.get_typed_query(
-                resource_type_cc,
-                query_result_format=QueryResultFormat.ID_RECORDS,
-                qfilter="name=={0}".format(name0))
-            q3_records = list(q3.execute())
-            self.assertEqual(1, len(q3_records),
-                             msg="Find org with query filter")
-        finally:
-            if admin_client is not None:
-                admin_client.logout()
+        # Find the org again using a query filter string
+        q3 = self._client.get_typed_query(
+            resource_type_cc,
+            query_result_format=QueryResultFormat.ID_RECORDS,
+            qfilter="name=={0}".format(name0))
+        q3_records = list(q3.execute())
+        self.assertEqual(1, len(q3_records),
+                         msg="Find org with query filter")
 
     def test_0020_find_existing_entities_with_org_user(self):
         """Find entities with low-privilege org user."""
@@ -92,38 +86,79 @@ class TestSearch(BaseTestCase):
     def test_0030_find_non_existing(self):
         """Verify we return nothing if no entities exist."""
         self._client = Environment.get_client_in_default_org(
-            CommonRoles.VAPP_USER)
+            CommonRoles.CATALOG_AUTHOR)
         for format in self._result_formats:
-            # Use the generator directly.
             q1 = self._client.get_typed_query(
-                ResourceType.ORGANIZATION.value,
-                query_result_format=QueryResultFormat.ID_RECORDS)
+                ResourceType.CATALOG.value,
+                query_result_format=QueryResultFormat.ID_RECORDS,
+                qfilter='name==invalid_catalog_name')
             count = 0
             for item in q1.execute():
                 count += 1
-            self.assertEqual(0, count, "Should not find orgs via generator")
+            self.assertEqual(0, count, "Should not find invalid catalog via "
+                             "generator.")
             # Try a list.
             q1_records = list(q1.execute())
-            self.assertEqual(
-                0, len(q1_records),
-                "Should not find any orgs via list")
+            self.assertEqual(0, len(q1_records),
+                             "Should not find invalid catalog via list.")
 
-    def test_0040_check_all_resource_types(self):
-        """Verify that we can search on any resource type without error."""
+    def test_0040_find_unsupported_type(self):
+        """Verify we raise appropriate exception if user can't see entities."""
         self._client = Environment.get_client_in_default_org(
-            CommonRoles.ORGANIZATION_ADMINISTRATOR)
+            CommonRoles.VAPP_USER)
+        for format in self._result_formats:
+            try:
+                q1 = self._client.get_typed_query(
+                    ResourceType.ORGANIZATION.value,
+                    query_result_format=QueryResultFormat.ID_RECORDS)
+                q1.execute()
+                self.fail('User (vApp user) should not be able to fetch any '
+                          'orgs.')
+            except OperationNotSupportedException as e:
+                pass
+
+    def test_0050_check_all_resource_types(self):
+        """Verify that we can search on any resource type without error."""
+        self._client = Environment.get_sys_admin_client()
         resource_types = [r.value for r in ResourceType]
-        # Some types of course won't exist but the search should not fail.
+
+        allowed_exceptions = [
+            # deprecated
+            ResourceType.ADMIN_ALLOCATED_EXTERNAL_ADDRESS.value,
+            # deprecated
+            ResourceType.ADMIN_ORG_NETWORK.value,
+            # deprecated
+            ResourceType.ALLOCATED_EXTERNAL_ADDRESS.value,
+            # only admin version visible to sys admin in /api/query
+            ResourceType.CATALOG_ITEM.value,
+            # only admin version visible to sys admin in /api/query
+            ResourceType.DISK.value,
+            # only admin version visible to sys admin in /api/query
+            ResourceType.GROUP.value,
+            # deprecated
+            ResourceType.ORG_NETWORK.value,
+            # only admin version visible to sys admin in /api/query
+            ResourceType.ORG_VDC_STORAGE_PROFILE.value,
+            # only admin version visible to sys admin in /api/query
+            ResourceType.USER.value,
+            # only admin version visible to sys admin in /api/query
+            ResourceType.VAPP_NETWORK.value,
+            # only admin version visible to sys admin in /api/query
+            ResourceType.VM_DISK_RELATION.value]
+
+        # All typed queries apart from the allowed_exceptions shouldn't fail.
         for resource_type in resource_types:
+            if resource_type in allowed_exceptions:
+                continue
             q1 = self._client.get_typed_query(
                 resource_type,
                 query_result_format=QueryResultFormat.ID_RECORDS)
             q1_records = list(q1.execute())
             self.assertTrue(
                 len(q1_records) >= 0,
-                "Should get a list, even if tempty")
+                "Should get a list, even if empty")
 
-    def test_0050_check_result_formats(self):
+    def test_0060_check_result_formats(self):
         """Verify we get expected results for all result formats."""
         self._client = Environment.get_client_in_default_org(
             CommonRoles.ORGANIZATION_ADMINISTRATOR)


### PR DESCRIPTION
Whenever a typed query with an invalid type value or a type value that is hidden from the current user is specified, pyvcloud is unable to construct the query url and chooses to silently return an empty list as result set. This change list changes the behavior to raise an OperationNotSupportedException, as well as log the issue in log file.
As a fallout search_tests needed to be modified to address this behavioral change.

Also fixed a small typo in one of the Type Query type values (these type values are case sensitive).

Testing done : Ran all system tests and verified that none of them are failing after this change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/288)
<!-- Reviewable:end -->
