### PR TITLE
[VP-1369,VP-1371,VP-1373]: add/update/delete metadata in vDC Routed Network

### DIFF
--- a/pyvcloud/vcd/vdc_network.py
+++ b/pyvcloud/vcd/vdc_network.py
@@ -177,10 +177,11 @@ class VdcNetwork(object):
             vdc_network)
 
     def get_all_metadata(self):
-        """Fetch all metadata entries of the org vdc.
+        """Fetch all metadata entries of the org vdc network.
 
         :return: an object containing EntityType.METADATA XML data which
-            represents the metadata entries associated with the org vdc.
+            represents the metadata entries associated with the org vdc
+            network.
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
@@ -189,9 +190,9 @@ class VdcNetwork(object):
             self.resource, RelationType.DOWN, EntityType.METADATA.value)
 
     def get_metadata_value(self, key, domain=MetadataDomain.GENERAL):
-        """Fetch a metadata value identified by the domain and key.
+        """Fetch the metadata value identified by the domain and key.
 
-        :param str key: key of the value to be fetched.
+        :param str key: key of the metadata to be fetched.
         :param client.MetadataDomain domain: domain of the value to be fetched.
 
         :return: an object containing EntityType.METADATA_VALUE XML data which

--- a/pyvcloud/vcd/vdc_network.py
+++ b/pyvcloud/vcd/vdc_network.py
@@ -14,9 +14,13 @@
 
 from pyvcloud.vcd.client import E
 from pyvcloud.vcd.client import EntityType
+from pyvcloud.vcd.client import MetadataDomain
+from pyvcloud.vcd.client import MetadataValueType
+from pyvcloud.vcd.client import MetadataVisibility
 from pyvcloud.vcd.client import RelationType
 from pyvcloud.vcd.exceptions import InvalidParameterException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
+from pyvcloud.vcd.metadata import Metadata
 from pyvcloud.vcd.utils import get_admin_href
 
 
@@ -171,3 +175,88 @@ class VdcNetwork(object):
         return self.client.put_linked_resource(
             self.resource, RelationType.EDIT, EntityType.ORG_VDC_NETWORK.value,
             vdc_network)
