### PR TITLE
VP1259: [PySdk] Detach port groups from an external network

### DIFF
--- a/pyvcloud/vcd/external_network.py
+++ b/pyvcloud/vcd/external_network.py
@@ -319,8 +319,9 @@ class ExternalNetwork(object):
     def detach_port_group(self, vim_server_name, port_group_name):
         """Detach a portgroup from an external network.
 
-        :param str vc_name: name of vc where portgroup is present.
-        :param str pg_name: name of the portgroup to be detached from
+        :param str vim_server_name: name of vim server where
+        portgroup is present.
+        :param str port_group_name: name of the portgroup to be detached from
              external network.
 
         return: object containing vmext:VMWExternalNetwork XML element that
@@ -336,12 +337,16 @@ class ExternalNetwork(object):
 
         vc_record = platform.get_vcenter(vim_server_name)
         vc_href = vc_record.get('href')
-        pg_moref_types = \
-            platform.get_port_group_moref_types(vim_server_name,
-                                                port_group_name)
+        if hasattr(ext_net, 'VimPortGroupRefs'):
+            pg_moref_types = \
+                platform.get_port_group_moref_types(vim_server_name,
+                                                    port_group_name)
+        else:
+            raise \
+                InvalidParameterException("External network"
+                                          " has only one port group")
 
-        vim_port_group_refs = \
-            ext_net['{' + NSMAP['vmext'] + '}VimPortGroupRefs']
+        vim_port_group_refs = ext_net.VimPortGroupRefs
         vim_obj_refs = vim_port_group_refs.VimObjectRef
         for vim_obj_ref in vim_obj_refs:
             if vim_obj_ref.VimServerRef.get('href') == vc_href \

--- a/pyvcloud/vcd/external_network.py
+++ b/pyvcloud/vcd/external_network.py
@@ -340,10 +340,12 @@ class ExternalNetwork(object):
             platform.get_port_group_moref_types(vim_server_name,
                                                 port_group_name)
 
-        vim_port_group_refs = ext_net['{' + NSMAP['vmext'] + '}VimPortGroupRefs']
+        vim_port_group_refs = \
+            ext_net['{' + NSMAP['vmext'] + '}VimPortGroupRefs']
         vim_obj_refs = vim_port_group_refs.VimObjectRef
         for vim_obj_ref in vim_obj_refs:
-            if vim_obj_ref.VimServerRef.get('href') == vc_href and vim_obj_ref.MoRef == pg_moref_types[0] \
+            if vim_obj_ref.VimServerRef.get('href') == vc_href \
+                    and vim_obj_ref.MoRef == pg_moref_types[0] \
                     and vim_obj_ref.VimObjectType == pg_moref_types[1]:
                 vim_port_group_refs.remove(vim_obj_ref)
 

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -293,15 +293,15 @@ class TestExtNet(BaseTestCase):
         self.assertTrue(vc_href_found)
 
     def test_0061_detach_port_group(self):
-        """Detach a portgroup to an external network
+        """Detach a portgroup from an external network
        This test passes if the portgroup from another vCenter is removed
        from external network successfully.
        """
         logger = Environment.get_default_logger()
         platform = Platform(TestExtNet._sys_admin_client)
         vc_name = TestExtNet._config['vc2']['vcenter_host_name']
-        portgrouphelper = PortgroupHelper(TestExtNet._sys_admin_client)
-        pg_name = portgrouphelper.get_ext_net_portgroup_name(vc_name, self._name, TestExtNet._portgroupType)
+        port_group_helper = PortgroupHelper(TestExtNet._sys_admin_client)
+        pg_name = port_group_helper.get_ext_net_portgroup_name(vc_name, self._name)
 
         ext_net = self._get_ext_net(platform).detach_port_group(vc_name, pg_name)
         task = ext_net['{' + NSMAP['vcloud'] + '}Tasks'].Task[0]
@@ -311,8 +311,7 @@ class TestExtNet(BaseTestCase):
         self.assertIsNotNone(ext_net)
         vc_record = platform.get_vcenter(vc_name)
         vc_href = vc_record.get('href')
