### PR TITLE
Revert to lazy loading of resource during initialization of VDC objects.

### DIFF
--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -37,15 +37,11 @@ class Gateway(object):
         """
         self.client = client
         self.name = name
-        if href is None:
+        if href is None and resource is None:
             raise InvalidParameterException(
                 "Gateway initialization failed as arguments are either "
                 "invalid or None")
         self.href = href
-        if resource is None:
-            self.resource = None
-            self.get_resource()
-
         self.resource = resource
         if resource is not None:
             self.name = resource.get('name')

--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -257,8 +257,7 @@ class Gateway(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        if self.resource is None:
-            self.reload()
+        self.get_resource()
 
         gateway = self.resource
         for inf in gateway.Configuration.GatewayInterfaces.GatewayInterface:
@@ -315,8 +314,7 @@ class Gateway(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        if self.resource is None:
-            self.reload()
+        self.get_resource()
 
         gateway = self.resource
         interfaces = gateway.Configuration.GatewayInterfaces

--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -83,8 +83,7 @@ class Gateway(object):
         :rtype: lxml.objectify.ObjectifiedElement
 
         """
-        if self.resource is None:
-            self.reload()
+        self.get_resource()
 
         return self.client.post_linked_resource(
             self.resource, RelationType.CONVERT_TO_ADVANCED_GATEWAY, None,
@@ -100,8 +99,7 @@ class Gateway(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        if self.resource is None:
-            self.reload()
+        self.get_resource()
         gateway = self.resource
         current_dr_status = gateway.Configuration.DistributedRoutingEnabled
         if enable == current_dr_status:
@@ -168,8 +166,7 @@ class Gateway(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        if self.resource is None:
-            self.reload()
+        self.get_resource()
 
         return self.client.post_linked_resource(
             self.resource, RelationType.GATEWAY_REDEPLOY, None, None)
@@ -182,8 +179,7 @@ class Gateway(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        if self.resource is None:
-            self.reload()
+        self.get_resource()
 
         return self.client.post_linked_resource(
             self.resource, RelationType.GATEWAY_SYNC_SYSLOG_SETTINGS, None,

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -48,14 +48,11 @@ class VDC(object):
         """
         self.client = client
         self.name = name
-        if href is None:
+        if href is None and resource is None:
             raise InvalidParameterException(
                 "VDC initialization failed as arguments are either invalid "
                 "or None")
         self.href = href
-        if resource is None:
-            self.resource = None
-            self.get_resource()
         self.resource = resource
         if resource is not None:
             self.name = resource.get('name')

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -89,8 +89,7 @@ class VDC(object):
         :raises: MultipleRecordsException: if more than one vApp with the
             provided name are found.
         """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
         result = []
         if hasattr(self.resource, 'ResourceEntities') and \
            hasattr(self.resource.ResourceEntities, 'ResourceEntity'):
@@ -209,8 +208,7 @@ class VDC(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
 
         # Get hold of the template
         org_href = find_link(self.resource, RelationType.UP,
@@ -436,8 +434,7 @@ class VDC(object):
 
         :rtype: dict
         """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
         result = []
         if hasattr(self.resource, 'ResourceEntities') and \
            hasattr(self.resource.ResourceEntities, 'ResourceEntity'):
@@ -458,8 +455,7 @@ class VDC(object):
 
         :rtype: list
         """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
         links = self.client.get_linked_resource(self.resource,
                                                 RelationType.EDGE_GATEWAYS,
                                                 EntityType.RECORDS.value)
@@ -497,8 +493,7 @@ class VDC(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
 
         disk_params = E.DiskCreateParams(E.Disk(name=name, size=str(size)))
         if iops is not None:
@@ -1485,8 +1480,6 @@ class VDC(object):
         if external_networks is None or len(external_networks) == 0:
             raise InvalidParameterException('external networks can not be '
                                             'Null.')
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
         resource_admin = self.client.get_resource(self.href_admin)
 
         gateway_params = E.EdgeGateway(name=name)
@@ -1567,8 +1560,6 @@ class VDC(object):
         if external_networks is None or len(external_networks) == 0:
             raise InvalidParameterException('external networks can not be '
                                             'Null.')
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
 
         resource_admin = self.client.get_resource(self.href_admin)
         gateway_params = E.EdgeGateway(name=name)

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -544,8 +544,7 @@ class VDC(object):
 
         :raises: EntityNotFoundException: if the named disk cannot be located.
         """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
 
         if disk_id is not None:
             disk = self.get_disk(disk_id=disk_id)
@@ -593,8 +592,7 @@ class VDC(object):
 
         :raises: EntityNotFoundException: if the named disk cannot be located.
         """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
 
         if disk_id is not None:
             disk = self.get_disk(disk_id=disk_id)
@@ -615,8 +613,7 @@ class VDC(object):
 
         :rtype: list
         """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
 
         disks = []
         if hasattr(self.resource, 'ResourceEntities') and \
@@ -651,8 +648,7 @@ class VDC(object):
             raise InvalidParameterException(
                 'Unable to idendify disk without name or id.')
 
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
 
         disks = self.get_disks()
 
@@ -692,8 +688,7 @@ class VDC(object):
 
         :raises: EntityNotFoundException: if the named disk cannot be located.
         """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
 
         if disk_id is not None:
             disk = self.get_disk(disk_id=disk_id)
@@ -716,8 +711,7 @@ class VDC(object):
         :rtype: list
         """
         profile_list = []
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
 
         if hasattr(self.resource, 'VdcStorageProfiles') and \
            hasattr(self.resource.VdcStorageProfiles, 'VdcStorageProfile'):
@@ -736,8 +730,7 @@ class VDC(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
 
         if hasattr(self.resource, 'VdcStorageProfiles') and \
            hasattr(self.resource.VdcStorageProfiles, 'VdcStorageProfile'):
@@ -777,8 +770,7 @@ class VDC(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
 
         return self.client.delete_linked_resource(self.resource,
                                                   RelationType.REMOVE, None)
@@ -888,8 +880,7 @@ class VDC(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
 
         network_href = network_name = None
         if network is not None:
@@ -980,8 +971,7 @@ class VDC(object):
         """
         gateway_ip, netmask = cidr_to_netmask(network_cidr)
 
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
 
         request_payload = E.OrgVdcNetwork(name=network_name)
         if description is not None:
@@ -1051,8 +1041,7 @@ class VDC(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
 
         platform = Platform(self.client)
         parent_network = platform.get_external_network(parent_network_name)
@@ -1119,8 +1108,7 @@ class VDC(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        if self.resource is None:
-            self.resource = self.client.get_resource(self.href)
+        self.get_resource()
 
         request_payload = E.OrgVdcNetwork(name=network_name)
         if description is not None:


### PR DESCRIPTION
As part of CL https://github.com/vmware/pyvcloud/commit/71df56410034d9f122b77821d48d2d266dd28563, resource is None check was removed. It causes the failure for CLI command 'vcd vdc info'.

Removed the resource reload in case of None to keep the loading of resources on need basis as it was originally (before my changes).

Testing Done:
1: Successfully executed the pyvcloud->gateway_tests.py, pyvcloud->network_tests.py
2: Successfully executed the vcd-cli->vdc_network_tests.py and command vcd vdc info <name>
3: Tested Gateway creation successfully from CLI

@rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/347)
<!-- Reviewable:end -->
