### PR TITLE
[VCDA-840] Added metadata support for first class objects in vCD

### DIFF
--- a/pyvcloud/system_test_framework/environment.py
+++ b/pyvcloud/system_test_framework/environment.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from enum import Enum
 import logging
 import warnings
 
-from flufl.enum import Enum
 import requests
 
 from pyvcloud.vcd.client import BasicLoginCredentials

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -402,16 +402,20 @@ class NetworkAdapterType(Enum):
     VLANCE = 'PCNet32'
 
 
+# vCD docs are incomplete about valid Metadata Domain and Visibility values
+# Looking at vCD code the following are the only valid combinations, anything
+# else will generate a 400 or 500 response from vCD.
+# SYSTEM - PRIVATE
+# SYSTEM - READONLY
+# GENERAL - READWRITE
 class MetadataDomain(Enum):
     GENERAL = 'GENERAL'
     SYSTEM = 'SYSTEM'
 
 
 class MetadataVisibility(Enum):
-    # vCD docs lists these values but only READWRITE works, others thro
-    # Interal server error (500)
-    # PRIVATE = 'PRIVATE'
-    # READONLY = 'READONLY'
+    PRIVATE = 'PRIVATE'
+    READONLY = 'READONLY'
     READ_WRITE = 'READWRITE'
 
 

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -298,6 +298,7 @@ class EntityType(Enum):
     LEASE_SETTINGS = 'application/vnd.vmware.vcloud.leaseSettingsSection+xml'
     MEDIA = 'application/vnd.vmware.vcloud.media+xml'
     METADATA = 'application/vnd.vmware.vcloud.metadata+xml'
+    METADATA_VALUE = 'application/vnd.vmware.vcloud.metadata.value+xml'
     NETWORK_CONFIG_SECTION = \
         'application/vnd.vmware.vcloud.networkConfigSection+xml'
     NETWORK_CONNECTION_SECTION = \
@@ -399,6 +400,24 @@ class NetworkAdapterType(Enum):
     E1000 = 'E1000'
     E1000E = 'E1000E'
     VLANCE = 'PCNet32'
+
+
+class MetadataDomain(Enum):
+    GENERAL = 'GENERAL'
+    SYSTEM = 'SYSTEM'
+
+
+class MetadataVisibility(Enum):
+    PRIVATE = 'PRIVATE'
+    READONLY = 'READONLY'
+    READ_WRITE = 'READWRITE'
+
+
+class MetadataValueType(Enum):
+    STRING = 'MetadataStringValue'
+    NUMBER = 'MetadataNumberValue'
+    BOOLEAN = 'MetadataBooleanValue'
+    DATA_TIME = 'MetadataDateTimeValue'
 
 
 def _get_session_endpoints(session):

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -410,8 +410,8 @@ class MetadataDomain(Enum):
 class MetadataVisibility(Enum):
     # vCD docs lists these values but only READWRITE works, others thro
     # Interal server error (500)
-    #PRIVATE = 'PRIVATE'
-    #READONLY = 'READONLY'
+    # PRIVATE = 'PRIVATE'
+    # READONLY = 'READONLY'
     READ_WRITE = 'READWRITE'
 
 

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -16,13 +16,13 @@
 from datetime import datetime
 from datetime import timedelta
 from distutils.version import StrictVersion
+from enum import Enum
 import json
 import logging
 import sys
 import time
 import urllib
 
-from flufl.enum import Enum
 from lxml import etree
 from lxml import objectify
 import requests
@@ -408,8 +408,10 @@ class MetadataDomain(Enum):
 
 
 class MetadataVisibility(Enum):
-    PRIVATE = 'PRIVATE'
-    READONLY = 'READONLY'
+    # vCD docs lists these values but only READWRITE works, others thro
+    # Interal server error (500)
+    #PRIVATE = 'PRIVATE'
+    #READONLY = 'READONLY'
     READ_WRITE = 'READWRITE'
 
 

