### PR TITLE
[VCDA-786] Fix failure during template uploads to catalog.

### DIFF
--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -788,7 +788,7 @@ class Org(object):
                 if data_size <= chunk_size:
                     range_str = 'bytes %s-%s/%s' % \
                                 (offset + uploaded_bytes,
-                                 data_size - 1,
+                                 offset + uploaded_bytes + data_size - 1,
                                  total_file_size)
                     self.client.upload_fragment(target_uri, data, range_str)
                     uploaded_bytes += data_size


### PR DESCRIPTION
While uploading a template to a catalog we make multiple PUT calls in succession and write the data bits on the server. However while making the PUT calls we are specifying the wrong range where the data should be written. This can cause vCD to forcibly close the TCP connection, which will eventually lead to failed uploads.

This changelist fixes the value we are sending in Content-Range header of these PUT calls.

Signed by: Aritra Sen <aritra.iitkgp@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/303)
<!-- Reviewable:end -->
