### PR TITLE
Change occurrence of yaml.load() to yaml.safe_load() in examples

### DIFF
--- a/examples/tenant-onboard.py
+++ b/examples/tenant-onboard.py
@@ -76,7 +76,7 @@ config_yaml = sys.argv[1]
 # top-level entries.  Values are either scalar variables, dictionaries,
 # or lists depending on the structure of the YAML.
 with open(config_yaml, "r") as config_file:
-    config_dict = yaml.load(config_file)
+    config_dict = yaml.safe_load(config_file)
     cfg = namedtuple('ConfigObject', config_dict.keys())(**config_dict)
 
 # Disable warnings from self-signed certificates.

--- a/examples/tenant-remove.py
+++ b/examples/tenant-remove.py
@@ -36,7 +36,7 @@ config_yaml = sys.argv[1]
 
 # Load the YAML configuration and convert to an object with properties.
 with open(config_yaml, "r") as config_file:
-    config_dict = yaml.load(config_file)
+    config_dict = yaml.safe_load(config_file)
     cfg = namedtuple('ConfigObject', config_dict.keys())(**config_dict)
 
 # Disable warnings from self-signed certificates.


### PR DESCRIPTION
yaml.load() can be used by an attacker to  execute arbitrary code, yaml.safe_load() is capable of stopping this exploit. In this PR we have replaced all occurrences of yaml.load() with yaml.safe_load() in the sample pyvcloud app.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/299)
<!-- Reviewable:end -->
