### PR TITLE
Add methods for storage profiles to pvdc and vdc

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -438,6 +438,8 @@ class EntityType(Enum):
     UNDEPLOY = 'application/vnd.vmware.vcloud.undeployVAppParams+xml'
     UPDATE_PROVIDER_VDC_STORAGE_PROFILES = \
         'application/vnd.vmware.admin.updateProviderVdcStorageProfiles+xml'
+    UPDATE_VDC_STORAGE_PROFILES = \
+        'application/vnd.vmware.admin.updateVdcStorageProfiles+xml'
     UPLOAD_VAPP_TEMPLATE_PARAMS = \
         'application/vnd.vmware.vcloud.uploadVAppTemplateParams+xml'
     USER = 'application/vnd.vmware.admin.user+xml'
@@ -448,6 +450,8 @@ class EntityType(Enum):
     VDC_COMPUTE_POLICY_REFERENCES = \
         "application/vnd.vmware.vcloud.vdcComputePolicyReferences+xml"
     VDC_REFERENCES = 'application/vnd.vmware.admin.vdcReferences+xml'
+    VDC_STORAGE_PROFILE = 'application/vnd.vmware.vcloud.vdcStorageProfile+xml'
+    VDC_STORAGE_PROFILE_ADMIN = 'application/vnd.vmware.admin.vdcStorageProfile+xml'
     VDCS_PARAMS = 'application/vnd.vmware.admin.createVdcParams+xml'
     VIM_SERVER_REFS = 'application/vnd.vmware.admin.vmwVimServerReferences+xml'
     VIRTUAL_CENTER = 'application/vnd.vmware.admin.vmwvirtualcenter+xml'

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -451,7 +451,8 @@ class EntityType(Enum):
         "application/vnd.vmware.vcloud.vdcComputePolicyReferences+xml"
     VDC_REFERENCES = 'application/vnd.vmware.admin.vdcReferences+xml'
     VDC_STORAGE_PROFILE = 'application/vnd.vmware.vcloud.vdcStorageProfile+xml'
-    VDC_STORAGE_PROFILE_ADMIN = 'application/vnd.vmware.admin.vdcStorageProfile+xml'
+    VDC_STORAGE_PROFILE_ADMIN = \
+        'application/vnd.vmware.admin.vdcStorageProfile+xml'
     VDCS_PARAMS = 'application/vnd.vmware.admin.createVdcParams+xml'
     VIM_SERVER_REFS = 'application/vnd.vmware.admin.vmwVimServerReferences+xml'
     VIRTUAL_CENTER = 'application/vnd.vmware.admin.vmwvirtualcenter+xml'

--- a/pyvcloud/vcd/pvdc.py
+++ b/pyvcloud/vcd/pvdc.py
@@ -143,8 +143,8 @@ class PVDC(object):
         profile_list = []
         self.get_resource()
 
-        if hasattr(self.resource, 'StorageProfiles') and \
-            hasattr(self.resource.StorageProfiles, 'ProviderVdcStorageProfile'):
+        if hasattr(self.resource, 'StorageProfiles') and hasattr(
+                self.resource.StorageProfiles, 'ProviderVdcStorageProfile'):
             profiles = self.resource.StorageProfiles.ProviderVdcStorageProfile
             for profile in profiles:
                 profile_list.append(profile)
