### PR TITLE
Update Changelog for pyvcloud v20.0.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,16 @@
 CHANGES
 =======
 
+20.0.1
+------
+
+* [VCDA-786] Additional fix for failures during template uploads to catalog.  (#304)
+* [VCDA-786] Fix failure during template uploads to catalog
+
+20.0.0
+------
+
+* [VCDA-764] Update OSL files for pyvcloud. (#298)
 * [VCDA-752] Update doc generation source files (#300)
 * Change occurrence of yaml.load() to yaml.safe\_load() in pyvcloud sample app (#299)
 * bug fix: correct typo in comments (namespace -> names) (#297)


### PR DESCRIPTION
Updated version of pyvcloud to 20.0.1. Publishing the changelog via this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/305)
<!-- Reviewable:end -->