--- a/pyvcloud/vcd/metadata.py
+++ b/pyvcloud/vcd/metadata.py
@@ -1,0 +1,199 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2014-2019 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyvcloud.vcd.client import E
+from pyvcloud.vcd.client import EntityType
+from pyvcloud.vcd.client import MetadataDomain
+from pyvcloud.vcd.client import MetadataValueType
+from pyvcloud.vcd.client import MetadataVisibility
+from pyvcloud.vcd.client import NSMAP
+from pyvcloud.vcd.client import RelationType
+from pyvcloud.vcd.exceptions import InvalidParameterException
+from pyvcloud.vcd.utils import get_admin_href
+
+
+class Metadata(object):
+    def __init__(self, client, href=None, resource=None):
+        """Constructor for metadata object.
+
+        :param pyvcloud.vcd.client.Client client: the client that will be used
+            to make REST calls to vCD.
+        :param str href: non admin URI of the metadata. Exception : provider
+            VDC related metadata objects will be initiated with admin href.
+        :param lxml.objectify.ObjectifiedElement resource: object containing
+            EntityType.METADATA XML data representing metadata of a vCD object.
+        """
+        self.client = client
+        if href is None and resource is None:
+            raise InvalidParameterException(
+                "Metadata initialization failed as arguments are either "
+                "invalid or None")
+        self.href = href
+        self.resource = resource
+        if resource is not None:
+            self.href = resource.get('href')
+
+    def get_resource(self):
+        """Fetches the XML representation of the metadata from vCD.
+
+        Will serve cached response if possible.
+
+        :return: object containing EntityType.METADATA XML data representing
+            the metadata.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        if self.resource is None:
+            self.reload()
+        return self.resource
+
+    def reload(self):
+        """Reloads the resource representation of the metadata.
+
+        This method should be called in between two method invocations on the
+        metadata object or it's parent, if the former call changes the
+        representation of the metadata in vCD.
+        """
+        self.resource = self.client.get_resource(self.href)
+
+    def get_metadata(self, use_admin_endpoint=False):
+        """Fetch all metadata entries of the parent object.
+
+        :param bool use_admin_endpoint: if True, will use the /api/admin
+            endpoint to retrieve the metadata object else will use the vanilla
+            /api endpoint.
+
+        :return: an object containing EntityType.METADATA XML data which
+            represents the metadata entries associated with parent object.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        if not use_admin_endpoint:
+            return self.get_resource()
+        else:
+            admin_href = get_admin_href(self.href)
+            return self.client.get_resource(admin_href)
+
+    def set_metadata(self,
+                     key,
+                     value,
+                     domain=MetadataDomain.GENERAL,
+                     visibility=MetadataVisibility.READONLY,
+                     metadata_value_type=MetadataValueType.STRING,
+                     use_admin_endpoint=False):
+        """Add/update a metadata entry to/of the parent object.
+
+        If an entry with the same key exists, it will be updated with the new
+        value.
+
+        :param str key: an arbitrary key name. Length cannot exceed 256 UTF-8
+            characters.
+        :param str value: value of the metadata entry
+        :param client.MetadataDomain domain: domain where the new entry would
+            be put.
+        :param client.MetadataVisibility visibility: visibility of the metadata
+            entry.
+        :param client.MetadataValueType metadata_value_type:
+        :param bool use_admin_endpoint: if True, will use the /api/admin
+            endpoint to add new entry to the metadata object else will use the
+            vanilla /api endpoint.
+
+        :return: an object of type EntityType.TASK XML which represents
+            the asynchronous task that is updating the metadata.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        if not isinstance(domain, MetadataDomain):
+            raise InvalidParameterException('Invalid domain.')
+        if not isinstance(visibility, MetadataVisibility):
+            raise InvalidParameterException('Invalid visibility.')
+        if not isinstance(metadata_value_type, MetadataValueType):
+            raise InvalidParameterException('Invalid type of value.')
+
+        metadata = self.get_metadata(use_admin_endpoint)
+        new_metadata = E.Metadata(
+            E.MetadataEntry(
+                {'type': 'xs:string'},
+                E.Domain(domain.value, visibility=visibility.value),
+                E.Key(key),
+                E.TypedValue(
+                    {'{' + NSMAP['xsi'] + '}type': metadata_value_type.value},
+                    E.Value(value))))
+        return self.client.post_linked_resource(metadata, RelationType.ADD,
+                                                EntityType.METADATA.value,
+                                                new_metadata)
+
+    def get_metadata_entry(self,
+                           key,
+                           domain=MetadataDomain.GENERAL,
+                           use_admin_endpoint=False):
+        """Fetch a metadata entry identified by the domain and key.
+
+        :param str key: key of the entry to be fetched.
+        :param client.MetadataDomain domain: domain of the entry to be fetched.
+        :param bool use_admin_endpoint: if True, will use the /api/admin
+            endpoint to retrieve the metadata entry else will use the vanilla
+            /api endpoint.
+
+        :return: an object containing EntityType.METADATA_VALUE XML data which
+            represents the metadata entry.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+
+        :raises: AccessForbiddenException: If there is no metadata entry
+            corresponding to the key provided.
+        """
+        if not isinstance(domain, MetadataDomain):
+            raise InvalidParameterException('Invalid domain.')
+
+        if not use_admin_endpoint:
+            href = self.href
+        else:
+            href = get_admin_href(self.href)
+
+        metadata_entry_href = \
+            f"{href}/metadata/{domain.value}/{key}"
+
+        return self.client.get_resource(metadata_entry_href)
+
+    def remove_metadata(self,
+                        key,
+                        domain=MetadataDomain.GENERAL,
+                        use_admin_endpoint=False):
+        """Remove a metadata entry.
+
+        :param str key: key of the metadata to be removed.
+        :param client.MetadataDomain domain: domain of the entry to be removed.
+
+        :return: an object of type EntityType.TASK XML which represents
+            the asynchronous task that is deleting the metadata entry.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+
+        :raises: AccessForbiddenException: If there is no metadata entry
+            corresponding to the key provided.
+
+        :raises: MissingLinkException: If the remove link is missing from the
+            XML representation of the metadata entry. This error most likely
+            indicates that the wrong api endpoint was used viz. /api instead of
+            /api/admin.
+        """
+        metadata = self.get_metadata_entry(
+            key=key,
+            domain=domain,
+            use_admin_endpoint=use_admin_endpoint)
+
+        return self.client.delete_linked_resource(metadata,
+                                                  RelationType.REMOVE, None)

--- a/pyvcloud/vcd/metadata.py
+++ b/pyvcloud/vcd/metadata.py
@@ -30,8 +30,9 @@ class Metadata(object):
 
         :param pyvcloud.vcd.client.Client client: the client that will be used
             to make REST calls to vCD.
-        :param str href: non admin URI of the metadata. Exception : provider
-            VDC related metadata objects will be initiated with admin href.
+        :param str href: non admin URI of the metadata. With the exception of
+            provider VDC related metadata objects, those will be initiated with
+            admin href (since non admin href of pVDC doesn't exist).
         :param lxml.objectify.ObjectifiedElement resource: object containing
             EntityType.METADATA XML data representing metadata of a vCD object.
         """
