### PR TITLE
[VCDA-786] Additional fix for failures during template uploads to catalog. 

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -997,7 +997,7 @@ class Client(object):
                                        (attempt, range_str))
                     continue
                 else:
-                    self._logger.debug(
+                    self._logger.error(
                         'Reached max retry limit. Failing upload.')
                     raise
 


### PR DESCRIPTION
This PR is addendum to https://github.com/vmware/pyvcloud/pull/303

If vCD servers are behind a load balancer, the TCP connections are generally closed as soon as the first response is sent out by the load balancer. If we pump too much data in a short burst to such a system, we run the risk of getting back 416 instead of 200. Additionally we run the risk of getting the error
``urllib3.exceptions.ProtocolError: ('Connection aborted.', ConnectionResetError(10054, 'An existing connection was forcibly closed by the remote host', None, 10054, None))``

In this PR, we address these two concerns, by 
1. Introducing a retry mechanism in case we get back non 200 status on a PUT call for uploading content.
2. Increasing the upload chunk size from 1 MB to 10 MB.
3. Introducing delay between successive PUT calls if we detect that the server is closing the TCP connections.

Tested this fix by uploading and downloading templates to/from a vCD cluster sitting behind a load balancer. Without these fixes the upload never succeeded. With the fix both upload and download are working fine. Also tested the new code against a stand alone vCD server and to make sure that no regressions were introduced.

Signed by: Aritra Sen<aritra.iitkgp@gmail.com

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/304)
<!-- Reviewable:end -->