-        vim_port_group_ref = \
-            ext_net['{' + NSMAP['vmext'] + '}VimPortGroupRef']
+        vim_port_group_ref = ext_net.VimPortGroupRef
         vc_href_found = False
 
         if vim_port_group_ref.VimServerRef.get('href') == vc_href:

--- a/system_tests/helpers/portgroup_helper.py
+++ b/system_tests/helpers/portgroup_helper.py
@@ -49,8 +49,40 @@ class PortgroupHelper(object):
         pgroup_name = ''
         for record in list(query.execute()):
             if record.get('networkName') == '--':
-                if record.get('portgroupType') == portgroupType  \
-                   and not record.get('name').startswith('vxw-'):
+                if record.get('portgroupType') == portgroupType \
+                        and not record.get('name').startswith('vxw-'):
+                    pgroup_name = record.get('name')
+                    break
+        if not pgroup_name:
+            raise EntityNotFoundException('port group not found in'
+                                          'vCenter : ' + vim_server_name)
+
+        return pgroup_name
+
+    def get_ext_net_portgroup_name(self, vim_server_name, ext_net_name, port_group_type):
+        """Fetches portgroup name using portgroup type(DV_PORTGROUP or NETWORK).
+
+        Query uses vCenter Server name as filter and returns the first available
+        portgroup
+
+        :param str vim_server_name: vCenter server name
+        :param str ext_net_name: external network name
+        :param str port_group_type: port group type
+        :return: name of the portgroup
+        :rtype: str
+        :raises: EntityNotFoundException: if any port group cannot be found.
+        """
+        name_filter = ('vcName', vim_server_name)
+
+        query = self.client.get_typed_query(
+            ResourceType.PORT_GROUP.value,
+            query_result_format=QueryResultFormat.RECORDS,
+            equality_filter=name_filter)
+        pgroup_name = ''
+        for record in list(query.execute()):
+            if record.get('networkName') == ext_net_name:
+                if record.get('portgroupType') == port_group_type \
+                        and not record.get('name').startswith('vxw-'):
                     pgroup_name = record.get('name')
                     break
         if not pgroup_name:

--- a/system_tests/helpers/portgroup_helper.py
+++ b/system_tests/helpers/portgroup_helper.py
@@ -80,8 +80,8 @@ class PortgroupHelper(object):
             equality_filter=name_filter)
         pgroup_name = ''
         for record in list(query.execute()):
-            if record.get('networkName') == ext_net_name:
-                if not record.get('name').startswith('vxw-'):
+            if record.get('networkName') == ext_net_name \
+                    and not record.get('name').startswith('vxw-'):
                     pgroup_name = record.get('name')
                     break
         if not pgroup_name:

--- a/system_tests/helpers/portgroup_helper.py
+++ b/system_tests/helpers/portgroup_helper.py
@@ -59,15 +59,15 @@ class PortgroupHelper(object):
 
         return pgroup_name
 
-    def get_ext_net_portgroup_name(self, vim_server_name, ext_net_name, port_group_type):
-        """Fetches portgroup name using portgroup type(DV_PORTGROUP or NETWORK).
+    def get_ext_net_portgroup_name(self, vim_server_name, ext_net_name):
+        """Fetches portgroup name using portgroup type(DV_PORTGROUP or NETWORK)
+         which is used by given external network.
 
         Query uses vCenter Server name as filter and returns the first available
         portgroup
 
         :param str vim_server_name: vCenter server name
         :param str ext_net_name: external network name
-        :param str port_group_type: port group type
         :return: name of the portgroup
         :rtype: str
         :raises: EntityNotFoundException: if any port group cannot be found.
@@ -81,8 +81,7 @@ class PortgroupHelper(object):
         pgroup_name = ''
         for record in list(query.execute()):
             if record.get('networkName') == ext_net_name:
-                if record.get('portgroupType') == port_group_type \
-                        and not record.get('name').startswith('vxw-'):
+                if not record.get('name').startswith('vxw-'):
                     pgroup_name = record.get('name')
                     break
         if not pgroup_name:


### PR DESCRIPTION
[PySdk] Detach port groups from an external network

This code has both functionality and test case for detaching port group
from external network.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/346)
<!-- Reviewable:end -->
