### PR TITLE
VP-1239: List external network ip allocations.

### DIFF
--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -81,10 +81,9 @@ class Gateway(object):
         if self.resource is None:
             self.reload()
 
-        return self.client.post_linked_resource(self.resource,
-                                                RelationType.
-                                                CONVERT_TO_ADVANCED_GATEWAY,
-                                                None, None)
+        return self.client.post_linked_resource(
+            self.resource, RelationType.CONVERT_TO_ADVANCED_GATEWAY, None,
+            None)
 
     def enable_distributed_routing(self, enable=True):
         """Enable Distributed Routing.
@@ -104,10 +103,9 @@ class Gateway(object):
             return
         gateway.Configuration.DistributedRoutingEnabled = \
             E.DistributedRoutingEnabled(enable)
-        return self.client.put_linked_resource(self.resource,
-                                               RelationType.EDIT,
-                                               EntityType.EDGE_GATEWAY.value,
-                                               gateway)
+        return self.client.put_linked_resource(
+            self.resource, RelationType.EDIT, EntityType.EDGE_GATEWAY.value,
+            gateway)
 
     def modify_form_factor(self, gateway_type):
         """Modify form factor.
@@ -129,12 +127,30 @@ class Gateway(object):
         try:
             GatewayBackingConfigType.__getitem__(gateway_type)
         except ValueError:
-            raise InvalidParameterException('Provided %s is not valid. It '
-                                            'should be from allowed list '
-                                            'compact/full/full4/x-large' %
-                                            gateway_type)
+            raise InvalidParameterException(
+                'Provided %s is not valid. It '
+                'should be from allowed list '
+                'compact/full/full4/x-large' % gateway_type)
         gateway_form_factor = E.EdgeGatewayFormFactor()
         gateway_form_factor.append(E.gatewayType(gateway_type))
         return self.client.post_linked_resource(
             self.resource, RelationType.MODIFY_FORM_FACTOR,
             EntityType.EDGE_GATEWAY_FORM_FACTOR.value, gateway_form_factor)
+
+    def list_external_network_ip_allocations(self):
+        """List external network ip allocations of the gateway.
+
+        This operation can be performed by System/Org Administrators.
+
+        :return: a dictionary that maps external network name to list of ip
+            addresses. Ex: {'extnw1': ['10.10.10.2'...]}
+
+        :rtype: dict
+        """
+        gateway = self.get_resource()
+        out = {}
+        for inf in gateway.Configuration.GatewayInterfaces.GatewayInterface:
+            if inf.InterfaceType.text == 'uplink':
+                ips = out.setdefault(inf.Name.text, [])
+                ips.append(inf.SubnetParticipation.IpAddress.text)
+        return out

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -42,8 +42,6 @@ class TestGateway(BaseTestCase):
 
         This test passes if the gateway is created successfully.
         """
-        logger = Environment.get_default_logger()
-
         TestGateway._client = Environment.get_sys_admin_client()
         vdc = Environment.get_test_vdc(TestGateway._client)
         platform = Platform(TestGateway._client)
@@ -75,16 +73,12 @@ class TestGateway(BaseTestCase):
                 subnet_addr: [next_ip + '-' + next_ip]
             }
         }
-        ext_net_to_rate_limit = {
-            ext_net_resource.get('name'): {
-                100 : 100
-            }
-        }
+        ext_net_to_rate_limit = {ext_net_resource.get('name'): {100: 100}}
         TestGateway._gateway = vdc.create_gateway(
             self._name, [ext_net_resource.get('name')], 'compact', None, True,
             ext_net_resource.get('name'), gateway_ip, True, False, False,
-            False, True, ext_net_to_participated_subnet_with_ip_settings,
-            True, ext_net_to_subnet_with_ip_range, ext_net_to_rate_limit)
+            False, True, ext_net_to_participated_subnet_with_ip_settings, True,
+            ext_net_to_subnet_with_ip_range, ext_net_to_rate_limit)
         result = TestGateway._client.get_task_monitor().wait_for_success(
             task=TestGateway._gateway.Tasks.Task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
@@ -125,6 +119,16 @@ class TestGateway(BaseTestCase):
         result = TestGateway._client.get_task_monitor().wait_for_success(
             task=task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0004_list_external_network_ip_allocations(self):
+        """List external network ip allocations.
+
+        Invoke the list_external_network_ip_allocations of the gateway.
+        """
+        gateway_obj = Gateway(TestGateway._client, self._name,
+                              TestGateway._gateway.get('href'))
+        ip_allocations = gateway_obj.list_external_network_ip_allocations()
+        self.assertEqual(bool(ip_allocations), True)
 
     def test_0098_teardown(self):
         """Test the method System.delete_gateway().

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -128,7 +128,7 @@ class TestGateway(BaseTestCase):
         gateway_obj = Gateway(TestGateway._client, self._name,
                               TestGateway._gateway.get('href'))
         ip_allocations = gateway_obj.list_external_network_ip_allocations()
-        self.assertEqual(bool(ip_allocations), True)
+        self.assertTrue(bool(ip_allocations))
 
     def test_0098_teardown(self):
         """Test the method System.delete_gateway().


### PR DESCRIPTION
List external network ip allocations of the gateway.

The newly added function returns a dictionary that maps-
external network name to the list of ip addresses allocated to the gateway.
This CL has few formatting changes done by YPAF.

Testing Done: ran gateway_tests successfully.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/324)
<!-- Reviewable:end -->
