### PR TITLE
VP-1257: Attach port groups to an external network

### DIFF
--- a/pyvcloud/vcd/external_network.py
+++ b/pyvcloud/vcd/external_network.py
@@ -258,12 +258,16 @@ class ExternalNetwork(object):
         """
         ext_net = self.get_resource()
         platform = Platform(self.client)
-        if vim_server_name and port_group_name is not None:
-            vc_record = platform.get_vcenter(vim_server_name)
-            vc_href = vc_record.get('href')
-            pg_moref_types =  \
-                platform.get_port_group_moref_types(vim_server_name,
-                                                    port_group_name)
+
+        if not vim_server_name or not port_group_name:
+            raise InvalidParameterException(
+                "Either vCenter Server name is none or portgroup name is none")
+
+        vc_record = platform.get_vcenter(vim_server_name)
+        vc_href = vc_record.get('href')
+        pg_moref_types =  \
+            platform.get_port_group_moref_types(vim_server_name,
+                                                port_group_name)
 
         if hasattr(ext_net,
                    '{' + NSMAP['vmext'] + '}VimPortGroupRef'):

--- a/pyvcloud/vcd/external_network.py
+++ b/pyvcloud/vcd/external_network.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pyvcloud.vcd.client import E
+from pyvcloud.vcd.client import E_VMEXT
 from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import NSMAP
 from pyvcloud.vcd.client import RelationType
@@ -243,3 +244,68 @@ class ExternalNetwork(object):
                                 media_type=EntityType.
                                 EXTERNAL_NETWORK.value,
                                 contents=ext_net)
+
+    def attach_port_group(self, vim_server_name, port_group_name):
+        """Attach a portgroup to an external network.
+
+        :param str vc_name: name of vc where portgroup is present.
+        :param str pg_name: name of the portgroup to be attached to
+             external network.
+
+        return: object containing vmext:VMWExternalNetwork XML element that
+             representing the external network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        if self.resource is None:
+            self.reload()
+        ext_net = self.resource
+        platform = Platform(self.client)
+        vc_record = platform.get_vcenter(vim_server_name)
+        vc_href = vc_record.get('href')
+        pg_moref_types = \
+            platform.get_port_group_moref_types(vim_server_name,
+                                                port_group_name)
+
+        if hasattr(ext_net,
+                   '{' + NSMAP['vmext'] + '}VimPortGroupRef'):
+            vim_port_group_refs = E_VMEXT.VimPortGroupRefs()
+            vim_object_ref1 = self.__create_vimobj_ref(
+                vc_href,
+                pg_moref_types[0],
+                pg_moref_types[1])
+
+            vim_pg_ref = ext_net['{' + NSMAP['vmext'] + '}VimPortGroupRef']
+            vc2_href = vim_pg_ref.VimServerRef.get('href')
+            vim_object_ref2 = self.__create_vimobj_ref(
+                vc2_href,
+                vim_pg_ref.MoRef.text,
+                vim_pg_ref.VimObjectType.text)
+
+            vim_port_group_refs.append(vim_object_ref1)
+            vim_port_group_refs.append(vim_object_ref2)
+            ext_net.remove(vim_pg_ref)
+        else:
+            vim_port_group_refs = \
+                ext_net['{' + NSMAP['vmext'] + '}VimPortGroupRefs']
+            vim_object_ref1 = self.__create_vimobj_ref(
+                vc_href,
+                pg_moref_types[0],
+                pg_moref_types[1])
+            vim_port_group_refs.append(vim_object_ref1)
+
+        ext_net.append(vim_port_group_refs)
+
+        return self.client. \
+            put_linked_resource(ext_net, rel=RelationType.EDIT,
+                                media_type=EntityType.
+                                EXTERNAL_NETWORK.value,
+                                contents=ext_net)
+
+    def __create_vimobj_ref(self, vc_href, pg_moref, pg_type):
+        """Creates the VimObjectRef."""
+        vim_object_ref = E_VMEXT.VimObjectRef()
+        vim_object_ref.append(E_VMEXT.VimServerRef(href=vc_href))
+        vim_object_ref.append(E_VMEXT.MoRef(pg_moref))
+        vim_object_ref.append(E_VMEXT.VimObjectType(pg_type))
+
+        return vim_object_ref

--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -1000,3 +1000,36 @@ class Platform(object):
             query_result_format=QueryResultFormat.RECORDS)
 
         return query.execute()
