### PR TITLE
VP-1473,VP-1656,VP-1658: Configure default gateway,DNS and list

### DIFF
--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -710,7 +710,7 @@ class Gateway(object):
                                                gateway)
 
     def __update_dns_relay(self, configuration, enable_dns_relay=None):
-        """Updates DNS Relay gateway.
+        """Updates DNS Relay of a gateway.
 
         :param configuration: gateway configuration
         :param bool enable_dns_relay: flag to enable/disable DNS Relay
@@ -726,7 +726,7 @@ class Gateway(object):
 
         :param gateway_inf: gateway interface.
         :param bool enable_default_gateway: flag to enable/disable default
-        gateway
+            gateway
         """
         if enable_default_gateway is not None and \
                 hasattr(gateway_inf, 'UseForDefaultRoute'):
@@ -740,7 +740,7 @@ class Gateway(object):
 
         :param subnet: subnet participation of gateway.
         :param bool enable_default_gateway: flag to enable/disable default
-        gateway
+            gateway
         """
         if enable_default_gateway is not None and \
                 hasattr(subnet, 'UseForDefaultRoute') and \
@@ -750,12 +750,12 @@ class Gateway(object):
 
     def configure_default_gateway(self, ext_network, ip,
                                   enable_default_gateway):
-        """Configures gateway for provided external networks and gateway ip.
+        """Configures gateway for provided external networks and gateway IP.
 
         :param ext_network: External network connected to gateway
         :param ip: default ip of the gateway
         :param bool enable_default_gateway: flag to enable/disable default
-        gateway
+            gateway
 
         :return: object containing EntityType.TASK XML data
              representing the asynchronous task.
@@ -810,10 +810,10 @@ class Gateway(object):
         for gateway_inf in \
                 gateway.Configuration.GatewayInterfaces.GatewayInterface:
             gateway_config = dict()
-            if gateway_inf.UseForDefaultRoute.text == 'true':
+            if gateway_inf.UseForDefaultRoute is True:
                 gateway_config['external_network'] = gateway_inf.Name.text
                 for subnet_part in gateway_inf.SubnetParticipation:
-                    if subnet_part.UseForDefaultRoute.text == 'true':
+                    if subnet_part.UseForDefaultRoute.text is True:
                         gateway_config['gateway_ip'] = \
                             subnet_part.UseForDefaultRoute.text
 

--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -710,7 +710,7 @@ class Gateway(object):
                                                gateway)
 
     def __update_dns_relay(self, configuration, enable_dns_relay=None):
-        """updates DNS Relay gateway.
+        """Updates DNS Relay gateway.
 
         :param configuration: gateway configuration
         :param bool enable_dns_relay: flag to enable/disable DNS Relay
@@ -722,7 +722,7 @@ class Gateway(object):
 
     def __update_gateway_default_route(self, gateway_inf,
                                        enable_default_gateway=None):
-        """updates default route of gateway interface.
+        """Updates default route of gateway interface.
 
         :param gateway_inf: gateway interface.
         :param bool enable_default_gateway: flag to enable/disable default
@@ -736,7 +736,7 @@ class Gateway(object):
     def __update_subnet_participation_default_route(self, subnet, gateway_ip,
                                                     enable_default_gateway=None
                                                     ):
-        """updates default route of subnet participation of gateway.
+        """Updates default route of subnet participation of gateway.
 
         :param subnet: subnet participation of gateway.
         :param bool enable_default_gateway: flag to enable/disable default

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -509,6 +509,89 @@ class TestGateway(BaseTestCase):
         """removed the InRateLimit form gateway_interface."""
         self.assertFalse(hasattr(gateway_interface, 'InRateLimit'))
 
