### PR TITLE
Fix Flake8 failures

### DIFF
--- a/pyvcloud/vcd/acl.py
+++ b/pyvcloud/vcd/acl.py
@@ -373,9 +373,9 @@ class Acl(object):
                     access_settings_params.AccessSetting:
                 # if the subject name and type matches with the
                 # access_setting_params, return it.
-                if (access_setting_params.Subject.attrib['name'].lower() ==
-                    subject_name.lower()) and \
-                        (access_setting_params.Subject.attrib['type'] ==
-                         subject_type_to_entity_dict[subject_type]):
+                name = access_setting_params.Subject.attrib['name']
+                type = access_setting_params.Subject.attrib['type']
+                if (name.lower() == subject_name.lower()) and \
+                        (type == subject_type_to_entity_dict[subject_type]):
                     return access_setting_params
         return None

--- a/pyvcloud/vcd/api_extension.py
+++ b/pyvcloud/vcd/api_extension.py
@@ -51,7 +51,7 @@ class APIExtension(object):
             records = self.client.get_typed_query(
                 ResourceType.ADMIN_SERVICE.value,
                 query_result_format=QueryResultFormat.ID_RECORDS).execute()
-        except OperationNotSupportedException as e:
+        except OperationNotSupportedException:
             msg = 'User doesn\'t have permission to view extensions.'
             raise OperationNotSupportedException(msg)
 
@@ -90,16 +90,16 @@ class APIExtension(object):
                 ResourceType.ADMIN_SERVICE.value,
                 qfilter=qfilter,
                 query_result_format=format).find_unique()
-        except OperationNotSupportedException as e:
+        except OperationNotSupportedException:
             msg = 'User doesn\'t have permission to interact with extensions.'
             raise OperationNotSupportedException(msg)
-        except MissingRecordException as e:
+        except MissingRecordException:
             msg = 'API Extension service (name:' + name
             if namespace is not None:
                 msg += ', namespace:' + namespace
             msg += ') not found.'
             raise MissingRecordException(msg)
-        except MultipleRecordsException as e:
+        except MultipleRecordsException:
             msg = 'Found multiple API Extension service with (name:' + name
             if namespace is not None:
                 msg += ', namespace:' + namespace + ').'
@@ -142,7 +142,7 @@ class APIExtension(object):
                 ResourceType.API_FILTER.value,
                 equality_filter=('service', service_id),
                 query_result_format=QueryResultFormat.ID_RECORDS).execute()
-        except OperationNotSupportedException as e:
+        except OperationNotSupportedException:
             msg = 'User doesn\'t have permission to view api filters.'
             raise OperationNotSupportedException(msg)
 

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -742,8 +742,8 @@ class Client(object):
             # suitable version.
             if self._negotiate_api_version:
                 raise VcdException(
-                    "Unable to find a supported API version in " +
-                    " available server versions: {0}".format(active_versions))
+                    "Unable to find a supported API version in available \
+                        server versions: {0}".format(active_versions))
 
         # We can now proceed to login. Ensure we close session if
         # any exception is thrown to avoid leaking a socket connection.
@@ -989,7 +989,7 @@ class Client(object):
                     self._response_code_to_exception(sc, None, response)
                 else:
                     return response