@@ -68,7 +69,7 @@ class Metadata(object):
         """
         self.resource = self.client.get_resource(self.href)
 
-    def get_metadata(self, use_admin_endpoint=False):
+    def get_all_metadata(self, use_admin_endpoint=False):
         """Fetch all metadata entries of the parent object.
 
         :param bool use_admin_endpoint: if True, will use the /api/admin
@@ -115,6 +116,42 @@ class Metadata(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
+        key_value_dict = {key: value}
+        return self.set_multiple_metadata(
+            key_value_dict=key_value_dict,
+            domain=domain,
+            visibility=visibility,
+            metadata_value_type=metadata_value_type,
+            use_admin_endpoint=use_admin_endpoint)
+
+    def set_multiple_metadata(self,
+                              key_value_dict,
+                              domain=MetadataDomain.GENERAL,
+                              visibility=MetadataVisibility.READ_WRITE,
+                              metadata_value_type=MetadataValueType.STRING,
+                              use_admin_endpoint=False):
+        """Add/update multiple metadata entries to/of the parent object.
+
+        If an entry with the same key exists, it will be updated with the new
+        value. All entries must have the same value type and will be written to
+        the same domain with identical visibility.
+
+        :param dict key_value_dict: a dict containing key-value pairs to be
+            added/updated.
+        :param client.MetadataDomain domain: domain where the new entries would
+            be put.
+        :param client.MetadataVisibility visibility: visibility of the metadata
+            entries.
+        :param client.MetadataValueType metadata_value_type:
+        :param bool use_admin_endpoint: if True, will use the /api/admin
+            endpoint to add new entries to the metadata object else will use
+            the vanilla /api endpoint.
+
+        :return: an object of type EntityType.TASK XML which represents
+            the asynchronous task that is updating the metadata entries.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
         if not isinstance(domain, MetadataDomain):
             raise InvalidParameterException('Invalid domain.')
         if not isinstance(visibility, MetadataVisibility):
@@ -122,33 +159,36 @@ class Metadata(object):
         if not isinstance(metadata_value_type, MetadataValueType):
             raise InvalidParameterException('Invalid type of value.')
 
-        metadata = self.get_metadata(use_admin_endpoint)
-        new_metadata = E.Metadata(
-            E.MetadataEntry(
+        metadata = self.get_all_metadata(use_admin_endpoint)
+        new_metadata = E.Metadata()
+        for k, v in key_value_dict.items():
+            entry = E.MetadataEntry(
                 {'type': 'xs:string'},
                 E.Domain(domain.value, visibility=visibility.value),
-                E.Key(key),
+                E.Key(k),
                 E.TypedValue(
                     {'{' + NSMAP['xsi'] + '}type': metadata_value_type.value},
-                    E.Value(value))))
+                    E.Value(v)))
+            new_metadata.append(entry)
         return self.client.post_linked_resource(metadata, RelationType.ADD,
                                                 EntityType.METADATA.value,
                                                 new_metadata)
 
-    def get_metadata_entry(self,
+    def get_metadata_value(self,
                            key,
                            domain=MetadataDomain.GENERAL,
                            use_admin_endpoint=False):
-        """Fetch a metadata entry identified by the domain and key.
+        """Fetch a metadata value identified by the domain and key.
 
-        :param str key: key of the entry to be fetched.
-        :param client.MetadataDomain domain: domain of the entry to be fetched.
+        :param str key: key of the value to be fetched.
+        :param client.MetadataDomain domain: domain of the value to be fetched.
         :param bool use_admin_endpoint: if True, will use the /api/admin
-            endpoint to retrieve the metadata entry else will use the vanilla
+            endpoint to retrieve the metadata value else will use the vanilla
             /api endpoint.
 
         :return: an object containing EntityType.METADATA_VALUE XML data which
-            represents the metadata entry.
+            represents the metadata value corresponding to the provided key and
+            domain.
 
         :rtype: lxml.objectify.ObjectifiedElement
 
@@ -190,10 +230,10 @@ class Metadata(object):
             indicates that the wrong api endpoint was used viz. /api instead of
             /api/admin.
         """
-        metadata_entry = self.get_metadata_entry(
+        metadata_value = self.get_metadata_value(
             key=key,
             domain=domain,
             use_admin_endpoint=use_admin_endpoint)
 
-        return self.client.delete_linked_resource(metadata_entry,
+        return self.client.delete_linked_resource(metadata_value,
                                                   RelationType.REMOVE, None)

--- a/pyvcloud/vcd/metadata.py
+++ b/pyvcloud/vcd/metadata.py
@@ -190,10 +190,10 @@ class Metadata(object):
             indicates that the wrong api endpoint was used viz. /api instead of
             /api/admin.
         """
-        metadata = self.get_metadata_entry(
+        metadata_entry = self.get_metadata_entry(
             key=key,
             domain=domain,
             use_admin_endpoint=use_admin_endpoint)
 
-        return self.client.delete_linked_resource(metadata,
+        return self.client.delete_linked_resource(metadata_entry,
                                                   RelationType.REMOVE, None)

--- a/pyvcloud/vcd/metadata.py
+++ b/pyvcloud/vcd/metadata.py
@@ -90,7 +90,7 @@ class Metadata(object):
                      key,
                      value,
                      domain=MetadataDomain.GENERAL,
-                     visibility=MetadataVisibility.READONLY,
+                     visibility=MetadataVisibility.READ_WRITE,
                      metadata_value_type=MetadataValueType.STRING,
                      use_admin_endpoint=False):
         """Add/update a metadata entry to/of the parent object.
@@ -164,7 +164,7 @@ class Metadata(object):
             href = get_admin_href(self.href)
 
         metadata_entry_href = \
-            f"{href}/metadata/{domain.value}/{key}"
+            f"{href}/{domain.value}/{key}"
 
         return self.client.get_resource(metadata_entry_href)
 

--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -507,6 +507,63 @@ def access_settings_to_dict(control_access_params):
     return result
 
 
+def metadata_to_dict(metadata):
+    """Converts a lxml.objectify.ObjectifiedElement metadata object to a dict.
+
+    All MetadataEntry tags in the metadata object is converted to simple
+    key-value pair.
+
+    :param lxml.objectify.ObjectifiedElement metadata: an object containing
+        EntityType.METADATA XML data.
+
+    :return: dictionary representation of metadata entries. All keys and values
+        will be string.
+
+    :rtype: dict
+    """
+    result = {}
+    if hasattr(metadata, 'MetadataEntry'):
+        for entry in metadata.MetadataEntry:
+            key, value = metadata_entry_to_tuple(entry)
+            result[key] = value
+    return result
+
+
+def metadata_entry_to_tuple(metadata_entry):
+    """Converts a lxml.objectify.ObjectifiedElement metadata entry to a tuple.
+
+    The metadata entry object is converted into a simple (key, value) tuple.
+
+    :param lxml.objectify.ObjectifiedElement metadata_entry: an object
+        containing MetadataEntry XML data. This tag is a child tag of
+        EntityType.Metadata XML.
+
+    :return: a key-value tuple respresnting the metadata entry. Both key and
+        value will be strings.
+
+    :rtype: tuple
+    """
+    key = metadata_entry.Key.text
+    value = metadata_entry.TypedValue.Value.text
+    return (key, value)
+
+
+def extract_metadata_value(metadata_value):
+    """Converts a lxml.objectify.ObjectifiedElement metadata value to a string.
+
+    The textual representation of the metadata value is extracted out of the
+    metadata value object.
+
+    :param lxml.objectify.ObjectifiedElement metadata_value: an object
+        containing EntityType.METADATA_VALUE XML data.
+
+    :return: string representation of the metadata value
+
+    :rtype: str
+    """
+    return metadata_value.TypedValue.Value.text
+
+
 def filter_attributes(resource_type):
     """Returns a list of attributes for a given resource type.
 

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -146,10 +146,8 @@ class VApp(object):
         :rtype: lxml.objectify.ObjectifiedElement
         """
         self.get_resource()
-        metadata_href = self.find_link(
-            self.href, RelationType.DOWN, EntityType.METADATA.value)
-        metadata = Metadata(client=self.client, href=metadata_href)
-        return metadata.get_metadata()
+        return self.client.get_linked_resource(
+            self.resource, RelationType.DOWN, EntityType.METADATA.value)
 
     def set_metadata(self,
                      domain,
@@ -176,10 +174,7 @@ class VApp(object):
         :return: an object of type EntityType.TASK XML which represents
              the asynchronous task that is updating the metadata on the vApp.
         """
-        self.get_resource()
-        metadata_href = self.find_link(
-            self.href, RelationType.DOWN, EntityType.METADATA.value)
-        metadata = Metadata(client=self.client, href=metadata_href)
+        metadata = Metadata(client=self.client, resource=self.get_metadata())
         return metadata.set_metadata(
             key=key,
             value=value,

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -183,6 +183,25 @@ class VApp(object):
             metadata_value_type=MetadataValueType(metadata_type),
             use_admin_endpoint=False)
 
+    def remove_metadata(self, key, domain=MetadataDomain.GENERAL):
+        """Remove a metadata entry from the vApp.
+
+        :param str key: key of the metadata to be removed.
+        :param client.MetadataDomain domain: domain of the entry to be removed.
+
+        :return: an object of type EntityType.TASK XML which represents
+            the asynchronous task that is deleting the metadata on the vApp.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+
+        :raises: AccessForbiddenException: If there is no metadata entry
+            corresponding to the key provided.
+        """
+        metadata = Metadata(client=self.client, resource=self.get_metadata())
+        return metadata.remove_metadata(key=key,
+                                        domain=domain,
+                                        use_admin_endpoint=False)
+
     def get_vm_moid(self, vm_name):
         """Fetch the moref of a named vm in the vApp.
 

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -183,6 +183,36 @@ class VApp(object):
             metadata_value_type=MetadataValueType(metadata_type),
             use_admin_endpoint=False)
 
+    def set_multiple_metadata(self,
+                              key_value_dict,
+                              domain=MetadataDomain.GENERAL,
+                              visibility=MetadataVisibility.READ_WRITE,
+                              metadata_value_type=MetadataValueType.STRING):
+        """Add multiple new metadata entries to the vApp.
+
+        If an entry with the same key exists, it will be updated with the new
+        value. All entries must have the same value type and will be written to
+        the same domain with identical visibility.
+
+        :param dict key_value_dict: a dict containing key-value pairs to be
+            added/updated.
+        :param client.MetadataDomain domain: domain where the new entries would
+            be put.
+        :param client.MetadataVisibility visibility: visibility of the metadata
+            entries.
+        :param client.MetadataValueType metadata_value_type:
+
+        :return: an object of type EntityType.TASK XML which represents
+             the asynchronous task that is updating the metadata on the vApp.
+        """
+        metadata = Metadata(client=self.client, resource=self.get_metadata())
+        return metadata.set_multiple_metadata(
+            key_value_dict=key_value_dict,
+            domain=MetadataDomain(domain),
+            visibility=MetadataVisibility(visibility),
+            metadata_value_type=MetadataValueType(metadata_value_type),
+            use_admin_endpoint=False)
+
     def remove_metadata(self, key, domain=MetadataDomain.GENERAL):
         """Remove a metadata entry from the vApp.
 

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -733,10 +733,8 @@ class VDC(object):
         :rtype: lxml.objectify.ObjectifiedElement
         """
         self.get_resource()
-        metadata_href = self.find_link(
-            self.href, RelationType.DOWN, EntityType.METADATA.value)
-        metadata = Metadata(client=self.client, href=metadata_href)
-        return metadata.get_metadata()
+        return self.client.get_linked_resource(
+            self.resource, RelationType.DOWN, EntityType.METADATA.value)
 
     def get_metadata_entry(self, key, domain=MetadataDomain.GENERAL):
         """Fetch a metadata entry identified by the domain and key.
@@ -749,10 +747,7 @@ class VDC(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        self.get_resource()
-        metadata_href = self.find_link(
-            self.href, RelationType.DOWN, EntityType.METADATA.value)
-        metadata = Metadata(client=self.client, href=metadata_href)
+        metadata = Metadata(client=self.client, resource=self.get_metadata())
         return metadata.get_metadata_entry(key, domain)
 
     def set_metadata(self,
@@ -780,10 +775,7 @@ class VDC(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        self.get_resource()
-        metadata_href = self.find_link(
-            self.href, RelationType.DOWN, EntityType.METADATA.value)
-        metadata = Metadata(client=self.client, href=metadata_href)
+        metadata = Metadata(client=self.client, resource=self.get_metadata())
         return metadata.set_metadata(key=key,
                                      value=value,
                                      domain=domain,
@@ -807,10 +799,7 @@ class VDC(object):
         :raises: AccessForbiddenException: If there is no metadata entry
             corresponding to the key provided.
         """
-        self.get_resource()
-        metadata_href = self.find_link(
-            self.href, RelationType.DOWN, EntityType.METADATA.value)
-        metadata = Metadata(client=self.client, href=metadata_href)
+        metadata = Metadata(client=self.client, resource=self.get_metadata())
         return metadata.remove_metadata(key=key,
                                         domain=domain,
                                         use_admin_endpoint=True)

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -724,7 +724,7 @@ class VDC(object):
             return profile_list
         return None
 
-    def get_metadata(self):
+    def get_all_metadata(self):
         """Fetch all metadata entries of the org vdc.
 
         :return: an object containing EntityType.METADATA XML data which
@@ -736,19 +736,20 @@ class VDC(object):
         return self.client.get_linked_resource(
             self.resource, RelationType.DOWN, EntityType.METADATA.value)
 
-    def get_metadata_entry(self, key, domain=MetadataDomain.GENERAL):
-        """Fetch a metadata entry identified by the domain and key.
+    def get_metadata_value(self, key, domain=MetadataDomain.GENERAL):
+        """Fetch a metadata value identified by the domain and key.
 
-        :param str key: key of the entry to be fetched.
-        :param client.MetadataDomain domain: domain of the entry to be fetched.
+        :param str key: key of the value to be fetched.
+        :param client.MetadataDomain domain: domain of the value to be fetched.
 
         :return: an object containing EntityType.METADATA_VALUE XML data which
-            represents the metadata entry.
+            represents the metadata value.
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        metadata = Metadata(client=self.client, resource=self.get_metadata())
-        return metadata.get_metadata_entry(key, domain)
+        metadata = Metadata(client=self.client,
+                            resource=self.get_all_metadata())
+        return metadata.get_metadata_value(key, domain)
 
     def set_metadata(self,
                      key,
@@ -775,13 +776,46 @@ class VDC(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        metadata = Metadata(client=self.client, resource=self.get_metadata())
+        metadata = Metadata(client=self.client,
+                            resource=self.get_all_metadata())
         return metadata.set_metadata(key=key,
                                      value=value,
                                      domain=domain,
                                      visibility=visibility,
                                      metadata_value_type=metadata_value_type,
                                      use_admin_endpoint=True)
+
+    def set_multiple_metadata(self,
+                              key_value_dict,
+                              domain=MetadataDomain.GENERAL,
+                              visibility=MetadataVisibility.READ_WRITE,
+                              metadata_value_type=MetadataValueType.STRING):
+        """Add multiple metadata entries to the org vdc.
+
+        Only Sys admins can perform this operation. If an entry with the same
+        key exists, it will be updated with the new value.
+
+        :param dict key_value_dict: a dict containing key-value pairs to be
+            added/updated.
+        :param client.MetadataDomain domain: domain where the new entries would
+            be put.
+        :param client.MetadataVisibility visibility: visibility of the metadata
+            entries.
+        :param client.MetadataValueType metadata_value_type:
+
+        :return: an object of type EntityType.TASK XML which represents
+            the asynchronous task that is updating the metadata on the org vdc.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        metadata = Metadata(client=self.client,
+                            resource=self.get_all_metadata())
+        return metadata.set_multiple_metadata(
+            key_value_dict=key_value_dict,
+            domain=domain,
+            visibility=visibility,
+            metadata_value_type=metadata_value_type,
+            use_admin_endpoint=True)
 
     def remove_metadata(self, key, domain=MetadataDomain.GENERAL):
         """Remove a metadata entry from the org vdc.
@@ -799,7 +833,8 @@ class VDC(object):
         :raises: AccessForbiddenException: If there is no metadata entry
             corresponding to the key provided.
         """
-        metadata = Metadata(client=self.client, resource=self.get_metadata())
+        metadata = Metadata(client=self.client,
+                            resource=self.get_all_metadata())
         return metadata.remove_metadata(key=key,
                                         domain=domain,
                                         use_admin_endpoint=True)

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -754,7 +754,7 @@ class VDC(object):
                      key,
                      value,
                      domain=MetadataDomain.GENERAL,
-                     visibility=MetadataVisibility.READONLY,
+                     visibility=MetadataVisibility.READ_WRITE,
                      metadata_value_type=MetadataValueType.STRING):
         """Add a metadata entry to the org vdc.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-flufl.enum >= 4.1.1
 humanfriendly >= 4.8
 lxml >= 4.2.1
 pygments >= 2.2.0

--- a/system_tests/vdc_tests.py
+++ b/system_tests/vdc_tests.py
@@ -24,6 +24,7 @@ from pyvcloud.vcd.client import TaskStatus
 from pyvcloud.vcd.exceptions import AccessForbiddenException
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
+from pyvcloud.vcd.utils import extract_metadata_value
 from pyvcloud.vcd.vdc import VDC
 
 
@@ -275,9 +276,9 @@ class TestOrgVDC(BaseTestCase):
             except OperationNotSupportedException as e:
                 pass
 
-            # add new metadata as org admin
+            # add new metadata as sys admin
             logger.debug(f'Adding metadata [key={TestOrgVDC._metadata_key},'
-                         'value={TestOrgVDC._metadata_value}]) as Org admin.')
+                         'value={TestOrgVDC._metadata_value}]) as Sys admin.')
             task = vdc_sys_admin_view.set_metadata(
                 key=TestOrgVDC._metadata_key,
                 value=TestOrgVDC._metadata_value)
@@ -287,9 +288,9 @@ class TestOrgVDC(BaseTestCase):
             # retrieve metadata as vapp author
             logger.debug(f'Retriving metadata with key='
                          '{TestOrgVDC._metadata_key} as vApp author.')
-            metadata_entry = vdc_vapp_author_view.get_metadata_entry(
+            metadata_value = vdc_vapp_author_view.get_metadata_value(
                 key=TestOrgVDC._metadata_key)
-            self.assertEqual(metadata_entry.TypedValue.Value.text,
+            self.assertEqual(extract_metadata_value(metadata_value),
                              TestOrgVDC._metadata_value)
 
             # try to retrieve non existent metadata entry
@@ -297,7 +298,7 @@ class TestOrgVDC(BaseTestCase):
                 logger.debug(f'Retriving metadata with invalid key='
                              '{TestOrgVDC._non_existent_metadata_key} as vApp '
                              'author')
-                metadata_entry = vdc_vapp_author_view.get_metadata_entry(
+                metadata_value = vdc_vapp_author_view.get_metadata_value(
                     key=TestOrgVDC._non_existent_metadata_key)
                 self.assertFail('Shouldn\'t have been able to retrieve metadta'
                                 ' entry with bad key.')
@@ -306,7 +307,7 @@ class TestOrgVDC(BaseTestCase):
 
             # try to update metadata value as vapp author
             try:
-                logger.debug(f'Trying to u[date metadata with key='
+                logger.debug(f'Trying to update metadata with key='
                              '{TestOrgVDC._metadata_key} to value='
                              '{TestOrgVDC._metadata_new_value} as vApp '
                              'author.')
@@ -318,17 +319,17 @@ class TestOrgVDC(BaseTestCase):
             except OperationNotSupportedException as e:
                 pass
 
-            # update metadata value as org admin
+            # update metadata value as sys admin
             logger.debug(f'Updtaing metadata with key='
                          '{TestOrgVDC._metadata_key} to value='
-                         '{TestOrgVDC._metadata_new_value} as Org Admin.')
+                         '{TestOrgVDC._metadata_new_value} as Sys Admin.')
             task = vdc_sys_admin_view.set_metadata(
                 key=TestOrgVDC._metadata_key,
                 value=TestOrgVDC._metadata_new_value)
             sys_admin_client.get_task_monitor().wait_for_success(task)
-            metadata_entry = vdc_sys_admin_view.get_metadata_entry(
+            metadata_value = vdc_sys_admin_view.get_metadata_value(
                 key=TestOrgVDC._metadata_key)
-            self.assertEqual(metadata_entry.TypedValue.Value.text,
+            self.assertEqual(extract_metadata_value(metadata_value),
                              TestOrgVDC._metadata_new_value)
 
             # try to remove metadata as vapp author
@@ -342,9 +343,9 @@ class TestOrgVDC(BaseTestCase):
             except OperationNotSupportedException as e:
                 pass
 
-            # remove metadata entry as org admin
+            # remove metadata entry as sys admin
             logger.debug(f'Removing metadata with '
-                         'key={TestOrgVDC._metadata_key},as Org Admin.')
+                         'key={TestOrgVDC._metadata_key},as Sys Admin.')
             task = vdc_sys_admin_view.remove_metadata(
                 key=TestOrgVDC._metadata_key)
             result = sys_admin_client.get_task_monitor().wait_for_success(task)

--- a/system_tests/vdc_tests.py
+++ b/system_tests/vdc_tests.py
@@ -20,6 +20,8 @@ from pyvcloud.system_test_framework.environment import CommonRoles
 from pyvcloud.system_test_framework.environment import developerModeAware
 from pyvcloud.system_test_framework.environment import Environment
 
+from pyvcloud.vcd.client import TaskStatus
+from pyvcloud.vcd.exceptions import AccessForbiddenException
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
 from pyvcloud.vcd.vdc import VDC
@@ -34,6 +36,11 @@ class TestOrgVDC(BaseTestCase):
     _new_vdc_name = 'org_vdc_' + str(uuid1())
     _new_vdc_href = None
     _non_existent_vdc_name = 'non_existent_org_vdc_' + str(uuid1())
+
+    _metadata_key = 'key_' + str(uuid1())
+    _metadata_value = 'value_' + str(uuid1())
+    _metadata_new_value = 'new_value_' + str(uuid1())
+    _non_existent_metadata_key = 'non_existent_key_' + str(uuid1())
 
     def test_0000_setup(self):
         """Setup the org vdc required for the other tests in this module.
@@ -235,6 +242,118 @@ class TestOrgVDC(BaseTestCase):
         vdc.reload()
         control_access = vdc.remove_access_settings(remove_all=True)
         self.assertFalse(hasattr(control_access, 'AccessSettings'))
+
+    def test_0060_vdc_metadata(self):
+        """Test the methods related to metadata manipulation in vdc.py.
+
+        This test passes if all the metadata operations are successful.
+        """
+        vapp_author_client = None
+        sys_admin_client = None
+        try:
+            logger = Environment.get_default_logger()
+
+            vapp_author_client = Environment.get_client_in_default_org(
+                CommonRoles.VAPP_AUTHOR)
+            vdc_vapp_author_view = VDC(client=vapp_author_client,
+                                       href=TestOrgVDC._new_vdc_href)
+
+            sys_admin_client = Environment.get_sys_admin_client()
+            vdc_sys_admin_view = VDC(client=sys_admin_client,
+                                     href=TestOrgVDC._new_vdc_href)
+
+            # try to add new metadata as vapp author
+            try:
+                logger.debug(f'Adding metadata [key={TestOrgVDC._metadata_key}'
+                             ', value={TestOrgVDC._metadata_value}]) as vApp '
+                             'author')
+                vdc_vapp_author_view.set_metadata(
+                    key=TestOrgVDC._metadata_key,
+                    value=TestOrgVDC._metadata_value)
+                self.assertFail('vApp author shouldn\'t have been able to '
+                                'add new metadta entry.')
+            except OperationNotSupportedException as e:
+                pass
+
+            # add new metadata as org admin
+            logger.debug(f'Adding metadata [key={TestOrgVDC._metadata_key},'
+                         'value={TestOrgVDC._metadata_value}]) as Org admin.')
+            task = vdc_sys_admin_view.set_metadata(
+                key=TestOrgVDC._metadata_key,
+                value=TestOrgVDC._metadata_value)
+            result = sys_admin_client.get_task_monitor().wait_for_success(task)
+            self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+            # retrieve metadata as vapp author
+            logger.debug(f'Retriving metadata with key='
+                         '{TestOrgVDC._metadata_key} as vApp author.')
+            metadata_entry = vdc_vapp_author_view.get_metadata_entry(
+                key=TestOrgVDC._metadata_key)
+            self.assertEqual(metadata_entry.TypedValue.Value.text,
+                             TestOrgVDC._metadata_value)
+
+            # try to retrieve non existent metadata entry
+            try:
+                logger.debug(f'Retriving metadata with invalid key='
+                             '{TestOrgVDC._non_existent_metadata_key} as vApp '
+                             'author')
+                metadata_entry = vdc_vapp_author_view.get_metadata_entry(
+                    key=TestOrgVDC._non_existent_metadata_key)
+                self.assertFail('Shouldn\'t have been able to retrieve metadta'
+                                ' entry with bad key.')
+            except AccessForbiddenException as e:
+                pass
+
+            # try to update metadata value as vapp author
+            try:
+                logger.debug(f'Trying to u[date metadata with key='
+                             '{TestOrgVDC._metadata_key} to value='
+                             '{TestOrgVDC._metadata_new_value} as vApp '
+                             'author.')
+                vdc_vapp_author_view.set_metadata(
+                    key=TestOrgVDC._metadata_key,
+                    value=TestOrgVDC._metadata_new_value)
+                self.assertFail('Shouldn\'t have been able to update metadta'
+                                ' entry as vApp author.')
+            except OperationNotSupportedException as e:
+                pass
+
+            # update metadata value as org admin
+            logger.debug(f'Updtaing metadata with key='
+                         '{TestOrgVDC._metadata_key} to value='
+                         '{TestOrgVDC._metadata_new_value} as Org Admin.')
+            task = vdc_sys_admin_view.set_metadata(
+                key=TestOrgVDC._metadata_key,
+                value=TestOrgVDC._metadata_new_value)
+            sys_admin_client.get_task_monitor().wait_for_success(task)
+            metadata_entry = vdc_sys_admin_view.get_metadata_entry(
+                key=TestOrgVDC._metadata_key)
+            self.assertEqual(metadata_entry.TypedValue.Value.text,
+                             TestOrgVDC._metadata_new_value)
+
+            # try to remove metadata as vapp author
+            try:
+                logger.debug(f'Trying to remove metadata with key='
+                             '{TestOrgVDC._metadata_key} as vApp author.')
+                task = vdc_vapp_author_view.remove_metadata(
+                    key=TestOrgVDC._metadata_key)
+                self.assertFail('Shouldn\'t have been able to remove metadta '
+                                'entry as vApp author.')
+            except OperationNotSupportedException as e:
+                pass
+
+            # remove metadata entry as org admin
+            logger.debug(f'Removing metadata with '
+                         'key={TestOrgVDC._metadata_key},as Org Admin.')
+            task = vdc_sys_admin_view.remove_metadata(
+                key=TestOrgVDC._metadata_key)
+            result = sys_admin_client.get_task_monitor().wait_for_success(task)
+            self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        finally:
+            if sys_admin_client is not None:
+                sys_admin_client.logout()
+            if vapp_author_client is not None:
+                vapp_author_client.logout()
 
     @developerModeAware
     def test_9998_teardown(self):


### PR DESCRIPTION
* Added a new class Metadata, that models metadata on first class objects in vCD.
* Updated vApp metadata operations to use the new Metadata class.
* Added support for vDC metadata get/set.
* Added system tests for vApp and vDC metadata

Also changed flufl.enum to python's standard enum module - flufl.enum doesn't support isinstance() method properly.

Testing done: Ran the updated vApp, vDC system tests, the runs were successful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/348)
<!-- Reviewable:end -->
