### PR TITLE
VP-1293: Edit gateway Name

### DIFF
--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -330,3 +330,30 @@ class Gateway(object):
         return self.client.put_linked_resource(
             self.resource, RelationType.GATEWAY_UPDATE_PROPERTIES,
             EntityType.EDGE_GATEWAY.value, gateway)
+
+    def edit_gateway_name(self, oldname=None, newname=None):
+        """It changes the old name of the gateway to the new name.
+
+        :param String oldname: Old name of the gateway
+        :param String newname: new name of the gateway
+
+        :return: object containing EntityType.TASK XML data
+            representing the asynchronous task.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        if oldname is None or newname is None:
+            raise ValueError('Invalid input, oldname and newname cannot be '
+                             'empty.')
+
+        gateway = self.get_resource()
+        gateway_name = gateway.get('name')
+        if gateway_name != oldname:
+            raise ValueError('Gateway with name: {0} does not exists'.format
+                             (oldname))
+
+        gateway.set('name', newname)
+        return self.client.put_linked_resource(self.resource,
+                                               RelationType.EDIT,
+                                               EntityType.EDGE_GATEWAY.value,
+                                               gateway)

--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -331,10 +331,9 @@ class Gateway(object):
             self.resource, RelationType.GATEWAY_UPDATE_PROPERTIES,
             EntityType.EDGE_GATEWAY.value, gateway)
 
-    def edit_gateway_name(self, oldname=None, newname=None):
+    def edit_gateway_name(self, newname=None):
         """It changes the old name of the gateway to the new name.
 
-        :param String oldname: Old name of the gateway
         :param String newname: new name of the gateway
 
         :return: object containing EntityType.TASK XML data
@@ -342,16 +341,10 @@ class Gateway(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        if oldname is None or newname is None:
-            raise ValueError('Invalid input, oldname and newname cannot be '
-                             'empty.')
+        if newname is None:
+            raise ValueError('Invalid input, name cannot be empty.')
 
         gateway = self.get_resource()
-        gateway_name = gateway.get('name')
-        if gateway_name != oldname:
-            raise ValueError('Gateway with name: {0} does not exists'.format
-                             (oldname))
-
         gateway.set('name', newname)
         return self.client.put_linked_resource(self.resource,
                                                RelationType.EDIT,

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -275,8 +275,10 @@ class TestGateway(BaseTestCase):
         result = TestGateway._client.get_task_monitor().wait_for_success(
             task=task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        '''resetting back to original gateway name'''
         task = gateway_obj.edit_gateway_name(TestGateway._name)
-        TestGateway._client.get_task_monitor().wait_for_success(task=task)
+        result = TestGateway._client.get_task_monitor().wait_for_success(task=task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
     def test_0098_teardown(self):
         """Test the method System.delete_gateway().

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -271,11 +271,12 @@ class TestGateway(BaseTestCase):
         """
         gateway_obj = Gateway(TestGateway._client, self._name,
                               TestGateway._gateway.get('href'))
-        task = gateway_obj.edit_gateway_name(TestGateway._name, 'gateway2')
+        task = gateway_obj.edit_gateway_name('gateway2')
         result = TestGateway._client.get_task_monitor().wait_for_success(
             task=task)
-        TestGateway._name = 'gateway2'
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        task = gateway_obj.edit_gateway_name(TestGateway._name)
+        TestGateway._client.get_task_monitor().wait_for_success(task=task)
 
     def test_0098_teardown(self):
         """Test the method System.delete_gateway().

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -264,6 +264,19 @@ class TestGateway(BaseTestCase):
 
         self._delete_external_network(TestGateway._external_network2)
 
+    def test_0010_edit_gateway_name(self):
+        """Edit the gateway name.
+
+        Invokes the edit_gateway_name of the gateway.
+        """
+        gateway_obj = Gateway(TestGateway._client, self._name,
+                              TestGateway._gateway.get('href'))
+        task = gateway_obj.edit_gateway_name(TestGateway._name, 'gateway2')
+        result = TestGateway._client.get_task_monitor().wait_for_success(
+            task=task)
+        TestGateway._name = 'gateway2'
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
     def test_0098_teardown(self):
         """Test the method System.delete_gateway().
 


### PR DESCRIPTION
VP-1293: Edit gateway Name

- Its replaces the old gateway name with the new name 
- User has to pass old gateway name and new gateway name as input to method edit_gateway_name
- Added edit_gateway_name(self, oldname=None, newname=None) to gateway.py
- Added test cases to gateway-tests.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/336)
<!-- Reviewable:end -->
