### PR TITLE
[VP-1153] Update name and description of an external network

### DIFF
--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -275,7 +275,8 @@ class Platform(object):
         if new_name is not None:
             ext_net.set('name', new_name)
         if new_description is not None:
-            description = ext_net.find('vcloud:Description', NSMAP)
+
+            description = ext_net['{' + NSMAP['vcloud'] + '}Description']
             ext_net.replace(description, E.Description(new_description))
 
         return self.client.put_linked_resource(

--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -250,6 +250,40 @@ class Platform(object):
         raise EntityNotFoundException(
             'External network \'%s\' not found.' % name)
 
+    def update_external_network(self,
+                                name,
+                                new_name=None,
+                                new_description=None):
+        """Update name and description of an external network.
+
+        :param str name: name of the external network to be updated.
+
+        :param str new_name: new name of the external network.
+
+        :param str new_description: new description of the external network.
+
+        :return: an object containing vmext:VMWExternalNetwork XML element that
+            represents the updated external network.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        ext_net = self.get_external_network(name)
+
+        if (new_name is None) and (new_description is None):
+            return ext_net
+
+        if new_name is not None:
+            ext_net.set('name', new_name)
+        if new_description is not None:
+            description = ext_net.find('vcloud:Description', NSMAP)
+            ext_net.replace(description, E.Description(new_description))
+
+        return self.client.put_linked_resource(
+            ext_net,
+            rel=RelationType.EDIT,
+            media_type=EntityType.EXTERNAL_NETWORK.value,
+            contents=ext_net)
+
     def get_vxlan_network_pool(self, vxlan_network_pool_name):
         """[Deprecated] Fetch a vxlan_network_pool by its name.
 

--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -275,7 +275,6 @@ class Platform(object):
         if new_name is not None:
             ext_net.set('name', new_name)
         if new_description is not None:
-
             description = ext_net['{' + NSMAP['vcloud'] + '}Description']
             ext_net.replace(description, E.Description(new_description))
 

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -110,7 +110,7 @@ class TestExtNet(BaseTestCase):
         ext_net = platform.update_external_network(TestExtNet._name, new_name,
                                                    new_description)
 
-        task = ext_net.find('vcloud:Tasks', NSMAP).Task[0]
+        task = ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0]
         TestExtNet._sys_admin_client.get_task_monitor().wait_for_success(
             task=task)
         logger.debug('Updated external network ' + TestExtNet._name + '.')
@@ -123,7 +123,7 @@ class TestExtNet(BaseTestCase):
         # Reset the name and description to original
         ext_net = platform.update_external_network(new_name, self._name,
                                                    self._description)
-        task = ext_net.find('vcloud:Tasks', NSMAP).Task[0]
+        task = ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0]
         TestExtNet._sys_admin_client.get_task_monitor().wait_for_success(
             task=task)
 

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -72,8 +72,8 @@ class TestExtNet(BaseTestCase):
                     TestExtNet._port_group = record.get('name')
                     break
 
-        self.assertIsNotNone(
-            self._port_group, 'None of the port groups are free.')
+        self.assertIsNotNone(self._port_group,
+                             'None of the port groups are free.')
 
         ext_net = platform.create_external_network(
             name=TestExtNet._name,
@@ -92,6 +92,40 @@ class TestExtNet(BaseTestCase):
             task=task)
 
         logger.debug('Created external network ' + TestExtNet._name + '.')
+
+    def test_0010_update(self):
+        """Test the method Platform.update_external_network()
+
+        Update name and description of the external network created by setup.
+        Verifies name and description after update completes. Reset the name
+        and description to original.
+
+        This test passes if name and description are updated successfully.
+        """
+        logger = Environment.get_default_logger()
+        platform = Platform(TestExtNet._sys_admin_client)
+        new_name = 'updated_' + TestExtNet._name
+        new_description = 'Updated ' + TestExtNet._description
+
+        ext_net = platform.update_external_network(TestExtNet._name, new_name,
+                                                   new_description)
+
+        task = ext_net.find('vcloud:Tasks', NSMAP).Task[0]
+        TestExtNet._sys_admin_client.get_task_monitor().wait_for_success(
+            task=task)
+        logger.debug('Updated external network ' + TestExtNet._name + '.')
+
+        ext_net = platform.get_external_network(new_name)
+        self.assertIsNotNone(ext_net)
+        self.assertEqual(new_description,
+                         ext_net.find('vcloud:Description', NSMAP).text)
+
+        # Reset the name and description to original
+        ext_net = platform.update_external_network(new_name, self._name,
+                                                   self._description)
+        task = ext_net.find('vcloud:Tasks', NSMAP).Task[0]
+        TestExtNet._sys_admin_client.get_task_monitor().wait_for_success(
+            task=task)
 
     @developerModeAware
     def test_9998_teardown(self):


### PR DESCRIPTION
Implementation of name and description update of an external network. Name and description both are optional, if none of them is provided, code returns without doing anything. It takes the name of the existing external network to find it. 

Testing done:
Added a test in extnet.tests and ran all the tests in this class. 

- @rocknes @rajeshk2013 @ckolovson

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/317)
<!-- Reviewable:end -->
