### PR TITLE
VP-1292:List edge gateway's Configure IP Settings

### DIFF
--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -183,3 +183,36 @@ class Gateway(object):
         return self.client.post_linked_resource(
             self.resource, RelationType.GATEWAY_SYNC_SYSLOG_SETTINGS, None,
             None)
+
+    def list_gateways_configure_ip_settings(self):
+        """List all gateway's configure ip settings in the current vdc.
+
+        :return:  a list of dictionary that has gateway's configure ip settings
+            Ex: {'External Networks':
+            ['external_network_de99a4e2-f6d8-11e8-9e0c-9061ae543719'],
+            'Gateway': ['10.20.30.1/24'], 'Ip Address': ['10.20.30.2']}
+
+        :rtype: list
+
+        """
+        if self.resource is None:
+            self.reload()
+
+        out_list = []
+        gateway = self.get_resource()
+        for gatewayinf in \
+                gateway.Configuration.GatewayInterfaces.GatewayInterface:
+            ipconfigsettings = {}
+            extnetwork = ipconfigsettings.setdefault('External Networks', [])
+            extnetwork.append(gatewayinf.Name.text)
+            gatewayips = ipconfigsettings.setdefault('Gateway', [])
+            ips = ipconfigsettings.setdefault('Ip Address', [])
+            for subnetpart in gatewayinf.SubnetParticipation:
+                if hasattr(self.resource, 'SubnetPrefixLength'):
+                    gatewayips.append(subnetpart.Gateway.text + '/' +
+                                      subnetpart.SubnetPrefixLength.text)
+                else:
+                    gatewayips.append(subnetpart.Gateway.text)
+                ips.append(subnetpart.IpAddress.text)
+            out_list.append(ipconfigsettings)
+        return out_list

--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -188,9 +188,9 @@ class Gateway(object):
         """List all gateway's configure ip settings in the current vdc.
 
         :return:  a list of dictionary that has gateway's configure ip settings
-            Ex: [{'External Networks':
+            Ex: [{'external_network':
             'external_network_de99a4e2-f6d8-11e8-9e0c-9061ae543719',
-            'Gateway': ['10.20.30.1/24'], 'Ip Address': ['10.20.30.2']}]
+            'gateway': ['10.20.30.1/24'], 'ip_address': ['10.20.30.2']}]
 
         :rtype: list
 
@@ -203,7 +203,7 @@ class Gateway(object):
         for gatewayinf in \
                 gateway.Configuration.GatewayInterfaces.GatewayInterface:
             ipconfigsettings = dict()
-            ipconfigsettings['external_networks'] = gatewayinf.Name.text
+            ipconfigsettings['external_network'] = gatewayinf.Name.text
             gatewayips = ipconfigsettings.setdefault('gateway', [])
             ips = ipconfigsettings.setdefault('ip_address', [])
             for subnetpart in gatewayinf.SubnetParticipation:

--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -184,13 +184,13 @@ class Gateway(object):
             self.resource, RelationType.GATEWAY_SYNC_SYSLOG_SETTINGS, None,
             None)
 
-    def list_gateways_configure_ip_settings(self):
+    def list_configure_ip_settings(self):
         """List all gateway's configure ip settings in the current vdc.
 
         :return:  a list of dictionary that has gateway's configure ip settings
-            Ex: {'External Networks':
-            ['external_network_de99a4e2-f6d8-11e8-9e0c-9061ae543719'],
-            'Gateway': ['10.20.30.1/24'], 'Ip Address': ['10.20.30.2']}
+            Ex: [{'External Networks':
+            'external_network_de99a4e2-f6d8-11e8-9e0c-9061ae543719',
+            'Gateway': ['10.20.30.1/24'], 'Ip Address': ['10.20.30.2']}]
 
         :rtype: list
 
@@ -202,13 +202,12 @@ class Gateway(object):
         gateway = self.get_resource()
         for gatewayinf in \
                 gateway.Configuration.GatewayInterfaces.GatewayInterface:
-            ipconfigsettings = {}
-            extnetwork = ipconfigsettings.setdefault('External Networks', [])
-            extnetwork.append(gatewayinf.Name.text)
-            gatewayips = ipconfigsettings.setdefault('Gateway', [])
-            ips = ipconfigsettings.setdefault('Ip Address', [])
+            ipconfigsettings = dict()
+            ipconfigsettings['external_networks'] = gatewayinf.Name.text
+            gatewayips = ipconfigsettings.setdefault('gateway', [])
+            ips = ipconfigsettings.setdefault('ip_address', [])
             for subnetpart in gatewayinf.SubnetParticipation:
-                if hasattr(self.resource, 'SubnetPrefixLength'):
+                if hasattr(subnetpart, 'SubnetPrefixLength'):
                     gatewayips.append(subnetpart.Gateway.text + '/' +
                                       subnetpart.SubnetPrefixLength.text)
                 else:

