### PR TITLE
VP-1246: List associated direct org vDC networks in external network

### DIFF
--- a/pyvcloud/system_test_framework/base_test.py
+++ b/pyvcloud/system_test_framework/base_test.py
@@ -38,6 +38,7 @@ class BaseTestCase(unittest.TestCase):
         Environment.create_org()
         Environment.create_users()
         Environment.create_ovdc()
+        Environment.create_direct_ovdc_network()
         Environment.create_gateway()
         Environment.create_ovdc_network()
         Environment.create_catalog()

--- a/pyvcloud/system_test_framework/environment.py
+++ b/pyvcloud/system_test_framework/environment.py
@@ -557,6 +557,42 @@ class Environment(object):
             .wait_for_success(task=result.Tasks.Task[0])
 
     @classmethod
+    def create_direct_ovdc_network(cls):
+        """Creates a direct org vdc network.
+
+        The name of the created org vdc network is specified in the
+        configuration file, skips creating one, if such a network already
+        exists.
+
+        :raises: Exception: if the class variable _ovdc_href is not populated.
+        """
+        cls._basic_check()
+        if cls._ovdc_href is None:
+            raise Exception('OrgVDC ' +
+                            cls._config['vcd']['default_ovdc_name'] +
+                            ' doesn\'t exist.')
+
+        vdc = VDC(cls._sys_admin_client, href=cls._ovdc_href)
+        expected_net_name = cls._config['vcd']['default_direct ovdc_network_name']
+        records_dict = vdc.list_orgvdc_network_records()
+
+        for net_name in records_dict.keys():
+            if net_name.lower() == expected_net_name.lower():
+                cls._logger.debug('Reusing existing direct org-vdc network ' +
+                                  expected_net_name)
+                return
+
+        cls._logger.debug('Creating direct org-vdc network ' + expected_net_name)
+        result = vdc.create_directly_connected_vdc_network(
+            network_name=expected_net_name,
+            parent_network_name=cls._config['external_network']['name'],
+            description='direct org vdc network',
+            is_shared=False)
+
+        cls._sys_admin_client.get_task_monitor()\
+            .wait_for_success(task=result.Tasks.Task[0])
+
+    @classmethod
     def create_catalog(cls):
         """Creates a catalog by the name specified in the configuration  file.
 

--- a/pyvcloud/vcd/external_network.py
+++ b/pyvcloud/vcd/external_network.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import urllib
-
 from pyvcloud.vcd.client import E
 from pyvcloud.vcd.client import E_VMEXT
 from pyvcloud.vcd.client import EntityType
@@ -562,15 +560,16 @@ class ExternalNetwork(object):
         gateway = Gateway(self.client, href=gateway_href)
         return gateway.get_resource()
 
-    def list_associated_direct_org_vdc_networks(self):
+    def list_associated_direct_org_vdc_networks(self, filter=None):
         """List associated direct org vDC networks.
 
+        :param str filter: filter to fetch the direct org vDC network,
+        e.g., connectedTo==Ext*
         :return: list of direct org vDC networks
         :rtype: list
         :raises: EntityNotFoundException: if any direct org vDC network
          cannot be found.
         """
-        filter = 'connectedTo==%s' % urllib.parse.quote_plus(self.name)
         query = self.client.get_typed_query(
             ResourceType.ORG_VDC_NETWORK.value,
             qfilter=filter,

--- a/pyvcloud/vcd/external_network.py
+++ b/pyvcloud/vcd/external_network.py
@@ -12,6 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import urllib
+
 from pyvcloud.vcd.client import E
 from pyvcloud.vcd.client import E_VMEXT
 from pyvcloud.vcd.client import EntityType
@@ -558,3 +561,24 @@ class ExternalNetwork(object):
     def __get_gateway_resource(self, gateway_href):
         gateway = Gateway(self.client, href=gateway_href)
         return gateway.get_resource()
+
+    def list_associated_direct_org_vdc_networks(self):
+        """List associated direct org vDC networks.
+
+        :return: list of direct org vDC networks
+        :rtype: list
+        :raises: EntityNotFoundException: if any direct org vDC network
+         cannot be found.
+        """
+        filter = 'connectedTo==%s' % urllib.parse.quote_plus(self.name)
+        query = self.client.get_typed_query(
+            ResourceType.ORG_VDC_NETWORK.value,
+            qfilter=filter,
+            query_result_format=QueryResultFormat.RECORDS)
+        records = list(query.execute())
+
+        direct_ovdc_network_names = [record.get('name') for record in records]
+        if len(direct_ovdc_network_names) == 0:
+            raise EntityNotFoundException('No associated direct org vDC '
+                                          'networks found')
+        return direct_ovdc_network_names

--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -51,6 +51,7 @@ vcd:
   default_ovdc_network_name: 'test-isolated-vdc-network'
   default_ovdc_network_gateway_ip: '10.1.1.1'
   default_ovdc_network_gateway_netmask: '255.255.255.0'
+  default_direct ovdc_network_name: 'test-direct-vdc-network'
 
   default_catalog_name: 'test-cat'
   default_template_file_name: 'test_vapp_template.ova'

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -457,6 +457,17 @@ class TestExtNet(BaseTestCase):
         self.assertTrue(len(sub_allocated_ip_dict) > 0)
         self.__remove_sub_allocate_ip_pool()
 
+    def test_0100_list_associated_direct_org_vdc_networks(self):
+        """List associated direct org vDC networks
+        """
+        platform = Platform(TestExtNet._sys_admin_client)
+        ext_net_name = TestExtNet._config['external_network']['name']
+        ext_net_resource = platform.get_external_network(ext_net_name)
+        extnet_obj = ExternalNetwork(TestExtNet._sys_admin_client,
+                                     resource=ext_net_resource)
+        direct_ovdc_networks = extnet_obj.list_associated_direct_org_vdc_networks()
+        self.assertTrue(len(direct_ovdc_networks) > 0)
+
     def __add_sub_allocate_ip_pool(self):
         gateway = Environment. \
             get_test_gateway(TestExtNet._sys_admin_client)

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -461,11 +461,12 @@ class TestExtNet(BaseTestCase):
         """List associated direct org vDC networks
         """
         platform = Platform(TestExtNet._sys_admin_client)
-        ext_net_name = TestExtNet._config['external_network']['name']
-        ext_net_resource = platform.get_external_network(ext_net_name)
+        ext_net_resource = platform.get_external_network(
+            TestExtNet._common_ext_net_name)
         extnet_obj = ExternalNetwork(TestExtNet._sys_admin_client,
                                      resource=ext_net_resource)
-        direct_ovdc_networks = extnet_obj.list_associated_direct_org_vdc_networks()
+        direct_ovdc_networks = extnet_obj.list_associated_direct_org_vdc_networks(
+            'connectedTo==Ext*')
         self.assertTrue(len(direct_ovdc_networks) > 0)
 
     def __add_sub_allocate_ip_pool(self):


### PR DESCRIPTION
This will list the associated direct org vDC networks to external network

Testing done: Test case passed

If the direct_ovdc_networks list has 0 items then below exception will be thrown.
pyvcloud.vcd.exceptions.EntityNotFoundException: No associated direct org vDC networks found

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/371)
<!-- Reviewable:end -->
