### PR TITLE
VP-1521: Fix external network tests

### DIFF
--- a/pyvcloud/system_test_framework/environment.py
+++ b/pyvcloud/system_test_framework/environment.py
@@ -19,6 +19,7 @@ import warnings
 from flufl.enum import Enum
 import requests
 
+from helpers.portgroup_helper import PortgroupHelper
 from pyvcloud.system_test_framework.constants.gateway_constants import \
     GatewayConstants
 from pyvcloud.vcd.client import ApiVersion
@@ -82,6 +83,7 @@ class Environment(object):
     _external_network_name = None
     _org_href = None
     _ovdc_href = None
+    _portgroupType = "DV_PORTGROUP"
 
     _user_name_for_roles = {
         CommonRoles.CATALOG_AUTHOR: 'catalog_author',
@@ -292,18 +294,9 @@ class Environment(object):
     @classmethod
     def _create_external_network(cls):
         vc_name = cls._config['vc']['vcenter_host_name']
-        name_filter = ('vcName', vc_name)
-        query = cls._sys_admin_client.get_typed_query(
-            ResourceType.PORT_GROUP.value,
-            query_result_format=QueryResultFormat.RECORDS,
-            equality_filter=name_filter)
-
-        port_group = None
-        for record in list(query.execute()):
-            if record.get('networkName') == '--':
-                if not record.get('name').startswith('vxw-'):
-                    port_group = record.get('name')
-                    break
+        portgrouphelper = PortgroupHelper(cls._sys_admin_client)
+        port_group = portgrouphelper.get_available_portgroup_name(vc_name,
+                                                                  Environment._portgroupType)
 
         if port_group is None:
             raise Exception(

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -42,7 +42,7 @@ class TestExtNet(BaseTestCase):
     _ip_range = '10.20.30.2-10.20.30.99'
     _dns1 = '8.8.8.8'
     _dns2 = '8.8.8.9'
-    _portgroupType = "DV_PORTGROUP"
+    _portgroupType = "NETWORK"
     _dns_suffix = 'example.com'
     _gateway2 = '10.10.30.1'
     _ip_range2 = '10.10.30.2-10.10.30.99'


### PR DESCRIPTION
Fix the external network tests failing with below error:
:58:34 Traceback (most recent call last):
08:58:34   File "/data/jenkins/jenkins-py-cloud-sdk-93/system_tests/extnet_tests.py", line 72, in test_0000_setup
08:58:34     TestExtNet._portgroupType)
08:58:34   File "/data/jenkins/jenkins-py-cloud-sdk-93/system_tests/helpers/portgroup_helper.py", line 58, in get_available_portgroup_name
08:58:34     'vCenter : ' + vim_server_name)
08:58:34 pyvcloud.vcd.exceptions.EntityNotFoundException: port group not found invCenter : vc1

Testing done:
1. "ExtNw" is created using dvportgroup.
2.  Extnet test passed and external network is using "VM NETWORK" portgroup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/359)
<!-- Reviewable:end -->