--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -196,9 +196,6 @@ class Gateway(object):
         :rtype: list
 
         """
-        if self.resource is None:
-            self.reload()
-
         out_list = []
         gateway = self.get_resource()
         for gatewayinf in \

--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -17,6 +17,7 @@ from pyvcloud.vcd.client import GatewayBackingConfigType
 from pyvcloud.vcd.client import RelationType
 from pyvcloud.vcd.exceptions import InvalidParameterException
 from pyvcloud.vcd.utils import get_admin_href
+from pyvcloud.vcd.utils import netmask_to_cidr_prefix_len
 
 
 class Gateway(object):
@@ -211,7 +212,10 @@ class Gateway(object):
                     gatewayips.append(subnetpart.Gateway.text + '/' +
                                       subnetpart.SubnetPrefixLength.text)
                 else:
-                    gatewayips.append(subnetpart.Gateway.text)
+                    gatewayips.append(subnetpart.Gateway.text + '/' +
+                                      str(netmask_to_cidr_prefix_len(
+                                          subnetpart.Gateway.text,
+                                          subnetpart.Netmask.text)))
                 ips.append(subnetpart.IpAddress.text)
             out_list.append(ipconfigsettings)
         return out_list

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -175,7 +175,7 @@ class TestGateway(BaseTestCase):
             platform = Platform(TestGateway._client)
             external_networks = platform.list_external_networks()
             self.assertTrue(bool(ip_allocations))
-            exnet = ip_allocations[0].get('external_networks')
+            exnet = ip_allocations[0].get('external_network')
             self.assertEqual(external_networks[0].get('name'), exnet)
 
     def test_0098_teardown(self):

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -27,6 +27,9 @@ from pyvcloud.vcd.utils import netmask_to_cidr_prefix_len
 
 class TestGateway(BaseTestCase):
     """Test Gateway functionalities implemented in pyvcloud."""
+    # All tests in this module should be run as System Administrator.
+    _client = None
+
     _name = ("test_gateway1" + str(uuid1()))[:34]
 
     _description = "test_gateway1 description"
@@ -168,12 +171,12 @@ class TestGateway(BaseTestCase):
         for client in (TestGateway._client, TestGateway._org_client):
             gateway_obj = Gateway(client, self._name,
                                   TestGateway._gateway.get('href'))
-            ip_allocations = gateway_obj.list_gateways_configure_ip_settings()
+            ip_allocations = gateway_obj.list_configure_ip_settings()
             platform = Platform(TestGateway._client)
             external_networks = platform.list_external_networks()
             self.assertTrue(bool(ip_allocations))
-            exnet = ip_allocations[0].get('External Networks')
-            self.assertEqual(external_networks[0].get('name'), exnet[0])
+            exnet = ip_allocations[0].get('external_networks')
+            self.assertEqual(external_networks[0].get('name'), exnet)
 
     def test_0098_teardown(self):
         """Test the method System.delete_gateway().

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -27,10 +27,6 @@ from pyvcloud.vcd.utils import netmask_to_cidr_prefix_len
 
 class TestGateway(BaseTestCase):
     """Test Gateway functionalities implemented in pyvcloud."""
-
-    # All tests in this module should be run as System Administrator.
-
-    _client = None
     _name = ("test_gateway1" + str(uuid1()))[:34]
 
     _description = "test_gateway1 description"
@@ -163,6 +159,21 @@ class TestGateway(BaseTestCase):
             result = TestGateway._client.get_task_monitor().wait_for_success(
                 task=task)
             self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0007_list_external_network_config_ip_allocations(self):
+        """List external network configure ip allocations.
+
+        Invoke the list_gateways_configure_ip_settings of the gateway.
+        """
+        for client in (TestGateway._client, TestGateway._org_client):
+            gateway_obj = Gateway(client, self._name,
+                                  TestGateway._gateway.get('href'))
+            ip_allocations = gateway_obj.list_gateways_configure_ip_settings()
+            platform = Platform(TestGateway._client)
+            external_networks = platform.list_external_networks()
+            self.assertTrue(bool(ip_allocations))
+            exnet = ip_allocations[0].get('External Networks')
+            self.assertEqual(external_networks[0].get('name'), exnet[0])
 
     def test_0098_teardown(self):
         """Test the method System.delete_gateway().


### PR DESCRIPTION
VP-1292: List edge gateway's Configure IP Settings

This change set will list the edge gateway's Configure IP Settings 
Ex: {'External Networks':
            ['external_network_de99a4e2-f6d8-11e8-9e0c-9061ae543719'],
            'Gateway': ['10.20.30.1/24'], 'Ip Address': ['10.20.30.2']}

Made changes to the following files:
gateway.py
gateway_tests.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/335)
<!-- Reviewable:end -->
