### PR TITLE
VP-1257: Attach port groups to an external network

### DIFF
--- a/pyvcloud/vcd/external_network.py
+++ b/pyvcloud/vcd/external_network.py
@@ -194,7 +194,6 @@ class ExternalNetwork(object):
                                 media_type=EntityType.
                                 EXTERNAL_NETWORK.value,
                                 contents=ext_net)
-        return ext_net
 
     def modify_ip_range(self, gateway_ip, old_ip_range, new_ip_range):
         """Modify ip range of a subnet in external network.
@@ -244,4 +243,3 @@ class ExternalNetwork(object):
                                 media_type=EntityType.
                                 EXTERNAL_NETWORK.value,
                                 contents=ext_net)
-        return ext_net

--- a/pyvcloud/vcd/external_network.py
+++ b/pyvcloud/vcd/external_network.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pyvcloud.vcd.client import E
+from pyvcloud.vcd.client import E_VMEXT
 from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import NSMAP
 from pyvcloud.vcd.client import RelationType
@@ -243,3 +244,68 @@ class ExternalNetwork(object):
                                 media_type=EntityType.
                                 EXTERNAL_NETWORK.value,
                                 contents=ext_net)
+
+    def attach_port_group(self, vim_server_name, port_group_name):
+        """Attach a portgroup to an external network.
+
+        :param str vc_name: name of vc where portgroup is present.
+        :param str pg_name: name of the portgroup to be attached to
+             external network.
+
+        return: object containing vmext:VMWExternalNetwork XML element that
+             representing the external network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        if self.resource is None:
+            self.reload()
+        ext_net = self.resource
+        platform = Platform(self.client)
+        vc_record = platform.get_vcenter(vim_server_name)
+        vc_href = vc_record.get('href')
+        pg_moref_types = \
+            platform.get_port_group_moref_types(vim_server_name,
+                                                port_group_name)
+
+        if hasattr(ext_net,
+                   '{' + NSMAP['vmext'] + '}VimPortGroupRef'):
+            vim_port_group_refs = E_VMEXT.VimPortGroupRefs()
+            vim_object_ref1 = self.__create_vimobj_ref(
+                vc_href,
+                pg_moref_types[0],
+                pg_moref_types[1])
+
+            vim_pg_ref = ext_net['{' + NSMAP['vmext'] + '}VimPortGroupRef']
+            vc2_href = vim_pg_ref.VimServerRef.get('href')
+            vim_object_ref2 = self.__create_vimobj_ref(
+                vc2_href,
+                vim_pg_ref.MoRef.text,
+                vim_pg_ref.VimObjectType.text)
+
+            vim_port_group_refs.append(vim_object_ref1)
+            vim_port_group_refs.append(vim_object_ref2)
+            ext_net.remove(vim_pg_ref)
+        else:
+            vim_port_group_refs = \
+                ext_net['{' + NSMAP['vmext'] + '}VimPortGroupRefs']
+            vim_object_ref1 = self.__create_vimobj_ref(
+                vc_href,
+                pg_moref_types[0],
+                pg_moref_types[1])
+            vim_port_group_refs.append(vim_object_ref1)
+
+        ext_net.append(vim_port_group_refs)
+
+        return self.client. \
+            put_linked_resource(ext_net, rel=RelationType.EDIT,
+                                media_type=EntityType.
+                                EXTERNAL_NETWORK.value,
+                                contents=ext_net)
+
+    def __create_vimobj_ref(self, vc_href, pg_moref, pg_type):
+        """Creates the VimObjectRef."""
+        vim_object_ref = E_VMEXT.VimObjectRef()
+        vim_object_ref.append(E_VMEXT.VimServerRef(href=vc_href))
+        vim_object_ref.append(E_VMEXT.MoRef(pg_moref))
+        vim_object_ref.append(E_VMEXT.VimObjectType(pg_type))
+
+        return vim_object_ref

--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -1000,3 +1000,36 @@ class Platform(object):
             query_result_format=QueryResultFormat.RECORDS)
 
         return query.execute()
