### PR TITLE
Add methods for hosts to platform

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -376,6 +376,8 @@ class EntityType(Enum):
     EXTERNAL_NETWORK = 'application/vnd.vmware.admin.vmwexternalnet+xml'
     EXTERNAL_NETWORK_REFS = \
         'application/vnd.vmware.admin.vmwExternalNetworkReferences+xml'
+    HOST = 'application/vnd.vmware.admin.host+xml'
+    HOST_REFS = 'application/vnd.vmware.admin.vmwHostReferences+xml'
     INSTANTIATE_VAPP_TEMPLATE_PARAMS = \
         'application/vnd.vmware.vcloud.instantiateVAppTemplateParams+xml'
     GUEST_CUSTOMIZATION_SECTION = \

--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -1148,6 +1148,8 @@ class Platform(object):
     def enable_disable_host(self, name, enable_flag):
         """Enable or disable a host.
 
+        Deprecated since vCloud API version 31.0 (vCloud Director 9.5).
+
         :param str name: name of the host.
         :param boolean enable_flag: True means enable, False means disable.
 
@@ -1163,5 +1165,49 @@ class Platform(object):
         return self.client.post_linked_resource(
             resource=host,
             rel=(RelationType.ENABLE if enable_flag else RelationType.DISABLE),
+            media_type=None,
+            contents=None)
+
+    def prepare_host(self, name, username, password):
+        """Prepare a host.
+
+        Deprecated since vCloud API version 31.0 (vCloud Director 9.5).
+
+        :param str name: name of the host.
+        :param str username: username for preparing the host.
+        :param str password: password for preparing the host.
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is preparing the host.
+
+        rtype: lxml.objectify.ObjectifiedElement'
+        """
+        host = self.get_host(name)
+        params = E_VMEXT.PrepareHostParams(
+            E_VMEXT.Username(username),
+            E_VMEXT.Password(password)
+        )
+        return self.client.post_linked_resource(
+            resource=host,
+            rel=RelationType.EDIT,
+            media_type='application/vnd.vmware.admin.prepareHostParams+xml',
+            contents=params)
+
+    def unprepare_host(self, name):
+        """Unprepare a host.
+
+        Deprecated since vCloud API version 31.0 (vCloud Director 9.5).
+
+        :param str name: name of the host.
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is unpreparing the host.
+
+        rtype: lxml.objectify.ObjectifiedElement'
+        """
+        host = self.get_host(name)
+        return self.client.post_linked_resource(
+            resource=host,
+            rel=RelationType.EDIT,
             media_type=None,
             contents=None)

--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -711,10 +711,8 @@ class Platform(object):
                 media_type=EntityType.VMW_PVDC_STORAGE_PROFILE.value)
             num_links = len(links)
             if num_links == 1:
-                if hasattr(sp_resource,
-                   '{' + NSMAP['vcloud'] + '}Units'):
-                    units = \
-                        sp_resource['{' + NSMAP['vcloud'] + '}Units']
+                if hasattr(sp_resource, '{' + NSMAP['vcloud'] + '}Units'):
+                    units = sp_resource['{' + NSMAP['vcloud'] + '}Units']
                     disable_payload = \
                         E_VMEXT.VMWProviderVdcStorageProfile(
                             name=sp_name,
@@ -960,7 +958,7 @@ class Platform(object):
         :rtype: lxml.objectify.ObjectifiedElement
         """
         payload = E_VMEXT.NsxTManager(name=nsxt_manager_name)
-        if (nsxt_manager_description is not None):
+        if nsxt_manager_description is not None:
             payload.append(E.Description(nsxt_manager_description))
         payload.append(E_VMEXT.Username(nsxt_manager_username))
         payload.append(E_VMEXT.Password(nsxt_manager_password))
@@ -1162,10 +1160,8 @@ class Platform(object):
         host = self.get_host(name)
         if enable_flag == bool(host.Enabled):
             return None
-        else:
-            return self.client.post_linked_resource(
-                resource=host,
-                rel=RelationType.ENABLE if enable_flag \
-                    else RelationType.DISABLE,
-                media_type=None,
-                contents=None)
+        return self.client.post_linked_resource(
+            resource=host,
+            rel=(RelationType.ENABLE if enable_flag else RelationType.DISABLE),
+            media_type=None,
+            contents=None)

--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -1109,3 +1109,63 @@ class Platform(object):
                 if reference.get('id') == datastore_id:
                     return reference.get('href')
         raise EntityNotFoundException('Datastore id  \'%s\' not found' % id)
