### PR TITLE
VP-1450:List available portgroups in a vCenter

### DIFF
--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -1031,10 +1031,10 @@ class Platform(object):
                 'port group \'%s\' not Found' % port_group_name)
         return port_group_moref_types
 
-    def list_port_group_names(self, vim_server_name):
+    def list_available_port_group_names(self, vim_server_name):
         """Fetches the list of portgroup name in a particular vCenter.
 
-        :return: list of portgroup name. ex- VM Network
+        :return: list of available portgroup name. ex- VM Network
 
         :rtype: list
 

--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -1030,3 +1030,27 @@ class Platform(object):
             raise EntityNotFoundException(
                 'port group \'%s\' not Found' % port_group_name)
         return port_group_moref_types
+
+    def list_port_group_names(self, vim_server_name):
+        """Fetches the list of portgroup name in a particular vCenter.
+
+        :return: list of portgroup name. ex- VM Network
+
+        :rtype: list
+
+        :raises: EntityNotFoundException: if any port group name cannot be
+        found.
+        """
+        vcfilter = 'vcName==%s' % urllib.parse.quote_plus(vim_server_name)
+        query = self.client.get_typed_query(
+            ResourceType.PORT_GROUP.value,
+            qfilter=vcfilter,
+            query_result_format=QueryResultFormat.RECORDS)
+        records = list(query.execute())
+
+        port_group_names = [record.get('name') for record in records
+                            if (record.get('networkName') == '--' and
+                                not record.get('name').startswith('vxw-'))]
+        if not port_group_names:
+            raise EntityNotFoundException('No port group name found')
+        return port_group_names

--- a/system_tests/vc_tests.py
+++ b/system_tests/vc_tests.py
@@ -60,11 +60,12 @@ class TestVC(BaseTestCase):
                      (vcenter.get('name'), vcenter.Url.text))
         self.assertIsNotNone(vcenter)
 
-    def test_0021_list_port_group_names(self):
+    def test_0021_list_available_port_group_names(self):
         """Test the method Platform.list_port_group_names, this method fetches
         list of portgroup name for a particular vCenter"""
         platform = Platform(TestVC._client)
-        port_group_names = platform.list_port_group_names(TestVC._vcenter_host_name)
+        port_group_names = \
+            platform.list_available_port_group_names(TestVC._vcenter_host_name)
         self.assertTrue(len(port_group_names) > 0)
 
     def test_0030_get_vc_negative(self):

--- a/system_tests/vc_tests.py
+++ b/system_tests/vc_tests.py
@@ -60,6 +60,13 @@ class TestVC(BaseTestCase):
                      (vcenter.get('name'), vcenter.Url.text))
         self.assertIsNotNone(vcenter)
 
+    def test_0021_list_port_group_names(self):
+        """Test the method Platform.list_port_group_names, this method fetches
+        list of portgroup name for a particular vCenter"""
+        platform = Platform(TestVC._client)
+        port_group_names = platform.list_port_group_names(TestVC._vcenter_host_name)
+        self.assertTrue(len(port_group_names) > 0)
+
     def test_0030_get_vc_negative(self):
         """Platform.get_vcenter does not find a non-existent vcenter."""
         try:


### PR DESCRIPTION
List available portgroup names in a particular vCenter.
Note: 
This will be used by attach portgroup cli.

Testing done:
system test passed
Verified in the test environment that it prints correct values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/343)
<!-- Reviewable:end -->
