### PR TITLE
Fix search test for api version <= 29.0

### DIFF
--- a/system_tests/search_tests.py
+++ b/system_tests/search_tests.py
@@ -143,7 +143,7 @@ class TestSearch(BaseTestCase):
             allowed_exceptions.append(ResourceType.VAPP_TEMPLATE)
             allowed_exceptions.append(ResourceType.VM)
         else:
-            # feature deprecated in api v30.0
+            # features deprecated in api v30.0
             allowed_exceptions.append(
                 ResourceType.ADMIN_ORG_NETWORK)
             allowed_exceptions.append(

--- a/system_tests/search_tests.py
+++ b/system_tests/search_tests.py
@@ -120,43 +120,53 @@ class TestSearch(BaseTestCase):
     def test_0050_check_all_resource_types(self):
         """Verify that we can search on any resource type without error."""
         self._client = Environment.get_sys_admin_client()
-        resource_types = [r.value for r in ResourceType]
+        api_version = float(self._client.get_api_version())
 
+        # only admin version visible to sys admin in /api/query
         allowed_exceptions = [
-            # deprecated
-            ResourceType.ADMIN_ALLOCATED_EXTERNAL_ADDRESS.value,
-            # deprecated
-            ResourceType.ADMIN_ORG_NETWORK.value,
-            # deprecated
-            ResourceType.ALLOCATED_EXTERNAL_ADDRESS.value,
-            # only admin version visible to sys admin in /api/query
-            ResourceType.CATALOG_ITEM.value,
-            # only admin version visible to sys admin in /api/query
-            ResourceType.DISK.value,
-            # only admin version visible to sys admin in /api/query
-            ResourceType.GROUP.value,
-            # deprecated
-            ResourceType.ORG_NETWORK.value,
-            # only admin version visible to sys admin in /api/query
-            ResourceType.ORG_VDC_STORAGE_PROFILE.value,
-            # only admin version visible to sys admin in /api/query
-            ResourceType.USER.value,
-            # only admin version visible to sys admin in /api/query
-            ResourceType.VAPP_NETWORK.value,
-            # only admin version visible to sys admin in /api/query
-            ResourceType.VM_DISK_RELATION.value]
+            ResourceType.ALLOCATED_EXTERNAL_ADDRESS,
+            ResourceType.CATALOG_ITEM,
+            ResourceType.DISK,
+            ResourceType.GROUP,
+            ResourceType.ORG_NETWORK,
+            ResourceType.ORG_VDC_STORAGE_PROFILE,
+            ResourceType.USER,
+            ResourceType.VAPP_NETWORK,
+            ResourceType.VM_DISK_RELATION]
 
+        if api_version < 30.0:
+            # links added in api v30.0
+            allowed_exceptions.append(ResourceType.CATALOG)
+            allowed_exceptions.append(ResourceType.MEDIA)
+            allowed_exceptions.append(ResourceType.ORG_VDC)
+            allowed_exceptions.append(ResourceType.VAPP)
+            allowed_exceptions.append(ResourceType.VAPP_TEMPLATE)
+            allowed_exceptions.append(ResourceType.VM)
+        else:
+            # feature deprecated in api v30.0
+            allowed_exceptions.append(
+                ResourceType.ADMIN_ORG_NETWORK)
+            allowed_exceptions.append(
+                ResourceType.ADMIN_ALLOCATED_EXTERNAL_ADDRESS)
+
+        if api_version < 31.0:
+            # feature introduced in api v31.0
+            allowed_exceptions.append(ResourceType.NSXT_MANAGER)
+
+        resource_types = [r.value for r in ResourceType \
+            if r not in allowed_exceptions]
         # All typed queries apart from the allowed_exceptions shouldn't fail.
         for resource_type in resource_types:
-            if resource_type in allowed_exceptions:
-                continue
-            q1 = self._client.get_typed_query(
-                resource_type,
-                query_result_format=QueryResultFormat.ID_RECORDS)
-            q1_records = list(q1.execute())
-            self.assertTrue(
-                len(q1_records) >= 0,
-                "Should get a list, even if empty")
+            try:
+                q1 = self._client.get_typed_query(
+                    resource_type,
+                    query_result_format=QueryResultFormat.ID_RECORDS)
+                q1_records = list(q1.execute())
+                self.assertTrue(
+                    len(q1_records) >= 0,
+                    "Should get a list, even if empty")
+            except:
+                print(resource_type)
 
     def test_0060_check_result_formats(self):
         """Verify we get expected results for all result formats."""

--- a/system_tests/search_tests.py
+++ b/system_tests/search_tests.py
@@ -153,20 +153,17 @@ class TestSearch(BaseTestCase):
             # feature introduced in api v31.0
             allowed_exceptions.append(ResourceType.NSXT_MANAGER)
 
-        resource_types = [r.value for r in ResourceType \
-            if r not in allowed_exceptions]
+        resource_types = [r.value for r in ResourceType
+                          if r not in allowed_exceptions]
         # All typed queries apart from the allowed_exceptions shouldn't fail.
         for resource_type in resource_types:
-            try:
-                q1 = self._client.get_typed_query(
-                    resource_type,
-                    query_result_format=QueryResultFormat.ID_RECORDS)
-                q1_records = list(q1.execute())
-                self.assertTrue(
-                    len(q1_records) >= 0,
-                    "Should get a list, even if empty")
-            except:
-                print(resource_type)
+            q1 = self._client.get_typed_query(
+                resource_type,
+                query_result_format=QueryResultFormat.ID_RECORDS)
+            q1_records = list(q1.execute())
+            self.assertTrue(
+                len(q1_records) >= 0,
+                "Should get a list, even if empty")
 
     def test_0060_check_result_formats(self):
         """Verify we get expected results for all result formats."""


### PR DESCRIPTION
With https://github.com/vmware/pyvcloud/pull/288 the behavior of query service has changed. Queries with invalid query type will now generate OperationNotSupoprtedException. This also means that the search_tests needs to be adjusted to take in account the new behavior. In the earlier pull request we missed the broken test cases for api version 29.0 and lower. This PR fixes them by adjusting the expected behavior correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/295)
<!-- Reviewable:end -->
