### PR TITLE
VP 1264: [PySdk] List allocated IP addresses

### DIFF
--- a/pyvcloud/vcd/external_network.py
+++ b/pyvcloud/vcd/external_network.py
@@ -475,3 +475,41 @@ class ExternalNetwork(object):
             if gw_inf.InterfaceType == "uplink" and gw_inf.Name == self.name:
                 return gateway_resource.get('name')
         return None
+
+    def list_allocated_ip_address(self, filter=None):
+        """List allocated ip address of gateways.
+
+        :param str filter: filter to fetch the selected gateway, e.g.,
+        name==gateway*
+        :return: dict allocated ip address of associated gateways
+        :rtype: dict
+        """
+        gateway_name_allocated_ip_dict = {}
+        query = self.client.get_typed_query(
+            ResourceType.EDGE_GATEWAY.value,
+            query_result_format=QueryResultFormat.RECORDS,
+            qfilter=filter)
+        records = query.execute()
+        if records is None:
+            raise EntityNotFoundException('No Gateway found associated')
+        for record in records:
+            href = record.get('href')
+            gateway_entry = self.\
+                _get_gateway_allocated_ip_for_provided_ext_nw(href)
+            if gateway_entry is not None:
+                gateway_name_allocated_ip_dict[gateway_entry[0]] = \
+                    gateway_entry[1]
+        return gateway_name_allocated_ip_dict
+
+    def _get_gateway_allocated_ip_for_provided_ext_nw(self, gateway_href):
+        gateway_allocated_ip = []
+        gateway = Gateway(self.client, href=gateway_href)
+        gateway_resource = gateway.get_resource()
+        gateway_interfaces = gateway_resource.Configuration.GatewayInterfaces
+        for gw_inf in gateway_interfaces.GatewayInterface:
+            if gw_inf.InterfaceType == "uplink" and gw_inf.Name == self.name:
+                gateway_allocated_ip.append(gateway_resource.get('name'))
+                gateway_allocated_ip.\
+                    append(gw_inf.SubnetParticipation.IpAddress)
+                return gateway_allocated_ip
+        return None

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -399,6 +399,28 @@ class TestExtNet(BaseTestCase):
         gateway_name_list = extnet_obj.list_extnw_gateways('name==*')
         self.assertTrue(len(gateway_name_list) > 0)
 
+    def test_0085_list_allocated_ip(self):
+        """List allocated ip.
+        """
+        platform = Platform(TestExtNet._sys_admin_client)
+        ext_net_name = TestExtNet._config['external_network']['name']
+        ext_net_resource = platform.get_external_network(ext_net_name)
+        extnet_obj = ExternalNetwork(TestExtNet._sys_admin_client,
+                                    resource=ext_net_resource)
+        allocated_ip_dict = extnet_obj.list_allocated_ip_address()
+        self.assertTrue(len(allocated_ip_dict) > 0)
+
+    def test_0090_list_allocated_ip__with_gateway_filter(self):
+        """List allocated ips.
+        """
+        platform = Platform(TestExtNet._sys_admin_client)
+        ext_net_name = TestExtNet._config['external_network']['name']
+        ext_net_resource = platform.get_external_network(ext_net_name)
+        extnet_obj = ExternalNetwork(TestExtNet._sys_admin_client,
+                                    resource=ext_net_resource)
+        allocated_ip_dict = extnet_obj.list_allocated_ip_address('name==*')
+        self.assertTrue(len(allocated_ip_dict) > 0)
+
     @developerModeAware
     def test_9998_teardown(self):
         """Test the method Platform.delete_external_network().


### PR DESCRIPTION
[PySdk] List allocated IP addresses

This CLN contains code related to listing allocated IP address with
gateways name associated with given external network. This code also
contains related test cases.

Testing done:
Test case for list associated ip with gateway name  is added to a test
class extnet_tests.py
All tests in extnet_tests passed.