@@ -163,8 +163,8 @@ class PVDC(object):
         """
         self.get_resource()
 
-        if hasattr(self.resource, 'StorageProfiles') and \
-            hasattr(self.resource.StorageProfiles, 'ProviderVdcStorageProfile'):
+        if hasattr(self.resource, 'StorageProfiles') and hasattr(
+                self.resource.StorageProfiles, 'ProviderVdcStorageProfile'):
             profiles = self.resource.StorageProfiles.ProviderVdcStorageProfile
             for profile in profiles:
                 if profile.get('name') == profile_name:

--- a/pyvcloud/vcd/pvdc.py
+++ b/pyvcloud/vcd/pvdc.py
@@ -16,6 +16,7 @@ from pyvcloud.vcd.client import E
 from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import NSMAP
 from pyvcloud.vcd.client import RelationType
+from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import InvalidParameterException
 from pyvcloud.vcd.utils import get_admin_href
 
@@ -129,3 +130,45 @@ class PVDC(object):
         return self.client.post_linked_resource(metadata, RelationType.ADD,
                                                 EntityType.METADATA.value,
                                                 new_metadata)
+
+    def get_storage_profiles(self):
+        """Fetch a list of the Storage Profiles defined in a provider vdc.
+
+        :return: a list of lxml.objectify.ObjectifiedElement objects, where
+            each object contains a ProviderVdcStorageProfile XML element
+            representing an existing storage profile.
+
+        :rtype: list
+        """
+        profile_list = []
+        self.get_resource()
+
+        if hasattr(self.resource, 'StorageProfiles') and \
+            hasattr(self.resource.StorageProfiles, 'ProviderVdcStorageProfile'):
+            profiles = self.resource.StorageProfiles.ProviderVdcStorageProfile
+            for profile in profiles:
+                profile_list.append(profile)
+            return profile_list
+        return None
+
+    def get_storage_profile(self, profile_name):
+        """Fetch a specific Storage Profile within an provider vdc.
+
+        :param str profile_name: name of the requested storage profile.
+
+        :return: an object containing ProviderVdcStorageProfile XML element
+            that represents the requested storage profile.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        self.get_resource()
+
+        if hasattr(self.resource, 'StorageProfiles') and \
+            hasattr(self.resource.StorageProfiles, 'ProviderVdcStorageProfile'):
+            profiles = self.resource.StorageProfiles.ProviderVdcStorageProfile
+            for profile in profiles:
+                if profile.get('name') == profile_name:
+                    return profile
+
+        raise EntityNotFoundException(
+            'Storage Profile named \'%s\' not found' % profile_name)

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -1081,16 +1081,17 @@ class VDC(object):
         params = E.AdminVdcStorageProfile(
             E.Enabled(enabled),
             E.Units(
-                str(profile_admin_res.Units) if limit_in_mb is None \
+                str(profile_admin_res.Units) if limit_in_mb is None
                 else 'MB'),
             E.Limit(
-                int(profile_admin_res.Limit) if limit_in_mb is None \
+                int(profile_admin_res.Limit) if limit_in_mb is None
                 else limit_in_mb),
             E.Default(
-                bool(profile_admin_res.Default) if default is None \
+                bool(profile_admin_res.Default) if default is None
                 else default),
-            E.ProviderVdcStorageProfile('', href=\
-                profile_admin_res.ProviderVdcStorageProfile.get('href')),
+            E.ProviderVdcStorageProfile(
+                '',
+                href=profile_admin_res.ProviderVdcStorageProfile.get('href')),
             href=profile_admin_res.get('href'),
             name=profile_admin_res.get('name')
         )

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -39,6 +39,7 @@ from pyvcloud.vcd.exceptions import OperationNotSupportedException
 from pyvcloud.vcd.metadata import Metadata
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.platform import Platform
+from pyvcloud.vcd.pvdc import PVDC
 from pyvcloud.vcd.utils import cidr_to_netmask
 from pyvcloud.vcd.utils import get_admin_href
 from pyvcloud.vcd.utils import is_admin
@@ -1000,6 +1001,128 @@ class VDC(object):
 
         raise EntityNotFoundException(
             'Storage Profile named \'%s\' not found' % profile_name)