+
+    def get_all_metadata(self):
+        """Fetch all metadata entries of the org vdc.
+
+        :return: an object containing EntityType.METADATA XML data which
+            represents the metadata entries associated with the org vdc.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        self.get_resource()
+        return self.client.get_linked_resource(
+            self.resource, RelationType.DOWN, EntityType.METADATA.value)
+
+    def get_metadata_value(self, key, domain=MetadataDomain.GENERAL):
+        """Fetch a metadata value identified by the domain and key.
+
+        :param str key: key of the value to be fetched.
+        :param client.MetadataDomain domain: domain of the value to be fetched.
+
+        :return: an object containing EntityType.METADATA_VALUE XML data which
+            represents the metadata value.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        metadata = Metadata(client=self.client,
+                            resource=self.get_all_metadata())
+        return metadata.get_metadata_value(key, domain)
+
+    def set_metadata(self,
+                     key,
+                     value,
+                     domain=MetadataDomain.GENERAL,
+                     visibility=MetadataVisibility.READ_WRITE,
+                     metadata_value_type=MetadataValueType.STRING):
+        """Add a metadata entry to the org vdc network.
+
+        Only admins can perform this operation. If an entry with the same key
+        exists, it will be updated with the new value.
+
+        :param str key: an arbitrary key name. Length cannot exceed 256 UTF-8
+            characters.
+        :param str value: value of the metadata entry
+        :param client.MetadataDomain domain: domain where the new entry would
+            be put.
+        :param client.MetadataVisibility visibility: visibility of the metadata
+            entry.
+        :param client.MetadataValueType metadata_value_type:
+
+        :return: an object of type EntityType.TASK XML which represents
+            the asynchronous task that is updating the metadata on the org vdc
+            network.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        metadata = Metadata(client=self.client,
+                            resource=self.get_all_metadata())
+        return metadata.set_metadata(key=key,
+                                     value=value,
+                                     domain=domain,
+                                     visibility=visibility,
+                                     metadata_value_type=metadata_value_type,
+                                     use_admin_endpoint=True)
+
+    def remove_metadata(self, key, domain=MetadataDomain.GENERAL):
+        """Remove a metadata entry from the org vdc network.
+
+        Only admins can perform this operation.
+
+        :param str key: key of the metadata to be removed.
+        :param client.MetadataDomain domain: domain of the entry to be removed.
+
+        :return: an object of type EntityType.TASK XML which represents
+            the asynchronous task that is deleting the metadata on the org vdc
+            network.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+
+        :raises: AccessForbiddenException: If there is no metadata entry
+            corresponding to the key provided.
+        """
+        metadata = Metadata(client=self.client,
+                            resource=self.get_all_metadata())
+        return metadata.remove_metadata(key=key,
+                                        domain=domain,
+                                        use_admin_endpoint=True)

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -68,8 +68,8 @@ class TestExtNet(BaseTestCase):
         platform = Platform(TestExtNet._sys_admin_client)
         vc_name = TestExtNet._config['vc']['vcenter_host_name']
         portgrouphelper = PortgroupHelper(TestExtNet._sys_admin_client)
-        pg_name = portgrouphelper.get_available_portgroup_name(vc_name,
-                                                               TestExtNet._portgroupType)
+        pg_name = portgrouphelper.get_available_portgroup_name(
+            vc_name, TestExtNet._portgroupType)
 
         ext_net = platform.create_external_network(
             name=TestExtNet._name,
@@ -302,8 +302,8 @@ class TestExtNet(BaseTestCase):
         platform = Platform(TestExtNet._sys_admin_client)
         vc_name = TestExtNet._config['vc2']['vcenter_host_name']
         portgrouphelper = PortgroupHelper(TestExtNet._sys_admin_client)
-        pg_name = portgrouphelper.get_available_portgroup_name(vc_name,
-                                                               TestExtNet._portgroupType)
+        pg_name = portgrouphelper.get_available_portgroup_name(
+            vc_name, TestExtNet._portgroupType)
 
         ext_net = self._get_ext_net(platform).attach_port_group(
             vc_name,
@@ -345,7 +345,7 @@ class TestExtNet(BaseTestCase):
         TestExtNet._sys_admin_client.get_task_monitor().wait_for_success(
             task=task)
         logger.debug(
-            'Detach a portgroup from an external network' + TestExtNet._name + '.')
+            'Detach a portgroup from an external network' + TestExtNet._name)
         ext_net = platform.get_external_network(self._name)
         self.assertIsNotNone(ext_net)
         vc_record = platform.get_vcenter(vc_name)
@@ -452,8 +452,8 @@ class TestExtNet(BaseTestCase):
         gateway_obj = Gateway(TestExtNet._sys_admin_client,
                               href=gateway.get('href'))
         ext_net = TestExtNet._config['external_network']['name']
-        task = gateway_obj.add_sub_allocated_ip_pools(ext_net,
-                            [TestExtNet._gateway_sub_allocate_ip_pool_range])
+        task = gateway_obj.add_sub_allocated_ip_pools(
+            ext_net, [TestExtNet._gateway_sub_allocate_ip_pool_range])
         TestExtNet._sys_admin_client.get_task_monitor(). \
             wait_for_success(task=task)
 
@@ -463,8 +463,8 @@ class TestExtNet(BaseTestCase):
         gateway_obj = Gateway(TestExtNet._sys_admin_client,
                               href=gateway.get('href'))
         ext_net = TestExtNet._config['external_network']['name']
-        task = gateway_obj.remove_sub_allocated_ip_pools(ext_net,
-                            [TestExtNet._gateway_sub_allocate_ip_pool_range])
+        task = gateway_obj.remove_sub_allocated_ip_pools(
+            ext_net, [TestExtNet._gateway_sub_allocate_ip_pool_range])
         TestExtNet._sys_admin_client.get_task_monitor(). \
             wait_for_success(task=task)
 


### PR DESCRIPTION
[VP-1369,VP-1371,VP-1373]: add/update/delete metadata in vDC Routed Network

Support to add/update/delete metadat in a vDC Routed Network. Providing key and value adds an entry taking defualt values of domain (GENERAL), visibility (READWRITE) and metadata value type (MetadataStringValue). Specific valued of domain, visibility and metadata value type can also be provided. API for add and update is same, calling this updates if there is already an existing key with this name.

Also fixed Flake-8 formatting errors in extnet_tests.py and network_tests.py

Testing done:
Added test cases for add/update/delete metadata for vDC Routed Network in network_tests.py. All test of this class passes.

@rajeshk2013 @guptaankit52

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/374)
<!-- Reviewable:end -->
