### PR TITLE
Add cidr to isolated vdc network

### DIFF
--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -1183,8 +1183,7 @@ class VDC(object):
 
     def create_isolated_vdc_network(self,
                                     network_name,
-                                    gateway_ip,
-                                    netmask,
+                                    network_cidr,
                                     description=None,
                                     primary_dns_ip=None,
                                     secondary_dns_ip=None,
@@ -1200,8 +1199,7 @@ class VDC(object):
         """Create a new isolated org vdc network in this vdc.
 
         :param str network_name: name of the new network.
-        :param str gateway_ip: IP address of the gateway of the new network.
-        :param str netmask: network mask.
+        :param str network_cidr: CIDR in the format of 10.2.2.1/20.
         :param str description: description of the new network.
         :param str primary_dns_ip: IP address of primary DNS server.
         :param str secondary_dns_ip: IP address of secondary DNS Server.
@@ -1227,6 +1225,8 @@ class VDC(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
+        gateway_ip, netmask = cidr_to_netmask(network_cidr)
+
         self.get_resource()
 
         request_payload = E.OrgVdcNetwork(name=network_name)

--- a/system_tests/network_tests.py
+++ b/system_tests/network_tests.py
@@ -39,8 +39,7 @@ class TestNetwork(BaseTestCase):
     _vapp_author_client = None
 
     _isolated_orgvdc_network_name = 'isolated_orgvdc_network_' + str(uuid1())
-    _isolated_orgvdc_network_gateway = '10.0.0.1'
-    _isolated_orgvdc_network_netmask = '255.255.255.0'
+    _isolated_orgvdc_network_gateway_ip = '10.0.0.1/24'
 
     _routed_orgvdc_network_gateway_ip = '6.6.2.1/10'
     _ip_range = '6.6.2.2-6.6.2.10'
@@ -73,8 +72,7 @@ class TestNetwork(BaseTestCase):
                      TestNetwork._isolated_orgvdc_network_name)
         result = vdc.create_isolated_vdc_network(
             network_name=TestNetwork._isolated_orgvdc_network_name,
-            gateway_ip=TestNetwork._isolated_orgvdc_network_gateway,
-            netmask=TestNetwork._isolated_orgvdc_network_netmask)
+            network_cidr=TestNetwork._isolated_orgvdc_network_gateway_ip)
         TestNetwork._client.get_task_monitor().wait_for_success(
             task=result.Tasks.Task[0])
 


### PR DESCRIPTION
Adds `network_cidr` param to `create_isolated_vdc_network()` method in vdc.py

This PR bring `create_isolated_vdc_network()` inline with `create_routed_vdc_network()`. They both now use `network_cidr` param rather then `gateway_ip` and `netmask`.  `network_tests.py` had been updated to reflect the changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/373)
<!-- Reviewable:end -->
