### PR TITLE
[VCDA-752] Update doc generation source files.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,7 +87,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/docs/source/pyvcloud.system_test_framework.rst
+++ b/docs/source/pyvcloud.system_test_framework.rst
@@ -8,6 +8,7 @@ Submodules
 
    pyvcloud.system_test_framework.base_test
    pyvcloud.system_test_framework.environment
+   pyvcloud.system_test_framework.utils
 
 Module contents
 ---------------

--- a/docs/source/pyvcloud.system_test_framework.utils.rst
+++ b/docs/source/pyvcloud.system_test_framework.utils.rst
@@ -1,0 +1,7 @@
+pyvcloud.system\_test\_framework.utils module
+=============================================
+
+.. automodule:: pyvcloud.system_test_framework.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Since we have added some new files in system test framework, the source files for documentation generation has changed. This PR will add those new files to the repo.

Also commented out the static element portion in config since we don't have any customized CSS for our doc pages. This extra line was causing a warning during doc generation process. After this change the warning is no longer visible.