### PR TITLE
[VCDA-749] Add support for api v31.0, remove support for api v27.0

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -97,7 +97,7 @@ E_RASD = objectify.ElementMaker(
 
 # Important! Values must be listed in ascending order.
 API_CURRENT_VERSIONS = [
-    '27.0', '28.0', '29.0', '30.0'
+    '28.0', '29.0', '30.0', '31.0'
 ]
 
 VCLOUD_STATUS_MAP = {


### PR DESCRIPTION
Added api v31.0 to list of officially supported versions.
Removed api v27.0 from list of officially supported versions.

Testing done : logged into a vCD 9.5 beta server, the REST calls were auto negotiated to api v31.0.