+
+    def get_port_group_moref_types(self, vim_server_name, port_group_name):
+        """Fetches moref and type for a given list of port group name.
+
+        :return: list of tuples containing port group moref and type.
+
+        :rtype: list
+
+        :raises: EntityNotFoundException: if any port group names cannot be
+        found.
+        """
+        vcfilter = 'vcName==%s' % urllib.parse.quote_plus(vim_server_name)
+        query = self.client.get_typed_query(
+            ResourceType.PORT_GROUP.value,
+            qfilter=vcfilter,
+            query_result_format=QueryResultFormat.RECORDS)
+        records = list(query.execute())
+        port_groups = {}
+        for record in records:
+            port_groups[record.get('name')] = ((record.get('moref'),
+                                                record.get('portgroupType')))
+        port_group_moref_types = []
+        for port_group in port_groups:
+            port_group_found = False
+            if port_group_name == port_group:
+                port_group_found = True
+                port_group_moref_types.append(port_groups[port_group_name][0])
+                port_group_moref_types.append(port_groups[port_group_name][1])
+                break
+        if not port_group_found:
+            raise EntityNotFoundException(
+                'port group \'%s\' not Found' % port_group_name)
+        return port_group_moref_types

--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -1002,13 +1002,15 @@ class Platform(object):
         return query.execute()
 
     def get_port_group_moref_types(self, vim_server_name, port_group_name):
-        """Fetches moref and type for a given list of port group name.
+        """Fetches portgroup moref and portgroup type(DV_PORTGROUP or NETWORK).
+
+        Using portgroup name in particular vCenter.
 
         :return: list of tuples containing port group moref and type.
 
         :rtype: list
 
