### PR TITLE
VP-1251, VP-1252: Configure external network: add/remove

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -140,6 +140,7 @@ class RelationType(Enum):
     ENABLE = 'enable'
     GATEWAY_REDEPLOY = 'edgeGateway:redeploy'
     GATEWAY_SYNC_SYSLOG_SETTINGS = 'edgeGateway:syncSyslogSettings'
+    GATEWAY_UPDATE_PROPERTIES = 'edgeGateway:updateProperties'
     LINK_TO_TEMPLATE = 'linkToTemplate'
     MIGRATE_VMS = 'migrateVms'
     MODIFY_FORM_FACTOR = 'edgeGateway:modifyFormFactor'


### PR DESCRIPTION
This CL adds code to configure external networks for a given gateway.
Two methods are added. One to add and other to remove external networks from the gateway.

Testing done: added test cases to add and remove networks.
Ran gateway_tests successfully.

