### PR TITLE
VP-1300: [PySdk] List edge gateway's Syslog Server Settings

### DIFF
--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -602,3 +602,24 @@ class Gateway(object):
                                                RelationType.EDIT,
                                                EntityType.EDGE_GATEWAY.value,
                                                gateway)
+
+    def list_syslog_server_ip(self):
+        """List syslog server ip of the gateway.
+
+        This operation can be performed by System/Org Administrators.
+
+        :return: a dictionary that maps tenant syslog server to ip
+            address. Ex: {'Tenant Syslog server:': '1.1.1.1'}
+
+        :rtype: dict
+        """
+        gateway = self.get_resource()
+        out = {}
+        syslogserver_settings = gateway.Configuration.SyslogServerSettings.\
+            TenantSyslogServerSettings
+        if hasattr(syslogserver_settings, 'SyslogServerIp'):
+            out["Tenant Syslog server"] = syslogserver_settings.SyslogServerIp
+        else:
+            raise EntityNotFoundException('TenantSyslogServer Ip in gateway' +
+                                          self.name + 'is not set.')
+        return out

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -459,6 +459,19 @@ class TestGateway(BaseTestCase):
                 self.assertEqual(self._rate_limit_end,
                                  gateway_inf.OutRateLimit.text)
 
+    @unittest.skip("Skipping test case because set syslog server is not in "
+                   "code")
+    def test_0018_list_syslog_settings(self):
+        """List Tenant syslog server of the gateway.
+
+        Invoke the list_syslog_server_ip function of gateway.
+        """
+        for client in (TestGateway._client, TestGateway._org_client):
+            gateway_obj = Gateway(client, self._name,
+                                  TestGateway._gateway.get('href'))
+            tenant_syslog_server = gateway_obj.list_syslog_server_ip()
+            self.assertEqual(len(tenant_syslog_server), 1)
+
     def test_0098_teardown(self):
         """Test the method System.delete_gateway().
 


### PR DESCRIPTION
[PySdk] List edge gateway's Syslog Server Settings

This CLN has code for listing tenant syslog server of a gateway. Test
case is also included. test case is skipped because set syslog server
code is not written before. unittest.skip will be removed once set
tenant syslog server is written.

Testing done:
Test case for list syslog server  is added to a test class
gateway_tests.py
All tests in gateway_tests passed.

To help us process your pull request efficiently, please include: 

- (Required) Short description of changes in the PR topic line

- (Required) Detailed description of changes include tests and
  documentation.  If the pull request contains multiple commits with 
  detailed messages, refer to those instead

- (Optional) Names of reviewers using @ sign + name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/364)
<!-- Reviewable:end -->