-        :raises: EntityNotFoundException: if any port group names cannot be
+        :raises: EntityNotFoundException: if any port group name cannot be
         found.
         """
         vcfilter = 'vcName==%s' % urllib.parse.quote_plus(vim_server_name)
@@ -1017,19 +1019,43 @@ class Platform(object):
             qfilter=vcfilter,
             query_result_format=QueryResultFormat.RECORDS)
         records = list(query.execute())
-        port_groups = {}
-        for record in records:
-            port_groups[record.get('name')] = ((record.get('moref'),
-                                                record.get('portgroupType')))
+
         port_group_moref_types = []
-        for port_group in port_groups:
-            port_group_found = False
-            if port_group_name == port_group:
-                port_group_found = True
-                port_group_moref_types.append(port_groups[port_group_name][0])
-                port_group_moref_types.append(port_groups[port_group_name][1])
+        for record in records:
+            if record.get('name') == port_group_name:
+                port_group_moref_types.append(record.get('moref'))
+                port_group_moref_types.append(record.get('portgroupType'))
                 break
-        if not port_group_found:
+        if not port_group_moref_types:
             raise EntityNotFoundException(
                 'port group \'%s\' not Found' % port_group_name)
         return port_group_moref_types
+
+    def get_pgroup_name(self, vim_server_name, portgroupType):
+        """Fetches portgroup name using portgroup type(DV_PORTGROUP or NETWORK).
+
+        Query uses vCenter Server name as filter.
+
+        :param str vim_server_name: vCenter server name
+        :param str portgroupType: type of port group
+        :return: name of the portgroup
+        :rtype: str
+        :raises: EntityNotFoundException: if any port group cannot be found.
+        """
+        name_filter = ('vcName', vim_server_name)
+        query = self.client.get_typed_query(
+            ResourceType.PORT_GROUP.value,
+            query_result_format=QueryResultFormat.RECORDS,
+            equality_filter=name_filter)
+        pgroup_name = ''
+        for record in list(query.execute()):
+            if record.get('networkName') == '--':
+                if record.get('portgroupType') == portgroupType  \
+                   and not record.get('name').startswith('vxw-'):
+                    pgroup_name = record.get('name')
+                    break
+        if not pgroup_name:
+            raise EntityNotFoundException('port group not found in'
+                                          'vCenter : ' + vim_server_name)
+
+        return pgroup_name

--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -1030,32 +1030,3 @@ class Platform(object):
             raise EntityNotFoundException(
                 'port group \'%s\' not Found' % port_group_name)
         return port_group_moref_types
-
-    def get_pgroup_name(self, vim_server_name, portgroupType):
-        """Fetches portgroup name using portgroup type(DV_PORTGROUP or NETWORK).
-
-        Query uses vCenter Server name as filter.
-
-        :param str vim_server_name: vCenter server name
-        :param str portgroupType: type of port group
-        :return: name of the portgroup
-        :rtype: str
-        :raises: EntityNotFoundException: if any port group cannot be found.
-        """
-        name_filter = ('vcName', vim_server_name)
-        query = self.client.get_typed_query(
-            ResourceType.PORT_GROUP.value,
-            query_result_format=QueryResultFormat.RECORDS,
-            equality_filter=name_filter)
-        pgroup_name = ''
-        for record in list(query.execute()):
-            if record.get('networkName') == '--':
-                if record.get('portgroupType') == portgroupType  \
-                   and not record.get('name').startswith('vxw-'):
-                    pgroup_name = record.get('name')
-                    break
-        if not pgroup_name:
-            raise EntityNotFoundException('port group not found in'
-                                          'vCenter : ' + vim_server_name)
-
-        return pgroup_name

--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -23,10 +23,10 @@ logging:
 vcd:
 # Fill in the vCloud Dirctor host, sysadmin credentials and other related
 # information here. These will be required for the tests to run.
-  host: '<vcd ip>'
-  api_version: '30.0'
+  host: 'bos1-vcd-sp-static-199-53.eng.vmware.com'
+  api_version: '31.0'
   sys_admin_username: 'administrator'
-  sys_admin_pass: '<root-password>'
+  sys_admin_pass: 'ca$hc0w'
   sys_org_name: 'System'
 
 # The following params defines the org, pvdc, ovdc, etc. that the tests will
@@ -64,6 +64,7 @@ vc:
   vcenter_host_ip: '<vc ip>'
   vcenter_admin_username: 'administrator@vsphere.local'
   vcenter_admin_password: '<vc root password>'
+  vcenter1_host_name: 'vc2'
 
 nsx:
   nsx_hostname: 'nsx1'

--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -23,10 +23,10 @@ logging:
 vcd:
 # Fill in the vCloud Dirctor host, sysadmin credentials and other related
 # information here. These will be required for the tests to run.
-  host: 'bos1-vcd-sp-static-199-53.eng.vmware.com'
-  api_version: '31.0'
+  host: '<vcd ip>'
+  api_version: '30.0'
   sys_admin_username: 'administrator'
-  sys_admin_pass: 'ca$hc0w'
+  sys_admin_pass: '<root-password>'
   sys_org_name: 'System'
 
 # The following params defines the org, pvdc, ovdc, etc. that the tests will
@@ -64,7 +64,12 @@ vc:
   vcenter_host_ip: '<vc ip>'
   vcenter_admin_username: 'administrator@vsphere.local'
   vcenter_admin_password: '<vc root password>'
-  vcenter1_host_name: 'vc2'
+
+vc2:
+  vcenter_host_name: 'vc2'
+  vcenter_host_ip: '<vc2 ip>'
+  vcenter_admin_username: 'administrator@vsphere.local'
+  vcenter_admin_password: '<vc root password>'
 
 nsx:
   nsx_hostname: 'nsx1'

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -68,7 +68,8 @@ class TestExtNet(BaseTestCase):
         platform = Platform(TestExtNet._sys_admin_client)
         vc_name = TestExtNet._config['vc']['vcenter_host_name']
         portgrouphelper = PortgroupHelper(TestExtNet._sys_admin_client)
-        pg_name = portgrouphelper.get_pgroup_name(vc_name, TestExtNet._portgroupType)
+        pg_name = portgrouphelper.get_available_portgroup_name(vc_name,
+            TestExtNet._portgroupType)
 
         ext_net = platform.create_external_network(
             name=TestExtNet._name,
@@ -266,7 +267,8 @@ class TestExtNet(BaseTestCase):
         platform = Platform(TestExtNet._sys_admin_client)
         vc_name = TestExtNet._config['vc2']['vcenter_host_name']
         portgrouphelper = PortgroupHelper(TestExtNet._sys_admin_client)
-        pg_name = portgrouphelper.get_pgroup_name(vc_name, TestExtNet._portgroupType)
+        pg_name = portgrouphelper.get_available_portgroup_name(vc_name,
+            TestExtNet._portgroupType)
 
         ext_net = self._get_ext_net(platform).attach_port_group(
             vc_name,

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -16,6 +16,7 @@
 import unittest
 from uuid import uuid1
 
+from helpers.portgroup_helper import PortgroupHelper
 from pyvcloud.system_test_framework.base_test import BaseTestCase
 from pyvcloud.system_test_framework.environment import developerModeAware
 from pyvcloud.system_test_framework.environment import Environment
@@ -66,26 +67,13 @@ class TestExtNet(BaseTestCase):
 
         platform = Platform(TestExtNet._sys_admin_client)
         vc_name = TestExtNet._config['vc']['vcenter_host_name']
-        name_filter = ('vcName', vc_name)
-        query = TestExtNet._sys_admin_client.get_typed_query(
-            ResourceType.PORT_GROUP.value,
-            query_result_format=QueryResultFormat.RECORDS,
-            equality_filter=name_filter)
-
-        for record in list(query.execute()):
-            if record.get('networkName') == '--':
-                if record.get('portgroupType') == TestExtNet._portgroupType  \
-                    and not record.get('name').startswith('vxw-'):
-                    TestExtNet._port_group = record.get('name')
-                    break
-
-        self.assertIsNotNone(self._port_group,
-                             'None of the port groups are free.')
+        portgrouphelper = PortgroupHelper(TestExtNet._sys_admin_client)
+        pg_name = portgrouphelper.get_pgroup_name(vc_name, TestExtNet._portgroupType)
 
         ext_net = platform.create_external_network(
             name=TestExtNet._name,
             vim_server_name=vc_name,
-            port_group_names=[TestExtNet._port_group],
+            port_group_names= [pg_name],
             gateway_ip=TestExtNet._gateway,
             netmask=TestExtNet._netmask,
             ip_ranges=[TestExtNet._ip_range],
@@ -276,13 +264,13 @@ class TestExtNet(BaseTestCase):
        """
         logger = Environment.get_default_logger()
         platform = Platform(TestExtNet._sys_admin_client)
