### PR TITLE
VP 1447: [PySDK] Delete an IP range of a subnet in external network

### DIFF
--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -216,8 +216,8 @@ class TestExtNet(BaseTestCase):
                 ip_scope = scope
                 break
         self.assertIsNotNone(ip_scope)
-        assert self.__validate_ip_range(ip_scope,
-                                        TestExtNet._ip_range3) == True
+        self.assertTrue(self.__validate_ip_range(ip_scope,
+                                        TestExtNet._ip_range3))
 
     def test_0050_modify_ip_range(self):
         """Test the method externalNetwork.modify_ip_range()
@@ -248,8 +248,8 @@ class TestExtNet(BaseTestCase):
                 ip_scope = scope
                 break
         self.assertIsNotNone(ip_scope)
-        assert self.__validate_ip_range(ip_scope,
-                                        TestExtNet._ip_range4) == True
+        self.assertTrue(self.__validate_ip_range(ip_scope,
+                                        TestExtNet._ip_range4))
 
     def test_0055_delete_ip_range(self):
         """Test the method externalNetwork.delete_ip_range()
@@ -279,8 +279,8 @@ class TestExtNet(BaseTestCase):
                 ip_scope = scope
                 break
         self.assertIsNotNone(ip_scope)
-        assert self.__validate_ip_range(ip_scope,
-                                        TestExtNet._ip_range4) == False
+        self.assertFalse(self.__validate_ip_range(ip_scope,
+                                                  TestExtNet._ip_range4))
 
     def __validate_ip_range(self, ip_scope, _ip_range1):
         """ Validate if the ip range present in the existing ip ranges """


### PR DESCRIPTION
[PySDK] Delete an IP range of a subnet in external network

This changelist contains deletion of an IP range from a gateway of an
external network. This CLN also has test case related to this
functionality.

Testing done:
Test case for delete an ip range  is added to a test class
extnet_tests.py

All tests in extnet_tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/349)
<!-- Reviewable:end -->
