### PR TITLE
Add update_extension function to api_extension.py

### DIFF
--- a/pyvcloud/vcd/api_extension.py
+++ b/pyvcloud/vcd/api_extension.py
@@ -175,6 +175,39 @@ class APIExtension(object):
             n += 1
         return ext
 
+    def update_extension(self, name, namespace=None, routing_key=None,
+                         exchange=None):
+        """Update properties for an existing API extension.
+
+        :param str name: name of the API extension.
+        :param str namespace: namespace of the API extension.
+        :param str routing_key: AMQP routing key to use for the extension.
+        :param str exchange: AMQP exchange to use for the extension.
+
+        :return: href of the API extension.
+
+        :rtype: str
+
+        :raises MissingRecordException: if an extension with the given name and
+            namespace couldn't be found.
+        :raise MultipleRecordsException: if more than one service with the
+            given name and namespace are found.
+        """
+        record = self._get_extension_record(name=name,
+                                            namespace=namespace,
+                                            format=QueryResultFormat.RECORDS)
+
+        params = E_VMEXT.Service({'name': name})
+        params.append(E_VMEXT.Namespace(record.get('namespace')))
+        params.append(E_VMEXT.Enabled(record.get('enabled')))
+        params.append(E_VMEXT.RoutingKey(
+            routing_key if routing_key else record.get('routingKey')))
+        params.append(E_VMEXT.Exchange(
+            exchange if exchange else record.get('exchange')))
+
+        self.client.put_resource(record.get('href'), params, None)
+        return record.get('href')
+
     def add_extension(self, name, namespace, routing_key, exchange, patterns):
         """Add an API extension service.
 

--- a/system_tests/api_extension_tests.py
+++ b/system_tests/api_extension_tests.py
@@ -258,6 +258,35 @@ class TestApiExtension(BaseTestCase):
         registered_right_name = register_right.get('name')
         self.assertEqual(expected_right_name, registered_right_name)
 
+    def test_0080_update_service(self):
+        """Test the method APIExtension.update_extension().
+
+        This test passes if the routing key and exchange after execution of the
+        method matches the respective test strings.
+        """
+        logger = Environment.get_default_logger()
+        api_extension = APIExtension(TestApiExtension._client)
+        ext_name = TestApiExtension._service_name
+        ext_namespace = TestApiExtension._service1_namespace
+
+        logger.debug('Updating service (name:' +
+                     ext_name + ', namespace:' +
+                     ext_namespace + ').')
+
+        test_routing_key = 'testroutingkey'
+        test_exchange = 'testexchange'
+        href = api_extension.update_extension(
+            name=ext_name,
+            namespace=ext_namespace,
+            routing_key=test_routing_key,
+            exchange=test_exchange)
+        self.assertEqual(href, TestApiExtension._service1_href)
+
+        ext_info = api_extension.get_extension_info(ext_name,
+                                                    namespace=ext_namespace)
+        self.assertEqual(ext_info['routing_key'], test_routing_key)
+        self.assertEqual(ext_info['exchange'], test_exchange)
+
     @developerModeAware
     def test_9998_teardown(self):
         """Test the method APIExtension.delete_extension().


### PR DESCRIPTION
CSE would be using this function, as opposed to unregistering and re-registering with updated properties. The function docstring has relevant information.

This function takes a service name, namespace, routing key, and exchange name.
We update the currently registered extension to have the specified routing key and exchange name.
We return the service href, following the precedence from enable_extension()

@rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/379)
<!-- Reviewable:end -->