+
+    def get_default_storage_profile(self):
+        """Fetch the default Storage Profile within an org vdc.
+
+        :return: an object containing VdcStorageProfile XML element that
+            represents the requested storage profile.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        for profile in self.get_storage_profiles():
+            profile_admin_href = get_admin_href(profile.get('href'))
+            profile_admin_res = self.client.get_resource(profile_admin_href)
+            if bool(profile_admin_res.Default):
+                return profile_admin_res
+
+        raise EntityNotFoundException('Default Storage Profile not found')
+
+    def add_storage_profile(self, profile_name,
+                            enabled=True, default=False, limit_in_mb=0):
+        """Add a storage profile to the vdc.
+
+        :param str profile_name: name of the storage profile.
+        :param bool enabled: True, if the profile should be enabled
+            (default to True).
+        :param bool default: True, if the profile should be the default profile
+            (default to False).
+        :param int limit_in_mb: the profile limit in MB
+            (default to 0, means unlimited).
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vdc storage profiles.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        resource_admin = self.client.get_resource(self.href_admin)
+
+        pvdc_href = resource_admin.ProviderVdcReference.get('href')
+        pvdc = PVDC(self.client, href=pvdc_href)
+        pvdc_profile = pvdc.get_storage_profile(profile_name)
+
+        params = E.UpdateVdcStorageProfiles(
+            E.AddStorageProfile(
+                E.Enabled(enabled),
+                E.Units('MB'),
+                E.Limit(limit_in_mb),
+                E.Default(default),
+                E.ProviderVdcStorageProfile('', href=pvdc_profile.get('href'))
+            )
+        )
+
+        return self.client.post_linked_resource(
+            resource=resource_admin,
+            rel=RelationType.EDIT,
+            media_type=EntityType.UPDATE_VDC_STORAGE_PROFILES.value,
+            contents=params)
+
+    def update_storage_profile(self, profile_name, enabled,
+                               default=None, limit_in_mb=None):
+        """Update a storage profile of the vdc.
+
+        :param str profile_name: name of the storage profile.
+        :param bool enabled: True, if the profile should be enabled
+            (default to True).
+        :param bool default: True, if the profile should be the default profile
+            (default to None, means current value).
+        :param int limit_in_mb: the profile limit in MB
+            (default to None, means current value).
+
+        :return: an object containing AdminVdcStorageProfile XML element that
+            represents the updated storage profile.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        profile = self.get_storage_profile(profile_name)
+        profile_admin_href = get_admin_href(profile.get('href'))
+        profile_admin_res = self.client.get_resource(profile_admin_href)
+
+        params = E.AdminVdcStorageProfile(
+            E.Enabled(enabled),
+            E.Units(
+                str(profile_admin_res.Units) if limit_in_mb is None \
+                else 'MB'),
+            E.Limit(
+                int(profile_admin_res.Limit) if limit_in_mb is None \
+                else limit_in_mb),
+            E.Default(
+                bool(profile_admin_res.Default) if default is None \
+                else default),
+            E.ProviderVdcStorageProfile('', href=\
+                profile_admin_res.ProviderVdcStorageProfile.get('href')),
+            href=profile_admin_res.get('href'),
+            name=profile_admin_res.get('name')
+        )
+
+        return self.client.put_resource(
+            uri=profile_admin_res.get('href'),
+            contents=params,
+            media_type=EntityType.VDC_STORAGE_PROFILE_ADMIN.value)
+
+    def remove_storage_profile(self, profile_name):
+        """Remove a storage profile from the vdc.
+
+        :param str profile_name: name of the storage profile.
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vdc storage profiles.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        resource_admin = self.client.get_resource(self.href_admin)
+
+        profile = self.get_storage_profile(profile_name)
+
+        params = E.UpdateVdcStorageProfiles(
+            E.RemoveStorageProfile('', href=profile.get('href'))
+        )
+
+        return self.client.post_linked_resource(
+            resource=resource_admin,
+            rel=RelationType.EDIT,
+            media_type=EntityType.UPDATE_VDC_STORAGE_PROFILES.value,
+            contents=params)
 
     def enable_vdc(self, enable=True):
         """Enable current vdc.

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -847,25 +847,6 @@ class VDC(object):
         return self.client.put_resource(
             disk.get('href') + '/owner/', new_owner, EntityType.OWNER.value)
 
-    def get_storage_profiles(self):
-        """Fetch a list of the Storage Profiles defined in a vdc.
-
-        :return: a list of lxml.objectify.ObjectifiedElement objects, where
-            each object contains VdcStorageProfile XML element representing an
-            existing storage profile.
-
-        :rtype: list
-        """
-        profile_list = []
-        self.get_resource()
-
-        if hasattr(self.resource, 'VdcStorageProfiles') and \
-           hasattr(self.resource.VdcStorageProfiles, 'VdcStorageProfile'):
-            for profile in self.resource.VdcStorageProfiles.VdcStorageProfile:
-                profile_list.append(profile)
-            return profile_list
-        return None
-
     def get_all_metadata(self):
         """Fetch all metadata entries of the org vdc.
 
@@ -980,6 +961,25 @@ class VDC(object):
             client=self.client, resource=self.get_all_metadata())
         return metadata.remove_metadata(
             key=key, domain=domain, use_admin_endpoint=True)
+
+    def get_storage_profiles(self):
+        """Fetch a list of the Storage Profiles defined in a vdc.
+
+        :return: a list of lxml.objectify.ObjectifiedElement objects, where
+            each object contains VdcStorageProfile XML element representing an
+            existing storage profile.
+
+        :rtype: list
+        """
+        profile_list = []
+        self.get_resource()
+
+        if hasattr(self.resource, 'VdcStorageProfiles') and \
+           hasattr(self.resource.VdcStorageProfiles, 'VdcStorageProfile'):
+            for profile in self.resource.VdcStorageProfiles.VdcStorageProfile:
+                profile_list.append(profile)
+            return profile_list
+        return None
 
     def get_storage_profile(self, profile_name):
         """Fetch a specific Storage Profile within an org vdc.


### PR DESCRIPTION
This PR adds 6 methods for working with storage profiles:
- PVDC:
    - get_storage_profiles()
    - get_storage_profile(profile_name)
- VDC:
    - get_default_storage_profile()
    - add_storage_profile(profile_name, enabled=True, default=False, limit_in_mb=0)
    - update_storage_profile(profile_name, enabled, default=None, limit_in_mb=None)
    - remove_storage_profile(profile_name)

Unfortunately, I was not able to write some tests for those, as I don't have a local vCD instance and our environments don't have internet access for installing the dependencies. However, as the code is not very special that shouldn't be a problem, one can add the tests later. Additionally, we are already using it in production.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/366)
<!-- Reviewable:end -->
