### PR TITLE
Add several methods to vdc, vapp and vm

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -301,7 +301,7 @@ class ResourceType(Enum):
     ORG_VDC_NETWORK = 'orgVdcNetwork'
     ORG_VDC_RESOURCE_POOL_RELATION = 'orgVdcResourcePoolRelation'
     ORG_VDC_STORAGE_PROFILE = 'orgVdcStorageProfile'
-    PORT_GROUP = 'portgroup'
+    PORT_GROUP = 'portGroup'
     PROVIDER_VDC = 'providerVdc'
     PROVIDER_VDC_RESOURCE_POOL_RELATION = 'providerVdcResourcePoolRelation'
     PROVIDER_VDC_STORAGE_PROFILE = 'providerVdcStorageProfile'
@@ -376,14 +376,14 @@ class EntityType(Enum):
     EXTERNAL_NETWORK = 'application/vnd.vmware.admin.vmwexternalnet+xml'
     EXTERNAL_NETWORK_REFS = \
         'application/vnd.vmware.admin.vmwExternalNetworkReferences+xml'
-    HOST = 'application/vnd.vmware.admin.host+xml'
-    HOST_REFS = 'application/vnd.vmware.admin.vmwHostReferences+xml'
-    INSTANTIATE_VAPP_TEMPLATE_PARAMS = \
-        'application/vnd.vmware.vcloud.instantiateVAppTemplateParams+xml'
     GUEST_CUSTOMIZATION_SECTION = \
         'application/vnd.vmware.vcloud.guestCustomizationSection+xml'
     HISTORIC_USAGE = \
         'application/vnd.vmware.vcloud.metrics.historicUsageSpec+xml'
+    HOST = 'application/vnd.vmware.admin.host+xml'
+    HOST_REFS = 'application/vnd.vmware.admin.vmwHostReferences+xml'
+    INSTANTIATE_VAPP_TEMPLATE_PARAMS = \
+        'application/vnd.vmware.vcloud.instantiateVAppTemplateParams+xml'
     JSON = 'application/json'
     LEASE_SETTINGS = 'application/vnd.vmware.vcloud.leaseSettingsSection+xml'
     MEDIA = 'application/vnd.vmware.vcloud.media+xml'

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -554,6 +554,24 @@ class VApp(object):
         return self._perform_power_operation(
             rel=RelationType.POWER_REBOOT, operation_name='reboot')
 
+    def set_name(self, name):
+        """Set the name of the vApp.
+
+        :param str name: new name for the vApp.
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is recomposing the vApp.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        self.get_resource()
+        params = E.RecomposeVAppParams(
+            name=name
+        )
+        return self.client.post_linked_resource(
+            self.resource, RelationType.RECOMPOSE,
+            EntityType.RECOMPOSE_VAPP_PARAMS.value, params)
+
     def connect_vm(self, mode='DHCP', reset_mac_address=False):
         self.get_resource()
         if hasattr(self.resource, 'Children') and \

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -554,24 +554,6 @@ class VApp(object):
         return self._perform_power_operation(
             rel=RelationType.POWER_REBOOT, operation_name='reboot')
 
-    def set_name(self, name):
-        """Set the name of the vApp.
-
-        :param str name: new name for the vApp.
-
-        :return: an object containing EntityType.TASK XML data which represents
-            the asynchronous task that is recomposing the vApp.
-
-        :rtype: lxml.objectify.ObjectifiedElement
-        """
-        self.get_resource()
-        params = E.RecomposeVAppParams(
-            name=name
-        )
-        return self.client.post_linked_resource(
-            self.resource, RelationType.RECOMPOSE,
-            EntityType.RECOMPOSE_VAPP_PARAMS.value, params)
-
     def connect_vm(self, mode='DHCP', reset_mac_address=False):
         self.get_resource()
         if hasattr(self.resource, 'Children') and \

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -151,8 +151,8 @@ class VDC(object):
         :rtype: lxml.objectify.ObjectifiedElement
 
         :raises: MissingRecordException: if the named VM can not be found.
-        :raises: MultipleRecordsException: if more than one VM with the provided
-            name are found.
+        :raises: MultipleRecordsException: if more than one VM with the
+            provided name are found.
         """
         vdc_filter = ('vdc==%s' % self.href)
         name_filter = ('name', name)

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -1042,12 +1042,22 @@ class VDC(object):
 
         :rtype: str
         """
-        self.get_resource()
+        return self._get_vc_ref().get('name')
 
-        vim_server_ref = self.resource.VCloudExtension[
+    def get_vc_resource(self):
+        """Returns the vCenter where this vdc is located as resource.
+
+        :return: an object containing EntityType.VIRTUAL_CENTER XML data which
+                 represents the vCenter of this vdc.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        return self.client.get_resource(self._get_vc_ref().get('href'))
+
+    def _get_vc_ref(self):
+        return self.get_resource().VCloudExtension[
             '{' + NSMAP['vmext'] + '}VimObjectRef'][
                 '{' + NSMAP['vmext'] + '}VimServerRef']