-        vim_server_name = TestExtNet._config['vc2']['vcenter_host_name']
+        vc_name = TestExtNet._config['vc2']['vcenter_host_name']
+        portgrouphelper = PortgroupHelper(TestExtNet._sys_admin_client)
+        pg_name = portgrouphelper.get_pgroup_name(vc_name, TestExtNet._portgroupType)
 
-        pgroup_name = platform.get_pgroup_name(vim_server_name,
-            TestExtNet._portgroupType)
         ext_net = self._get_ext_net(platform).attach_port_group(
-            vim_server_name,
-            pgroup_name)
+            vc_name,
+            pg_name)
         task = ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0]
         TestExtNet._sys_admin_client.get_task_monitor().wait_for_success(
         task=task)
@@ -291,7 +279,7 @@ class TestExtNet(BaseTestCase):
         + TestExtNet._name + '.')
         ext_net = platform.get_external_network(self._name)
         self.assertIsNotNone(ext_net)
-        vc_record = platform.get_vcenter(vim_server_name)
+        vc_record = platform.get_vcenter(vc_name)
         vc_href = vc_record.get('href')
         vim_port_group_refs = \
             ext_net['{' + NSMAP['vmext'] + '}VimPortGroupRefs']

--- a/system_tests/helpers/portgroup_helper.py
+++ b/system_tests/helpers/portgroup_helper.py
@@ -29,10 +29,11 @@ class PortgroupHelper(object):
         """
         self.client = client
 
-    def get_pgroup_name(self, vim_server_name, portgroupType):
+    def get_available_portgroup_name(self, vim_server_name, portgroupType):
         """Fetches portgroup name using portgroup type(DV_PORTGROUP or NETWORK).
 
-        Query uses vCenter Server name as filter.
+        Query uses vCenter Server name as filter and returns the first available
+        portgroup
 
         :param str vim_server_name: vCenter server name
         :param str portgroupType: type of port group

--- a/system_tests/helpers/portgroup_helper.py
+++ b/system_tests/helpers/portgroup_helper.py
@@ -1,0 +1,59 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyvcloud.vcd.client import QueryResultFormat
+from pyvcloud.vcd.client import ResourceType
+from pyvcloud.vcd.exceptions import EntityNotFoundException
+
+
+class PortgroupHelper(object):
+    """Helper class to get the portgroup details(name, moref or type)"""
+
+    def __init__(self, client):
+        """Constructor for PortgroupHelper object.
+
+        :param pyvcloud.vcd.client.Client client: the client that will be used
+            to make REST calls to vCD.
+        """
+        self.client = client
+
+    def get_pgroup_name(self, vim_server_name, portgroupType):
+        """Fetches portgroup name using portgroup type(DV_PORTGROUP or NETWORK).
+
+        Query uses vCenter Server name as filter.
+
+        :param str vim_server_name: vCenter server name
+        :param str portgroupType: type of port group
+        :return: name of the portgroup
+        :rtype: str
+        :raises: EntityNotFoundException: if any port group cannot be found.
+        """
+        name_filter = ('vcName', vim_server_name)
+        query = self.client.get_typed_query(
+            ResourceType.PORT_GROUP.value,
+            query_result_format=QueryResultFormat.RECORDS,
+            equality_filter=name_filter)
+        pgroup_name = ''
+        for record in list(query.execute()):
+            if record.get('networkName') == '--':
+                if record.get('portgroupType') == portgroupType  \
+                   and not record.get('name').startswith('vxw-'):
+                    pgroup_name = record.get('name')
+                    break
+        if not pgroup_name:
+            raise EntityNotFoundException('port group not found in'
+                                          'vCenter : ' + vim_server_name)
+
+        return pgroup_name


### PR DESCRIPTION
Attach port groups of same type to an external network.

Testing done:
Verified portgroup attached from "vc2" is successful.
Verified portgroup attached from "vc3" is also successful.
System tests :passed
Verified for multiple vcd api versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/339)
<!-- Reviewable:end -->
