### PR TITLE
VP-1243: Modify an IP range of a subnet in external network

### DIFF
--- a/pyvcloud/vcd/external_network.py
+++ b/pyvcloud/vcd/external_network.py
@@ -194,7 +194,6 @@ class ExternalNetwork(object):
                                 media_type=EntityType.
                                 EXTERNAL_NETWORK.value,
                                 contents=ext_net)
-        return ext_net
 
     def modify_ip_range(self, gateway_ip, old_ip_range, new_ip_range):
         """Modify ip range of a subnet in external network.
@@ -244,4 +243,3 @@ class ExternalNetwork(object):
                                 media_type=EntityType.
                                 EXTERNAL_NETWORK.value,
                                 contents=ext_net)
-        return ext_net

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -225,7 +225,7 @@ class TestExtNet(BaseTestCase):
                 ip_scope = scope
                 break
         self.assertIsNotNone(ip_scope)
-        self.validate_ip_range(ip_scope, TestExtNet._ip_range3)
+        self.__validate_ip_range(ip_scope, TestExtNet._ip_range3)
 
     def test_0050_modify_ip_range(self):
         """Test the method externalNetwork.modify_ip_range()
@@ -256,9 +256,9 @@ class TestExtNet(BaseTestCase):
                  ip_scope = scope
                  break
         self.assertIsNotNone(ip_scope)
-        self.validate_ip_range(ip_scope, TestExtNet._ip_range4)
+        self.__validate_ip_range(ip_scope, TestExtNet._ip_range4)
 
-    def validate_ip_range(self, ip_scope, _ip_range1):
+    def __validate_ip_range(self, ip_scope, _ip_range1):
         """ Validate if the ip range present in the existing ip ranges """
         _ip_ranges = _ip_range1.split('-')
         _ip_range1_start_address = _ip_ranges[0]

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -225,13 +225,7 @@ class TestExtNet(BaseTestCase):
                 ip_scope = scope
                 break
         self.assertIsNotNone(ip_scope)
-
-        _ip_ranges = TestExtNet._ip_range3.split('-')
-        _ip_range3_start_address = _ip_ranges[0]
-        _ip_range3_end_address = _ip_ranges[1]
-        for ip_range in ip_scope.IpRanges.IpRange:
-            if ip_range.StartAddress == _ip_range3_start_address:
-                self.assertEqual(ip_range.EndAddress, _ip_range3_end_address)
+        self.validate_ip_range(ip_scope, TestExtNet._ip_range3)
 
     def test_0050_modify_ip_range(self):
         """Test the method externalNetwork.modify_ip_range()
@@ -262,12 +256,16 @@ class TestExtNet(BaseTestCase):
                  ip_scope = scope
                  break
         self.assertIsNotNone(ip_scope)
-        _ip_ranges = TestExtNet._ip_range4.split('-')
-        _ip_range4_start_address = _ip_ranges[0]
-        _ip_range4_end_address = _ip_ranges[1]
+        self.validate_ip_range(ip_scope, TestExtNet._ip_range4)
+
+    def validate_ip_range(self, ip_scope, _ip_range1):
+        """ Validate if the ip range present in the existing ip ranges """
+        _ip_ranges = _ip_range1.split('-')
+        _ip_range1_start_address = _ip_ranges[0]
+        _ip_range1_end_address = _ip_ranges[1]
         for ip_range in ip_scope.IpRanges.IpRange:
-            if ip_range.StartAddress == _ip_range4_start_address:
-                 self.assertEqual(ip_range.EndAddress, _ip_range4_end_address)
+            if ip_range.StartAddress == _ip_range1_start_address:
+                self.assertEqual(ip_range.EndAddress, _ip_range1_end_address)
 
     @developerModeAware
     def test_9998_teardown(self):
@@ -293,7 +291,6 @@ class TestExtNet(BaseTestCase):
         ext_net_resource = platform.get_external_network(self._name)
         return ExternalNetwork(TestExtNet._sys_admin_client,
                                resource=ext_net_resource)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
VP-1243: Modify an IP range of a subnet in external network

This changelist involves the modification of a IP range in the subnet with the new IP range.
Testing done:
1. flake8 command succeeded
2. Test case passed, Ip Range modified in the subnet.


- (Optional) Names of reviewers using @ sign + name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/333)
<!-- Reviewable:end -->