+    def test_0021_configure_gateway(self):
+        """configures the gateway.
+
+        Invoke the configure_default_gateway function of gateway.
+        """
+        gateway_obj = Gateway(TestGateway._client, self._name,
+                              TestGateway._gateway.get('href'))
+        ip_allocations = gateway_obj.list_configure_ip_settings()
+        ip_allocation = ip_allocations[0]
+        ext_network = ip_allocation.get('external_network')
+        gateway = ip_allocation.get('gateway')
+        gateway_ip = gateway[0].split('/')
+        gateway_obj = Gateway(TestGateway._client, self._name,
+                              TestGateway._gateway.get('href'))
+        task = gateway_obj.configure_default_gateway(ext_network, gateway_ip[0]
+                                                     , 'true')
+        result = TestGateway._client.get_task_monitor().wait_for_success(
+            task=task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        # verification
+        gateway_obj = Gateway(TestGateway._client, self._name,
+                              TestGateway._gateway.get('href'))
+        gateway_interface = self.__get_gateway_interface(
+            gateway_obj.get_resource(), ext_network)
+        self.assertTrue(gateway_interface.UseForDefaultRoute.text == 'true')
+
+    def test_0022_enable_dns_relay_gateway(self):
+        """enables the dns relay of the gateway.
+
+        Invoke the configure_dns_default_gateway function of gateway.
+        """
+        gateway_obj = Gateway(TestGateway._client, self._name,
+                              TestGateway._gateway.get('href'))
+        task = gateway_obj.configure_dns_default_gateway('true')
+        result = TestGateway._client.get_task_monitor().wait_for_success(
+            task=task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        # verification
+        gateway_obj = Gateway(TestGateway._client, self._name,
+                              TestGateway._gateway.get('href'))
+        self.assertTrue(gateway_obj.get_resource().Configuration.
+                        UseDefaultRouteForDnsRelay.text == 'true')
+        task = gateway_obj.configure_dns_default_gateway('false')
+        result = TestGateway._client.get_task_monitor().wait_for_success(
+            task=task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0023_list_configure_default_gateway(self):
+        """list configured default gateway.
+
+        Invoke the list_configure_default_gateway function of gateway.
+        """
+        gateway_obj = Gateway(TestGateway._client, self._name,
+                              TestGateway._gateway.get('href'))
+        default_gateways = gateway_obj.list_configure_default_gateway()
+        self.assertTrue(len(default_gateways) > 0)
+
+    def test_0024_disable_configure_gateway(self):
+        """configures the gateway.
+
+        Invoke the configure_default_gateway function of gateway.
+        """
+        gateway_obj = Gateway(TestGateway._client, self._name,
+                              TestGateway._gateway.get('href'))
+        ip_allocations = gateway_obj.list_configure_ip_settings()
+        ip_allocation = ip_allocations[0]
+        ext_network = ip_allocation.get('external_network')
+        gateway = ip_allocation.get('gateway')
+        gateway_ip = gateway[0].split('/')
+        gateway_obj = Gateway(TestGateway._client, self._name,
+                              TestGateway._gateway.get('href'))
+        task = gateway_obj.configure_default_gateway(ext_network, gateway_ip[0]
+                                                     , 'false')
+        result = TestGateway._client.get_task_monitor().wait_for_success(
+            task=task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        # verification
+        gateway_obj = Gateway(TestGateway._client, self._name,
+                              TestGateway._gateway.get('href'))
+        gateway_interface = self.__get_gateway_interface(
+            gateway_obj.get_resource(), ext_network)
+        self.assertTrue(gateway_interface.UseForDefaultRoute.text == 'false')
+
     def test_0025_add_firewall_rule(self):
         """Add Firewall Rule's in the gateway."""
 

--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -533,7 +533,7 @@ class TestGateway(BaseTestCase):
                               TestGateway._gateway.get('href'))
         gateway_interface = self.__get_gateway_interface(
             gateway_obj.get_resource(), ext_network)
-        self.assertTrue(gateway_interface.UseForDefaultRoute.text == 'true')
+        self.assertTrue(gateway_interface.UseForDefaultRoute)
 
     def test_0022_enable_dns_relay_gateway(self):
         """enables the dns relay of the gateway.
@@ -550,7 +550,7 @@ class TestGateway(BaseTestCase):
         gateway_obj = Gateway(TestGateway._client, self._name,
                               TestGateway._gateway.get('href'))
         self.assertTrue(gateway_obj.get_resource().Configuration.
-                        UseDefaultRouteForDnsRelay.text == 'true')
+                        UseDefaultRouteForDnsRelay)
         task = gateway_obj.configure_dns_default_gateway('false')
         result = TestGateway._client.get_task_monitor().wait_for_success(
             task=task)


### PR DESCRIPTION
VP-1473,VP-1656,VP-1658: Configure default gateway,DNS and list

PYSDK support to add default gateway, enable/disable the dns realy and list the supported configured default gateway.
Implemented  configure_default_gateway, configure_dns_default_gateway, list_configure_default_gateway in gateway.py.

VP-1473: Configure default gateway
User would be able to enable the default gateway for provided external network and IP

VP-1656: Enable/Disable the DNS Relay
User would be able to enable/disable the DNS Relay

VP-1658:  List default gateway
User would be able list the configured default gateway

Testing:
Added test_0021_configure_gateway, test_0022_enable_dns_relay_gateway, test_0023_list_configure_default_gateway and test_0024_disable_configure_gateway to gateway_tests.py

All test cases are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/380)
<!-- Reviewable:end -->