+
+    def list_hosts(self):
+        """List all hosts available in the system.
+
+        :return: list of lxml.objectify.ObjectifiedElement objects which
+            contains vmext:HostReference XML element representing
+            the host references.
+
+        :rtype: list
+        """
+        host_refs = self.client.get_linked_resource(
+            self.extension.get_resource(), RelationType.DOWN,
+            EntityType.HOST_REFS.value)
+
+        if hasattr(host_refs, 'HostReference'):
+            return host_refs.HostReference
+
+        return []
+
+    def get_host(self, name):
+        """Fetch an host resource identified by its name.
+
+        :param str name: name of the host to be retrieved.
+
+        :return: an object containing EntityType.HOST XML data
+            which represents a host.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+
+        :raises: EntityNotFoundException: If the named host cannot
+            be located.
+        """
+        host_refs = self.list_hosts()
+        for host in host_refs:
+            if host.get('name') == name:
+                return self.client.get_resource(host.get('href'))
+        raise EntityNotFoundException('Host \'%s\' not found.' % name)
+
+    def enable_disable_host(self, name, enable_flag):
+        """Enable or disable a host.
+
+        :param str name: name of the host.
+        :param boolean enable_flag: True means enable, False means disable.
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is enabling or disabling the host.
+            None, if the host was already in correct state.
+
+        rtype: lxml.objectify.ObjectifiedElement'
+        """
+        host = self.get_host(name)
+        if enable_flag == bool(host.Enabled):
+            return None
+        else:
+            return self.client.post_linked_resource(
+                resource=host,
+                rel=RelationType.ENABLE if enable_flag \
+                    else RelationType.DISABLE,
+                media_type=None,
+                contents=None)

--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -87,6 +87,9 @@ nsxt:
   admin_pwd: '<nsx-t admin password>'
   descrip: 'This is a description.'
 
+host:
+  host_name: 'host1'
+
 pvdc:
   pvdc_name: '<pvdc-name>'
   respools_to_attach: ['<resource-pool-name1>', '<resource-pool-name2>', ...]

--- a/system_tests/host_tests.py
+++ b/system_tests/host_tests.py
@@ -1,0 +1,101 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.environment import Environment
+
+from pyvcloud.vcd.exceptions import EntityNotFoundException
+from pyvcloud.vcd.platform import Platform
+
+
+class TestHost(BaseTestCase):
+    """Test Host functionalities implemented in pyvcloud."""
+
+    # All tests in this module should be run as System Administrator
+    _client = None
+    _config = None
+    _host_name = None
+    _non_existent_host_name = 'non_existent_host'
+
+    def test_0000_setup(self):
+        TestHost._client = Environment.get_sys_admin_client()
+        TestHost._config = Environment.get_config()
+        TestHost._host_name = self._config['host']['host_name']
+
+    def test_0010_list_hosts(self):
+        """Platform.list_hosts prints a list of hosts."""
+        logger = Environment.get_default_logger()
+        platform = Platform(TestHost._client)
+        hosts = platform.list_hosts()
+        for host in hosts:
+            logger.debug('Host found: %s' % host.get('name'))
+        self.assertTrue(len(hosts) > 0)
+
+    def test_0020_get_host(self):
+        """Platform.get_host finds a known host."""
+        logger = Environment.get_default_logger()
+        platform = Platform(TestHost._client)
+        host = platform.get_host(TestHost._host_name)
+        logger.debug('Host: name=%s' % (host.get('name')))
+        self.assertIsNotNone(host)
+
+    def test_0030_get_host_negative(self):
+        """Platform.get_host does not find a non-existent host."""
+        try:
+            platform = Platform(TestHost._client)
+            platform.get_host(TestHost._non_existent_host_name)
+            self.fail('Should not be able to find Host that does not exist ' +
+                      TestHost._non_existent_host_name)
+        except EntityNotFoundException as e:
+            return
+
+    # Enable and disable host tests are commented-out as these methods
+    # are deprecated since API version 31.0.
+
+    # def test_0050_enable_host(self):
+    #     """Platform.enable_host enables a host.
+
+    #     Wait for async command to complete before checking result.
+    #     """
+    #     platform = Platform(TestHost._client)
+
+    #     task = platform.enable_disable_host(
+    #         name=TestHost._host_name, enable_flag=True)
+    #     TestHost._client.get_task_monitor().wait_for_success(task=task)
+    #     host = platform.get_host(name=TestHost._host_name)
+    #     self.assertTrue(host.IsEnabled)
+
+    # def test_0070_disable_host(self):
+    #     """Platform.disable_host disables a host.
+
+    #     Wait for async command to complete before checking result.
+    #     """
+    #     platform = Platform(TestHost._client)
+
+    #     task = platform.enable_disable_host(
+    #         name=TestHost._host_name, enable_flag=False)
+    #     TestHost._client.get_task_monitor().wait_for_success(task=task)
+    #     host = platform.get_vcenter(name=TestHost._host_name)
+    #     self.assertFalse(host.IsEnabled)
+
+    def test_9999_cleanup(self):
+        """Release all resources held by this object for testing purposes."""
+        TestHost._client.logout()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/system_tests/run_system_tests.sh
+++ b/system_tests/run_system_tests.sh
@@ -35,6 +35,7 @@ UNSTABLE_TESTS="helpers/portgroup_helper.py \
 main.py \
 nsxt_tests.py \
 pvdc_tests.py \
+host_tests.py \
 vc_tests.py \
 cleanup_test.py \
 __init__.py"


### PR DESCRIPTION
This PR adds 5 methods for working with hosts:
- list_hosts()
- get_host(name)
- enable_disable_host(name, enable_flag) => Although deprecated since API 31.0.
- prepare_host(name, username, password) => Although deprecated since API 31.0.
- unprepare_host(name) => Although deprecated since API 31.0.

Unfortunately, I was not able to write some tests for those, as I don't have a local vCD instance and our environments don't have internet access for installing the dependencies. However, as the code is not very special that shouldn't be a problem, one can add the tests later. Additionally, we are already using it in production.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/362)
<!-- Reviewable:end -->
