### PR TITLE
VP-1298:Remove Suballocate ip pool of gateway

### DIFF
--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -560,7 +560,7 @@ class Gateway(object):
         :param ext_network: external network connected to the gateway.
 
         :param ip_ranges: list of IP ranges that needs to be removed.
-            For example, .... For example, [192.168.1.2-192.168.1.49,
+            For example, [192.168.1.2-192.168.1.49,
             192.168.1.100-192.168.1.149]
 
         :return: object containing EntityType.TASK XML data representing the

--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -543,7 +543,7 @@ class Gateway(object):
         :param existing_ip_ranges: existing ip range present in the sub
                 allocate pool.
 
-        :param ip_ranges: ip range tha needs to be removed.
+        :param ip_ranges: ip range needs to be removed.
         """
         for exist_range in existing_ip_ranges.IpRange:
             for remove_range in ip_ranges:
@@ -555,7 +555,7 @@ class Gateway(object):
                     existing_ip_ranges.remove(exist_range)
 
     def remove_sub_allocated_ip_pools(self, ext_network, ip_ranges):
-        """removes new ip range present to the sub allocate pool of gateway.
+        """Removes new ip range present to the sub allocate pool of gateway.
 
         :param ext_network: external network connected to the gateway.
 

--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -538,12 +538,12 @@ class Gateway(object):
                                                gateway)
 
     def __remove_ip_range_elements(self, existing_ip_ranges, ip_ranges):
-        """Removes to the existing ip range present in the sub allocate pool.
+        """Removes the given IP ranges from existing IP ranges.
 
-        :param existing_ip_ranges: existing ip range present in the sub
+        :param existing_ip_ranges: existing IP range present in the sub
                 allocate pool.
 
-        :param ip_ranges: ip range needs to be removed.
+        :param ip_ranges: IP ranges that needs to be removed.
         """
         for exist_range in existing_ip_ranges.IpRange:
             for remove_range in ip_ranges:
@@ -555,12 +555,12 @@ class Gateway(object):
                     existing_ip_ranges.remove(exist_range)
 
     def remove_sub_allocated_ip_pools(self, ext_network, ip_ranges):
-        """Removes new ip range present to the sub allocate pool of gateway.
+        """Removes the given IP ranges from the sub allocated pool..
 
         :param ext_network: external network connected to the gateway.
 
-        :param ip_ranges: list of IP ranges used for static pool
-            allocation in the network. For example, [192.168.1.2-192.168.1.49,
+        :param ip_ranges: list of IP ranges that needs to be removed.
+            For example, .... For example, [192.168.1.2-192.168.1.49,
             192.168.1.100-192.168.1.149]
 
         :return: object containing EntityType.TASK XML data representing the

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -145,7 +145,6 @@ class TestGateway(BaseTestCase):
             ip_allocations = gateway_obj.list_external_network_ip_allocations()
             self.assertTrue(bool(ip_allocations))
 
-    @unittest.skip("skipping test_0005_redeploy")
     def test_0005_redeploy(self):
         """Redeploy the gateway.
 
@@ -159,7 +158,6 @@ class TestGateway(BaseTestCase):
                 task=task)
             self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
-    @unittest.skip("skipping test_0005_redeploy")
     def test_0006_sync_syslog_settings(self):
         """Sync syslog settings of the gateway.
 
@@ -188,7 +186,6 @@ class TestGateway(BaseTestCase):
             exnet = ip_allocations[0].get('external_network')
             self.assertEqual(external_networks[0].get('name'), exnet)
 
-    @unittest.skip("skipping test_0005_redeploy")
     def _create_external_network(self):
         """Creates an external network from the available portgroup."""
         vc_name = TestGateway._config['vc']['vcenter_host_name']
@@ -228,7 +225,6 @@ class TestGateway(BaseTestCase):
         TestGateway._external_network2 = ext_net
         return ext_net
 
-    @unittest.skip("skipping test_0005_redeploy")
     def _delete_external_network(self, network):
         logger = Environment.get_default_logger()
         platform = Platform(TestGateway._client)
@@ -236,7 +232,6 @@ class TestGateway(BaseTestCase):
         TestGateway._client.get_task_monitor().wait_for_success(task=task)
         logger.debug('Deleted external network ' + network.get('name') + '.')
 
-    @unittest.skip("skipping test_0005_redeploy")
     def test_0008_add_external_network(self):
         """Add an exernal netowrk to the gateway.
 
@@ -261,7 +256,6 @@ class TestGateway(BaseTestCase):
             task=task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
-    @unittest.skip("skipping test_0005_redeploy")
     def test_0009_remove_external_network(self):
         """Remove an exernal netowrk from the gateway.
 
@@ -277,7 +271,6 @@ class TestGateway(BaseTestCase):
 
         self._delete_external_network(TestGateway._external_network2)
 
-    @unittest.skip("skipping test_0005_redeploy")
     def test_0010_edit_gateway_name(self):
         """Edit the gateway name.
 


### PR DESCRIPTION
VP-1298:Remove Sub allocate ip pool of gateway
Removes the sub allocate ip ranges of the gateway.
made changes to gateway.py and gateway_test.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/345)
<!-- Reviewable:end -->