-            except VcdResponseException as e:
+            except VcdResponseException:
                 # retry if not the last attempt
                 if attempt < self._UPLOAD_FRAGMENT_MAX_RETRIES:
                     self._logger.debug('Failure: attempt#%s to upload data in '

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -333,11 +333,11 @@ class VApp(object):
         try:
             return self.client.post_linked_resource(
                 vapp_resource, rel, media_type, contents)
-        except OperationNotSupportedException as e:
+        except OperationNotSupportedException:
             power_state = self.get_power_state(vapp_resource)
             raise OperationNotSupportedException(
-                'Can\'t ' + operation_name + ' vApp. Current state of vApp:' +
-                VCLOUD_STATUS_MAP[power_state])
+                'Can\'t {0} vApp. Current state of vApp: {1}.'
+                .format(operation_name, VCLOUD_STATUS_MAP[power_state]))
 
     def deploy(self, power_on=None, force_customization=None):
         """Deploys the vApp.
@@ -610,8 +610,8 @@ class VApp(object):
         new_disk['{' + NSMAP['rasd'] + '}AddressOnParent'] = addr
         new_disk['{' + NSMAP['rasd'] + '}ElementName'] = 'Hard disk %s' % addr
         new_disk['{' + NSMAP['rasd'] + '}InstanceID'] = instance_id
-        new_disk['{' + NSMAP['rasd'] +
-                 '}VirtualQuantity'] = disk_size * 1024 * 1024
+        new_disk['{' + NSMAP['rasd'] + '}VirtualQuantity'] = \
+            disk_size * 1024 * 1024
         new_disk['{' + NSMAP['rasd'] + '}HostResource'].set(
             '{' + NSMAP['vcloud'] + '}capacity', str(disk_size))
         disk_list.append(new_disk)

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -100,9 +100,8 @@ class VDC(object):
             raise EntityNotFoundException('vApp named \'%s\' not found' % name)
 
         elif len(result) > 1:
-            raise MultipleRecordsException("Found multiple vApps named " +
-                                           "\'%s\', use the vapp-id to "
-                                           "identify." % name)
+            raise MultipleRecordsException("Found multiple vApps named '%s', \
+                use the vapp-id to identify." % name)
         return result[0]
 
     def reload(self):
@@ -318,16 +317,16 @@ class VDC(object):
             for item in items:
                 if memory is not None and memory_params is None:
                     if item['{' + NSMAP['rasd'] + '}ResourceType'] == 4:
-                        item['{' + NSMAP['rasd'] +
-                             '}ElementName'] = '%s MB of memory' % memory
+                        item['{' + NSMAP['rasd'] + '}ElementName'] = \
+                            '%s MB of memory' % memory
                         item['{' + NSMAP['rasd'] + '}VirtualQuantity'] = memory
                         memory_params = item
                         virtual_hardware_section.append(memory_params)
 
                 if cpu is not None and cpu_params is None:
                     if item['{' + NSMAP['rasd'] + '}ResourceType'] == 3:
-                        item['{' + NSMAP['rasd'] +
-                             '}ElementName'] = '%s virtual CPU(s)' % cpu
+                        item['{' + NSMAP['rasd'] + '}ElementName'] = \
+                            '%s virtual CPU(s)' % cpu
                         item['{' + NSMAP['rasd'] + '}VirtualQuantity'] = cpu
                         cpu_params = item
                         virtual_hardware_section.append(cpu_params)
@@ -336,10 +335,10 @@ class VDC(object):
                     if item['{' + NSMAP['rasd'] + '}ResourceType'] == 17:
                         item['{' + NSMAP['rasd'] + '}Parent'] = None
                         item['{' + NSMAP['rasd'] + '}HostResource'].attrib[
-                            '{' + NSMAP['vcloud'] +
-                            '}capacity'] = '%s' % disk_size
-                        item['{' + NSMAP['rasd'] +
-                             '}VirtualQuantity'] = disk_size * 1024 * 1024
+                            '{' + NSMAP['vcloud'] + '}capacity'] = \
+                            '%s' % disk_size
+                        item['{' + NSMAP['rasd'] + '}VirtualQuantity'] = \
+                            disk_size * 1024 * 1024
                         disk_params = item
                         virtual_hardware_section.append(disk_params)
             vm_instantiation_param.append(virtual_hardware_section)

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -126,8 +126,8 @@ class VM(object):
         if cores_per_socket is None:
             cores_per_socket = virtual_quantity
         item = self.client.get_resource(uri)
-        item['{' + NSMAP['rasd'] +
-             '}ElementName'] = '%s virtual CPU(s)' % virtual_quantity
+        item['{' + NSMAP['rasd'] + '}ElementName'] = \
+            '%s virtual CPU(s)' % virtual_quantity
         item['{' + NSMAP['rasd'] + '}VirtualQuantity'] = virtual_quantity
         item['{' + NSMAP['vmw'] + '}CoresPerSocket'] = cores_per_socket
         return self.client.put_resource(uri, item, EntityType.RASD_ITEM.value)
@@ -145,8 +145,8 @@ class VM(object):
         """
         uri = self.href + '/virtualHardwareSection/memory'
         item = self.client.get_resource(uri)
-        item['{' + NSMAP['rasd'] +
-             '}ElementName'] = '%s virtual CPU(s)' % virtual_quantity
+        item['{' + NSMAP['rasd'] + '}ElementName'] = \
+            '%s virtual CPU(s)' % virtual_quantity
         item['{' + NSMAP['rasd'] + '}VirtualQuantity'] = virtual_quantity
         return self.client.put_resource(uri, item, EntityType.RASD_ITEM.value)
 
@@ -247,11 +247,11 @@ class VM(object):
         try:
             return self.client.post_linked_resource(
                 vm_resource, rel, media_type, contents)
-        except OperationNotSupportedException as e:
+        except OperationNotSupportedException:
             power_state = self.get_power_state(vm_resource)
             raise OperationNotSupportedException(
-                'Can\'t ' + operation_name + ' vm. Current state of vm:' +
-                VCLOUD_STATUS_MAP[power_state])
+                'Can\'t {0} vm. Current state of vm: {1}.'
+                .format(operation_name, VCLOUD_STATUS_MAP[power_state]))
 
     def shutdown(self):
         """Shutdown the vm.


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

- Fix Flake8 failures

- There are new failures in existing python files after Flake8 is updated to 3.6.0. There are two types of errors: "W504 line break after binary operator" & "F841 local variable 'e' is assigned to but never used". Fixing these failures. 

- @rajeshk2013 @rocknes @ckolovson

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/313)
<!-- Reviewable:end -->
