### PR TITLE
VP 1266: [PySdk] List gateway IP sub-allocation

### DIFF
--- a/pyvcloud/vcd/external_network.py
+++ b/pyvcloud/vcd/external_network.py
@@ -536,14 +536,13 @@ class ExternalNetwork(object):
 
     def _get_gateway_sub_allocated_ip_for_provided_ext_nw(self,
                                                           gateway_href):
-
         gateway_sub_allocated_ip = []
+        allocation_range = ''
         gateway_resource = self.__get_gateway_resource(gateway_href)
         for gw_inf in gateway_resource.Configuration.GatewayInterfaces. \
                 GatewayInterface:
             if gw_inf.InterfaceType == "uplink" and gw_inf.Name == self.name:
                 if hasattr(gw_inf.SubnetParticipation, 'IpRanges'):
-                    allocation_range = ""
                     for ip_range in gw_inf.SubnetParticipation. \
                             IpRanges.IpRange:
                         start_address = ip_range.StartAddress


### PR DESCRIPTION
[PySdk] List gateway IP sub-allocation

Cli command throws error as Error: local variable 'allocation_range'
referenced before assignment.
This CLN fixes the issue.

Testing done:
Test case for list associated ip sub allocation with gateway name  is
added to a test class extnet_tests.py
All tests in extnet_tests passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/372)
<!-- Reviewable:end -->