+
+    def get_port_group_moref_types(self, vim_server_name, port_group_name):
+        """Fetches moref and type for a given list of port group name.
+
+        :return: list of tuples containing port group moref and type.
+
+        :rtype: list
+
+        :raises: EntityNotFoundException: if any port group names cannot be
+        found.
+        """
+        vcfilter = 'vcName==%s' % urllib.parse.quote_plus(vim_server_name)
+        query = self.client.get_typed_query(
+            ResourceType.PORT_GROUP.value,
+            qfilter=vcfilter,
+            query_result_format=QueryResultFormat.RECORDS)
+        records = list(query.execute())
+        port_groups = {}
+        for record in records:
+            port_groups[record.get('name')] = ((record.get('moref'),
+                                                record.get('portgroupType')))
+        port_group_moref_types = []
+        for port_group in port_groups:
+            port_group_found = False
+            if port_group_name == port_group:
+                port_group_found = True
+                port_group_moref_types.append(port_groups[port_group_name][0])
+                port_group_moref_types.append(port_groups[port_group_name][1])
+                break
+        if not port_group_found:
+            raise EntityNotFoundException(
+                'port group \'%s\' not Found' % port_group_name)
+        return port_group_moref_types

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -225,7 +225,7 @@ class TestExtNet(BaseTestCase):
                 ip_scope = scope
                 break
         self.assertIsNotNone(ip_scope)
-        self.validate_ip_range(ip_scope, TestExtNet._ip_range3)
+        self.__validate_ip_range(ip_scope, TestExtNet._ip_range3)
 
     def test_0050_modify_ip_range(self):
         """Test the method externalNetwork.modify_ip_range()
@@ -256,9 +256,9 @@ class TestExtNet(BaseTestCase):
                  ip_scope = scope
                  break
         self.assertIsNotNone(ip_scope)
-        self.validate_ip_range(ip_scope, TestExtNet._ip_range4)
+        self.__validate_ip_range(ip_scope, TestExtNet._ip_range4)
 
-    def validate_ip_range(self, ip_scope, _ip_range1):
+    def __validate_ip_range(self, ip_scope, _ip_range1):
         """ Validate if the ip range present in the existing ip ranges """
         _ip_ranges = _ip_range1.split('-')
         _ip_range1_start_address = _ip_ranges[0]

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -322,7 +322,7 @@ class TestExtNet(BaseTestCase):
 
         Invoke the method for the external network created by setup.
 
-        This test passes if4 the task for deleting the external network
+        This test passes if the task for deleting the external network
         succeeds.
         """
         logger = Environment.get_default_logger()

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -225,13 +225,7 @@ class TestExtNet(BaseTestCase):
                 ip_scope = scope
                 break
         self.assertIsNotNone(ip_scope)
-
-        _ip_ranges = TestExtNet._ip_range3.split('-')
-        _ip_range3_start_address = _ip_ranges[0]
-        _ip_range3_end_address = _ip_ranges[1]
-        for ip_range in ip_scope.IpRanges.IpRange:
-            if ip_range.StartAddress == _ip_range3_start_address:
-                self.assertEqual(ip_range.EndAddress, _ip_range3_end_address)
+        self.validate_ip_range(ip_scope, TestExtNet._ip_range3)
 
     def test_0050_modify_ip_range(self):
         """Test the method externalNetwork.modify_ip_range()
@@ -262,12 +256,16 @@ class TestExtNet(BaseTestCase):
                  ip_scope = scope
                  break
         self.assertIsNotNone(ip_scope)
-        _ip_ranges = TestExtNet._ip_range4.split('-')
-        _ip_range4_start_address = _ip_ranges[0]
-        _ip_range4_end_address = _ip_ranges[1]
+        self.validate_ip_range(ip_scope, TestExtNet._ip_range4)
+
+    def validate_ip_range(self, ip_scope, _ip_range1):
+        """ Validate if the ip range present in the existing ip ranges """
+        _ip_ranges = _ip_range1.split('-')
+        _ip_range1_start_address = _ip_ranges[0]
+        _ip_range1_end_address = _ip_ranges[1]
         for ip_range in ip_scope.IpRanges.IpRange:
-            if ip_range.StartAddress == _ip_range4_start_address:
-                 self.assertEqual(ip_range.EndAddress, _ip_range4_end_address)
+            if ip_range.StartAddress == _ip_range1_start_address:
+                self.assertEqual(ip_range.EndAddress, _ip_range1_end_address)
 
     @developerModeAware
     def test_9998_teardown(self):
@@ -293,7 +291,6 @@ class TestExtNet(BaseTestCase):
         ext_net_resource = platform.get_external_network(self._name)
         return ExternalNetwork(TestExtNet._sys_admin_client,
                                resource=ext_net_resource)
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Attach port groups to an external network.
Note: Only same type of portgroups are allowed to attach to external network.

Testing done:
Verified portgroup attached from "vc2" is successful.
Verified portgroup attached from "vc3" is also successful.
System tests passed.
Verified for multiple VCD versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/338)
<!-- Reviewable:end -->