-        return vim_server_ref.get('name')
 
     def get_access_settings(self):
         """Get the access settings of the vdc.

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -435,6 +435,61 @@ class VM(object):
         return self._perform_power_operation(
             rel=RelationType.POWER_RESET, operation_name='power reset')
 
+    def discard_suspended_state(self):
+        """Discard the suspended state of the vm.
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is discarding the vm's suspended state.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        self.get_resource()
+        return self.client.post_linked_resource(
+            self.resource, RelationType.DISCARD_SUSPENDED_STATE, None, None)
+
+    def set_name(self, name):
+        """Set the name of the vm.
+
+        :param str name: new name for the vm.
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is reconfiguring the vm.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        self.get_resource()
+        params = E.Vm(
+            name=name
+        )
+        return self.client.post_linked_resource(
+            self.resource, RelationType.RECONFIGURE_VM,
+            EntityType.VM.value, params)
+
+    def set_hostname(self, hostname):
+        """Set the hostname (computer name) of the vm.
+
+        :param str hostname: new hostname for the vm.
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vm's guest customization
+            section.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        from lxml import objectify
+
+        self.get_resource()
+
+        # Get current values and overwrite only ComputerName
+        params = self.resource.GuestCustomizationSection
+        params.ComputerName = objectify.DataElement(
+            hostname, nsmap='', _pytype='')
+
+        return self.client.put_resource(
+            self.resource.GuestCustomizationSection.get('href'),
+            params,
+            EntityType.GUEST_CUSTOMIZATION_SECTION.value)
+
     def deploy(self, power_on=True, force_customization=False):
         """Deploys the vm.
 

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -473,28 +473,30 @@ class VM(object):
         return self.client.post_linked_resource(
             self.resource, RelationType.DISCARD_SUSPENDED_STATE, None, None)
 
-    def set_name(self, name):
-        """Set the name of the vm.
+    def edit_name(self, name):
+        """Edit name of the vm.
 
-        :param str name: new name for the vm.
+        :param str name: New name of the vm. It is mandatory.
 
         :return: an object containing EntityType.TASK XML data which represents
             the asynchronous task that is reconfiguring the vm.
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
+        if name is None or name.isspace():
+            raise InvalidParameterException("Name can't be None or empty")
         self.get_resource()
         params = E.Vm(
-            name=name
+            name=name.strip()
         )
         return self.client.post_linked_resource(
             self.resource, RelationType.RECONFIGURE_VM,
             EntityType.VM.value, params)
 
-    def set_hostname(self, hostname):
-        """Set the hostname (computer name) of the vm.
+    def edit_hostname(self, hostname):
+        """Edit hostname (computer name) of the vm.
 
-        :param str hostname: new hostname for the vm.
+        :param str hostname: new hostname of the vm. It is mandatory.
 
         :return: an object containing EntityType.TASK XML data which represents
             the asynchronous task that is updating the vm's guest customization
@@ -502,14 +504,14 @@ class VM(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        from lxml import objectify
-
+        if hostname is None or hostname.isspace():
+            raise InvalidParameterException("Hostname can't be None or empty")
         self.get_resource()
-
         # Get current values and overwrite only ComputerName
+        from lxml import objectify
         params = self.resource.GuestCustomizationSection
         params.ComputerName = objectify.DataElement(
-            hostname, nsmap='', _pytype='')
+            hostname.strip(), nsmap='', _pytype='')
 
         return self.client.put_resource(
             self.resource.GuestCustomizationSection.get('href'),

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -103,6 +103,20 @@ class VM(object):
                     return record.VimServerRef.get('name')
         return None
 
+    def get_moid(self):
+        """Returns the vCenter MoRef of this vm.
+
+        :return: MoRef of this vm.
+
+        :rtype: str
+        """
+        if hasattr(self.get_resource(), 'VCloudExtension'):
+            return self.get_resource().VCloudExtension[
+                '{' + NSMAP['vmext'] + '}VmVimInfo'][
+                    '{' + NSMAP['vmext'] + '}VmVimObjectRef'][
+                        '{' + NSMAP['vmext'] + '}MoRef'].text
+        return None
+
     def get_cpus(self):
         """Returns the number of CPUs in the vm.
 

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -435,6 +435,18 @@ class VM(object):
         return self._perform_power_operation(
             rel=RelationType.POWER_RESET, operation_name='power reset')
 
+    def suspend(self):
+        """Suspend the vm.
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is suspending the VM.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        self.get_resource()
+        return self._perform_power_operation(
+            rel=RelationType.POWER_SUSPEND, operation_name='suspend')
+
     def discard_suspended_state(self):
         """Discard the suspended state of the vm.
 
@@ -708,31 +720,6 @@ class VM(object):
         return self.client.put_linked_resource(
             net_conn_section, RelationType.EDIT,
             EntityType.NETWORK_CONNECTION_SECTION.value, net_conn_section)
-
-    def suspend(self):
-        """Suspend the vm.
-
-        :return: an object containing EntityType.TASK XML data which represents
-            the asynchronous task that is suspending the VM.
-
-        :rtype: lxml.objectify.ObjectifiedElement
-        """
-        self.get_resource()
-        return self._perform_power_operation(
-            rel=RelationType.POWER_SUSPEND, operation_name='suspend')
-
-    def discard_suspended_state(self):
-        """Discard suspended state of the vm.
-
-        :return: an object containing EntityType.TASK XML data which represents
-                    the asynchronous task that is discarding suspended state
-                    of VM.
-
-        :rtype: lxml.objectify.ObjectifiedElement
-        """
-        self.get_resource()
-        return self.client.post_linked_resource(
-            self.resource, RelationType.DISCARD_SUSPENDED_STATE, None, None)
 
     def install_vmware_tools(self):
         """Install vmware tools in the vm.


### PR DESCRIPTION
This PR adds 7 methods:
- VDC:
    - get_resource_admin()
    - query_vm_by_name(name)
    - get_vc()
- ~~VApp~~:
    - ~~set_name(name)~~
- VM:
    - discard_suspended_state()
    - ~~set~~edit_name(name)
    - ~~set~~edit_hostname(hostname)

Unfortunately, I was not able to write some tests for those, as I don't have a local vCD instance and our environments don't have internet access for installing the dependencies. However, as the code is not very special that shouldn't be a problem, one can add the tests later. Additionally, we are already using it in production.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/367)
<!-- Reviewable:end -->
