### PR TITLE
Fix documentation for method add_extension in module api_extension.py

### DIFF
--- a/pyvcloud/vcd/api_extension.py
+++ b/pyvcloud/vcd/api_extension.py
@@ -181,7 +181,8 @@ class APIExtension(object):
         :param str namespace: namespace of the new API extension service.
         :param str routing_key: AMQP routing key to use with the extension.
         :param str exchange: AMQP exchange to use with the extension.
-        :param str patterns: URI API filters to register with the extension.
+        :param list patterns: list of url API filters to register with the
+            extension.
 
         :return: object containing EntityType.ADMIN_SERVICE XML data i.e. the
             sparse representation of the API extension.


### PR DESCRIPTION
The param 'patterns' is not a string but a list. Updated the document accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/296)
<!-- Reviewable:end -->
