### PR TITLE
[VCDA-756] Update version of lxml to 4.2.1 to avoid failure during installation on Windows machines

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 flufl.enum >= 4.1.1
 humanfriendly >= 4.8
-lxml >= 3.4.1
-PyYAML >= 3.10, <= 3.13
+lxml >= 4.2.1
 pygments >= 2.2.0
+PyYAML >= 3.11, <= 3.13
 requests >= 2.18.4


### PR DESCRIPTION
Updated requirements.txt to bump up version of lxml module to 4.2.1.  The older version of lxml has dependency on Microsoft Visual C++ runtime which cause installation failure on Windows machines.

Tested on Windows, Linux, Mac and made sure that installation + commands work fine on these systems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/290)
<!-- Reviewable:end -->
