### PR TITLE
[VP-1375] List IP allocations of a routed org vdc network

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -270,6 +270,8 @@ class EntityType(Enum):
     ADMIN_CATALOG = 'application/vnd.vmware.admin.catalog+xml'
     ADMIN_ORG = 'application/vnd.vmware.admin.organization+xml'
     ADMIN_SERVICE = 'application/vnd.vmware.admin.service+xml'
+    ALLOCATED_NETWORK_ADDRESS = \
+        'application/vnd.vmware.vcloud.allocatedNetworkAddress+xml'
     API_EXTENSIBILITY = 'application/vnd.vmware.vcloud.apiextensibility+xml'
     AMQP_SETTINGS = 'application/vnd.vmware.admin.amqpSettings+xml'
     CATALOG = 'application/vnd.vmware.vcloud.catalog+xml'

--- a/pyvcloud/vcd/vdc_network.py
+++ b/pyvcloud/vcd/vdc_network.py
@@ -263,8 +263,11 @@ class VdcNetwork(object):
     def list_allocated_ip_address(self):
         """List allocated ip address of org vDC network.
 
-        :return: dict allocated ip address with type and deploy status
-        :rtype: dict
+        :return: List where each entry is a dictionary containing allocated IP
+            address, deploy status and type.
+            For example: [{'IP Address': '10.20.30.1', 'Is Deployed': 'true',
+            'Type': 'vsmAllocated'}]
+        :rtype: list
         """
         allocated_ip_addresses = self.client.get_linked_resource(
             self.get_resource(), RelationType.DOWN,

--- a/pyvcloud/vcd/vdc_network.py
+++ b/pyvcloud/vcd/vdc_network.py
@@ -129,10 +129,8 @@ class VdcNetwork(object):
                 start_address = ip_range_arr[0]
                 end_address = ip_range_arr[0]
             ip_range_tag = E.IpRange()
-            ip_range_tag.append(E.StartAddress(
-                start_address))
-            ip_range_tag.append(E.EndAddress(
-                end_address))
+            ip_range_tag.append(E.StartAddress(start_address))
+            ip_range_tag.append(E.EndAddress(end_address))
             ip_ranges_list.append(ip_range_tag)
 
         return self.client.put_linked_resource(
@@ -200,8 +198,8 @@ class VdcNetwork(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        metadata = Metadata(client=self.client,
-                            resource=self.get_all_metadata())
+        metadata = Metadata(
+            client=self.client, resource=self.get_all_metadata())
         return metadata.get_metadata_value(key, domain)
 
     def set_metadata(self,
@@ -230,14 +228,15 @@ class VdcNetwork(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        metadata = Metadata(client=self.client,
-                            resource=self.get_all_metadata())
-        return metadata.set_metadata(key=key,
-                                     value=value,
-                                     domain=domain,
-                                     visibility=visibility,
-                                     metadata_value_type=metadata_value_type,
-                                     use_admin_endpoint=True)
+        metadata = Metadata(
+            client=self.client, resource=self.get_all_metadata())
+        return metadata.set_metadata(
+            key=key,
+            value=value,
+            domain=domain,
+            visibility=visibility,
+            metadata_value_type=metadata_value_type,
+            use_admin_endpoint=True)
 
     def remove_metadata(self, key, domain=MetadataDomain.GENERAL):
         """Remove a metadata entry from the org vdc network.
@@ -256,8 +255,25 @@ class VdcNetwork(object):
         :raises: AccessForbiddenException: If there is no metadata entry
             corresponding to the key provided.
         """
-        metadata = Metadata(client=self.client,
-                            resource=self.get_all_metadata())
-        return metadata.remove_metadata(key=key,
-                                        domain=domain,
-                                        use_admin_endpoint=True)
+        metadata = Metadata(
+            client=self.client, resource=self.get_all_metadata())
+        return metadata.remove_metadata(
+            key=key, domain=domain, use_admin_endpoint=True)
+
+    def list_allocated_ip_address(self):
+        """List allocated ip address of org vDC network.
+
+        :return: dict allocated ip address with type and deploy status
+        :rtype: dict
+        """
+        allocated_ip_addresses = self.client.get_linked_resource(
+            self.get_resource(), RelationType.DOWN,
+            EntityType.ALLOCATED_NETWORK_ADDRESS.value)
+        result = []
+        for ip_address in allocated_ip_addresses.IpAddress:
+            result.append({
+                'IP Address': ip_address.IpAddress,
+                'Is Deployed': ip_address.get('isDeployed'),
+                'Type': ip_address.get('allocationType')
+            })
+        return result

--- a/system_tests/network_tests.py
+++ b/system_tests/network_tests.py
@@ -279,8 +279,7 @@ class TestNetwork(BaseTestCase):
     def _add_routed_vdc_network_metadata(self, vdc_network, metadata_key,
                                          metadata_value):
         task = vdc_network.set_metadata(metadata_key, metadata_value)
-        TestNetwork._client.get_task_monitor().wait_for_success(
-            task=task)
+        TestNetwork._client.get_task_monitor().wait_for_success(task=task)
         vdc_network.reload()
         self.assertEqual(
             metadata_value,
@@ -288,10 +287,8 @@ class TestNetwork(BaseTestCase):
 
     def _update_routed_vdc_network_metadata(self, vdc_network, metadata_key,
                                             updated_metadata_value):
-        task = vdc_network.set_metadata(metadata_key,
-                                        updated_metadata_value)
-        TestNetwork._client.get_task_monitor().wait_for_success(
-            task=task)
+        task = vdc_network.set_metadata(metadata_key, updated_metadata_value)
+        TestNetwork._client.get_task_monitor().wait_for_success(task=task)
         vdc_network.reload()
         self.assertEqual(
             updated_metadata_value,
@@ -299,13 +296,12 @@ class TestNetwork(BaseTestCase):
 
     def _delete_routed_vcd_network_metadata(self, vdc_network, metadata_key):
         task = vdc_network.remove_metadata(metadata_key)
-        TestNetwork._client.get_task_monitor().wait_for_success(
-            task=task)
+        TestNetwork._client.get_task_monitor().wait_for_success(task=task)
         vdc_network.reload()
         with self.assertRaises(AccessForbiddenException):
             vdc_network.get_metadata_value(metadata_key)
 
-    def test_0080_routed_orgvdc_network_metadata(self):
+    def test_0080_routed_vdc_network_metadata(self):
         vdc = Environment.get_test_vdc(TestNetwork._client)
         org_vdc_routed_nw = vdc.get_routed_orgvdc_network(
             TestNetwork._routed_org_vdc_network_name)
@@ -324,6 +320,18 @@ class TestNetwork(BaseTestCase):
             self, vdc_network, metadata_key, updated_metadata_value)
         TestNetwork._delete_routed_vcd_network_metadata(
             self, vdc_network, metadata_key)
+
+    def test_0090_list_routed_vdc_network_allocated_ip(self):
+        vdc = Environment.get_test_vdc(TestNetwork._client)
+        org_vdc_routed_nw = vdc.get_routed_orgvdc_network(
+            TestNetwork._routed_org_vdc_network_name)
+        vdc_network = VdcNetwork(
+            TestNetwork._client, resource=org_vdc_routed_nw)
+        allocated_ip_addresses = vdc_network.list_allocated_ip_address()
+        self.assertEqual(len(allocated_ip_addresses), 1)
+        ip_address = TestNetwork._routed_orgvdc_network_gateway_ip.split(
+            '/')[0]
+        self.assertEqual(allocated_ip_addresses[0]['IP Address'], ip_address)
 
     def test_0100_delete_routed_orgvdc_networks(self):
         vdc = Environment.get_test_vdc(TestNetwork._client)


### PR DESCRIPTION
Adding support to list allocated IP Addresses of a org vdc routed network. Listing three columns, 'IP Address', 'Is Deployed' and 'Type'.

Testing done:
Added a test test_0090_list_routed_vdc_network_allocated_ip to network_test.py. All test cases in the class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/382)
<!-- Reviewable:end -->
