### PR TITLE
VP-1584,VP-1588: Add and delete nat rule

### DIFF
--- a/pyvcloud/system_test_framework/base_test.py
+++ b/pyvcloud/system_test_framework/base_test.py
@@ -39,7 +39,7 @@ class BaseTestCase(unittest.TestCase):
         Environment.create_users()
         Environment.create_ovdc()
         Environment.create_direct_ovdc_network()
-        Environment.create_gateway()
+        Environment.create_advanced_gateway()
         Environment.create_ovdc_network()
         Environment.create_catalog()
         Environment.share_catalog()

--- a/pyvcloud/system_test_framework/environment.py
+++ b/pyvcloud/system_test_framework/environment.py
@@ -838,7 +838,7 @@ class Environment(object):
         return VApp(client, resource=vapp_resource)
 
     @classmethod
-    def create_gateway(cls):
+    def create_advanced_gateway(cls):
         """Creates a gateway."""
 
         cls._basic_check()
@@ -857,8 +857,10 @@ class Environment(object):
                 gateway = vdc.create_gateway_api_version_30(
                     GatewayConstants.name, [ext_config['name']])
             else:
-                gateway = vdc.create_gateway(GatewayConstants.name,
-                                             [ext_config['name']])
+                gateway = vdc.create_gateway(
+                    GatewayConstants.name,
+                    [ext_config['name']],
+                    should_create_as_advanced=True)
 
             cls._sys_admin_client.get_task_monitor().wait_for_success(task
                                                     = gateway.Tasks.Task[0])

--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -19,6 +19,7 @@ from pyvcloud.vcd.exceptions import AlreadyExistsException
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import InvalidParameterException
 from pyvcloud.vcd.network_url_constants import FIREWALL_URL_TEMPLATE
+from pyvcloud.vcd.network_url_constants import NAT_URL_TEMPLATE
 from pyvcloud.vcd.platform import Platform
 from pyvcloud.vcd.utils import build_network_url_from_gateway_url
 from pyvcloud.vcd.utils import get_admin_href
@@ -821,3 +822,71 @@ class Gateway(object):
                             subnet_part.Gateway.text
                         out_list.append(gateway_config)
         return out_list
+
+    def add_nat_rule(self,
+                     action,
+                     original_address,
+                     translated_address,
+                     description=None,
+                     protocol='any',
+                     original_port='any',
+                     translated_port='any',
+                     type='User',
+                     icmp_type='any',
+                     logging_enabled=False,
+                     enabled=True):
+        """Add nat rule in the gateway.
+
+        param action str: action having values snat/dnat
+        param original_address str: original IP address
+        param translated_address str: translated IP address
+        param description str: nat rule description
+        param protocol str: protocol such as tcp/udp/icmp
+        param original_port: port no. such as FTP(21)
+        param translated_port: port no. such as HTTP(80)
+        param type str: nat rule type. Default: User
+        param icmp_type str: icmp type such as "Echo-request"
+        param logging_enabled bool: logging enabled
+        param enable bool: enable nat rule
+
+        """
+        nat_rule_href = self._build_nat_rule_href()
+        nat_rules_resource = self.get_nat_rules()
+        nat_rules_tag = nat_rules_resource.natRules
+        nat_rule = E.natRule()
+        nat_rule.append(E.ruleType(type))
+        nat_rule.append(E.action(action))
+        nat_rule.append(E.originalAddress(original_address))
+        nat_rule.append(E.translatedAddress(translated_address))
+        nat_rule.append(E.loggingEnabled(logging_enabled))
+        nat_rule.append(E.enabled(enabled))
+        nat_rule.append(E.description(description))
+
+        # DNAT rule requries additonal parameters
+        if action == 'dnat' and protocol != 'icmp':
+            nat_rule.append(E.protocol(protocol))
+            nat_rule.append(E.originalPort(original_port))
+            nat_rule.append(E.translatedPort(translated_port))
+
+        if action == 'dnat' and protocol == 'icmp':
+            nat_rule.append(E.translatedPort(translated_port))
+            nat_rule.append(E.protocol(protocol))
+            nat_rule.append(E.icmpType(icmp_type))
+
+        nat_rules_tag.append(nat_rule)
+        self.client.put_resource(nat_rule_href, nat_rules_resource,
+                                 EntityType.DEFAULT_CONTENT_TYPE.value)
+
+    def get_nat_rules(self):
+        """Get firewall Rules from vCD.
+
+        Form a Firewall Rules using gateway href and fetches from vCD.
+
+        return: FirewallRule Object
+        """
+        nat_rule_href = self._build_nat_rule_href()
+        return self.client.get_resource(nat_rule_href)
+
+    def _build_nat_rule_href(self):
+        network_url = build_network_url_from_gateway_url(self.href)
+        return network_url + NAT_URL_TEMPLATE

--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -878,11 +878,11 @@ class Gateway(object):
                                  EntityType.DEFAULT_CONTENT_TYPE.value)
 
     def get_nat_rules(self):
-        """Get firewall Rules from vCD.
+        """Get Nat Rules from vCD.
 
-        Form a Firewall Rules using gateway href and fetches from vCD.
+        Form a Nat Rules using gateway href and fetches from vCD.
 
-        return: FirewallRule Object
+        return: NatRule Object
         """
         nat_rule_href = self._build_nat_rule_href()
         return self.client.get_resource(nat_rule_href)

--- a/pyvcloud/vcd/nat_rule.py
+++ b/pyvcloud/vcd/nat_rule.py
@@ -1,0 +1,127 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2014-2019 VMware, Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyvcloud.vcd.client import QueryResultFormat
+from pyvcloud.vcd.client import ResourceType
+from pyvcloud.vcd.exceptions import EntityNotFoundException
+from pyvcloud.vcd.exceptions import InvalidParameterException
+from pyvcloud.vcd.exceptions import MultipleRecordsException
+from pyvcloud.vcd.network_url_constants import NAT_RULE_URL_TEMPLATE
+from pyvcloud.vcd.network_url_constants import NAT_RULES
+from pyvcloud.vcd.network_url_constants import NAT_RULES_URL_TEMPLATE
+from pyvcloud.vcd.utils import build_network_url_from_gateway_url
+
+
+class NatRule(object):
+    def __init__(self, client, gateway_name=None, rule_id=None,
+                 nat_href=None, resource=None):
+        """Constructor for Nat objects.
+
+        :param pyvcloud.vcd.client.Client client: the client that will be used
+            to make REST calls to vCD.
+        :param str gateway_name: name of the gateway entity.
+        :param str rule_id: nat rule id.
+        :param str nat_href: nat rule href.
+        :param lxml.objectify.ObjectifiedElement resource: object containing
+            EntityType.NAT XML data representing the gateway.
+        """
+        self.client = client
+        self.gateway_name = gateway_name
+        self.rule_id = rule_id
+        if gateway_name is not None and \
+           rule_id is not None and \
+           nat_href is None and \
+           resource is None:
+            self.__get_href()
+        if nat_href is None and resource is None and self.href is None:
+            raise InvalidParameterException(
+                "NatRule initialization failed as arguments are either "
+                "invalid or None")
+        if nat_href is not None:
+            self.rule_id = self.__extract_rule_id(nat_href)
+        if self.href is None:
+            self.href = nat_href
+        self.resource = resource
+
+    def __get_href(self):
+        self.parent = self.get_parent_by_name()
+        self.parent_href = self.parent.get('href')
+        network_url = build_network_url_from_gateway_url(self.parent_href)
+        self.href = (network_url + NAT_RULE_URL_TEMPLATE).format(self.rule_id)
+
+    def __extract_rule_id(self, nat_href):
+        self.rule_id = nat_href
+        rule_id_index = nat_href.index(NAT_RULES_URL_TEMPLATE) \
+            + len(NAT_RULES_URL_TEMPLATE) + 1
+        self.rule_id = nat_href[rule_id_index:]
+
+    def get_resource(self):
+        """Fetches the XML representation of the nat rule.
+
+        :return: object containing EntityType.NAT_RULE XML data
+        representing the nat rule.
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        if self.resource is None:
+            self.reload()
+        return self.resource
+
+    def reload(self):
+        """Reloads the resource representation of the nat rule."""
+        rule_id_length = len(NAT_RULES + '/' + str(self.rule_id))
+        nat_rule_config_url = self.href[:-rule_id_length]
+        nat_rules_config_resource = \
+            self.client.get_resource(nat_rule_config_url)
+        nat_rules = nat_rules_config_resource.natRules.natRule
+        for rule in nat_rules:
+            if rule.ruleId == self.rule_id:
+                self.resource = rule
+                break
+
+    def get_parent_by_name(self):
+        """Get a gateway by name.
+
+        :param str name: name of the gateway to be fetched.​
+        :return: gateway​
+        :rtype: lxml.objectify.ObjectifiedElement​
+        :raises: EntityNotFoundException: if the named gateway can not be
+            found.
+        :raises: MultipleRecordsException: if more than one gateway with the
+            provided name are found.
+        """
+        name_filter = ('name', self.gateway_name)
+        query = self.client.get_typed_query(
+            ResourceType.EDGE_GATEWAY.value,
+            query_result_format=QueryResultFormat.RECORDS,
+            equality_filter=name_filter)
+        records = list(query.execute())
+        if records is None or len(records) == 0:
+            raise EntityNotFoundException(
+                'Gateway with name \'%s\' not found.' % self.gateway_name)
+        elif len(records) > 1:
+            raise MultipleRecordsException("Found multiple gateway named "
+                                           "'%s'," % self.gateway_name)
+        return records[0]
+
+    def delete_nat_rule(self):
+        """Delete a nat rule from gateway.
+
+        :param str name: name of the vApp to be deleted.
+
+        :raises: EntityNotFoundException: if the named vApp can not be found.
+        :raises: MultipleRecordsException: if more than one vApp with the
+        provided name are found.
+        """
+        self.get_resource()
+        return self.client.delete_resource(self.href)

--- a/pyvcloud/vcd/nat_rule.py
+++ b/pyvcloud/vcd/nat_rule.py
@@ -34,7 +34,7 @@ class NatRule(object):
         :param str rule_id: nat rule id.
         :param str nat_href: nat rule href.
         :param lxml.objectify.ObjectifiedElement resource: object containing
-            EntityType.NAT XML data representing the gateway.
+            EntityType.NAT XML data representing the nat rule.
         """
         self.client = client
         self.gateway_name = gateway_name
@@ -43,18 +43,17 @@ class NatRule(object):
            rule_id is not None and \
            nat_href is None and \
            resource is None:
-            self.__get_href()
+            self.__build_self_href()
         if nat_href is None and resource is None and self.href is None:
             raise InvalidParameterException(
                 "NatRule initialization failed as arguments are either "
                 "invalid or None")
         if nat_href is not None:
             self.rule_id = self.__extract_rule_id(nat_href)
-        if self.href is None:
             self.href = nat_href
         self.resource = resource
 
-    def __get_href(self):
+    def __build_self_href(self):
         self.parent = self.get_parent_by_name()
         self.parent_href = self.parent.get('href')
         network_url = build_network_url_from_gateway_url(self.parent_href)
@@ -70,7 +69,7 @@ class NatRule(object):
         """Fetches the XML representation of the nat rule.
 
         :return: object containing EntityType.NAT_RULE XML data
-        representing the nat rule.
+        representing the Nat Rule.
         :rtype: lxml.objectify.ObjectifiedElement
         """
         if self.resource is None:
@@ -92,7 +91,6 @@ class NatRule(object):
     def get_parent_by_name(self):
         """Get a gateway by name.
 
-        :param str name: name of the gateway to be fetched.​
         :return: gateway​
         :rtype: lxml.objectify.ObjectifiedElement​
         :raises: EntityNotFoundException: if the named gateway can not be
@@ -115,13 +113,6 @@ class NatRule(object):
         return records[0]
 
     def delete_nat_rule(self):
-        """Delete a nat rule from gateway.
-
-        :param str name: name of the vApp to be deleted.
-
-        :raises: EntityNotFoundException: if the named vApp can not be found.
-        :raises: MultipleRecordsException: if more than one vApp with the
-        provided name are found.
-        """
+        """Delete a nat rule from gateway."""
         self.get_resource()
         return self.client.delete_resource(self.href)

--- a/pyvcloud/vcd/network_url_constants.py
+++ b/pyvcloud/vcd/network_url_constants.py
@@ -15,3 +15,7 @@
 
 FIREWALL_URL_TEMPLATE = "/firewall/config"
 FIREWALL_RULES_URL_TEMPLATE = "/firewall/config/rules"
+NAT_URL_TEMPLATE = "/nat/config"
+NAT_RULES = "/rules"
+NAT_RULES_URL_TEMPLATE = "/nat/config" + NAT_RULES
+NAT_RULE_URL_TEMPLATE = NAT_RULES_URL_TEMPLATE + "/{0}"

--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -98,5 +98,5 @@ external_network:
     - subnet: '2.2.3.1/20'
       ip_ranges:
         - '2.2.3.2-2.2.3.100'
-  gateway_sub_allocated_ip_range: '2.2.3.5-2.2.3.50'
-  new_gateway_sub_allocated_ip_range: '2.2.3.6-2.2.3.60'
+  gateway_sub_allocated_ip_range: '2.2.3.5-2.2.3.30'
+  new_gateway_sub_allocated_ip_range: '2.2.3.6-2.2.3.31'

--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -98,5 +98,5 @@ external_network:
     - subnet: '2.2.3.1/20'
       ip_ranges:
         - '2.2.3.2-2.2.3.100'
-  gateway_sub_allocated_ip_range: '2.2.3.5-2.2.3.10'
-  new_gateway_sub_allocated_ip_range: '2.2.3.11-2.2.3.12'
+  gateway_sub_allocated_ip_range: '2.2.3.5-2.2.3.50'
+  new_gateway_sub_allocated_ip_range: '2.2.3.6-2.2.3.60'

--- a/system_tests/nat_rule_tests.py
+++ b/system_tests/nat_rule_tests.py
@@ -1,0 +1,241 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+from uuid import uuid1
+from pyvcloud.vcd.client import ApiVersion
+from pyvcloud.vcd.client import NSMAP
+from pyvcloud.vcd.client import TaskStatus
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.environment import CommonRoles
+from pyvcloud.system_test_framework.environment import Environment
+from pyvcloud.system_test_framework.constants.gateway_constants import \
+    GatewayConstants
+from pyvcloud.vcd.nat_rule import NatRule
+from pyvcloud.vcd.gateway import Gateway
+from pyvcloud.vcd.utils import netmask_to_cidr_prefix_len
+
+
+class TestNatRule(BaseTestCase):
+    """Test Nat Rule functionalities implemented in pyvcloud."""
+    # All tests in this module should be run as System Administrator.
+    _client = None
+    _name = (GatewayConstants.name + str(uuid1()))[:34]
+    _description = GatewayConstants.description + str(uuid1())
+    _gateway = None
+    _snat_action = 'snat'
+    _snat_orig_addr = '2.2.3.7'
+    _snat_trans_addr = '2.2.3.8'
+    _dnat_action = 'dnat'
+    _dnat1_orig_addr = '2.2.3.10'
+    _dnat1_trans_addr = '2.2.3.11-2.2.3.12'
+    _dnat1_protocol = 'tcp'
+    _dnat1_orig_port = 80
+    _dnat1_trans_port = 80
+    _dnat2_orig_addr = '2.2.3.15'
+    _dnat2_trans_addr = '2.2.3.16-2.2.3.17'
+    _dnat2_protocol = 'icmp'
+    _dnat2_desc = 'icmp protocol'
+
+    def test_0000_setup(self):
+        """Setup the gateway required for the other tests in this module.
+
+        Create a gateway as per the configuration stated
+        above.
+
+        This test passes if the gateway is created successfully.
+        """
+        TestNatRule._client = Environment.get_sys_admin_client()
+        TestNatRule._vdc = Environment.get_test_vdc(TestNatRule._client)
+
+        TestNatRule._org_client = Environment.get_client_in_default_org(
+            CommonRoles.ORGANIZATION_ADMINISTRATOR)
+        TestNatRule._config = Environment.get_config()
+        TestNatRule._api_version = TestNatRule._config['vcd']['api_version']
+
+        external_network = Environment.get_test_external_network(
+            TestNatRule._client)
+
+        ext_net_resource = external_network.get_resource()
+        ip_scopes = ext_net_resource.xpath(
+            'vcloud:Configuration/vcloud:IpScopes/vcloud:IpScope',
+            namespaces=NSMAP)
+        first_ipscope = ip_scopes[0]
+        gateway_ip = first_ipscope.Gateway.text
+        prefix_len = netmask_to_cidr_prefix_len(gateway_ip,
+                                           first_ipscope.Netmask.text)
+        subnet_addr = gateway_ip + '/' + str(prefix_len)
+        ext_net_to_participated_subnet_with_ip_settings = {
+            ext_net_resource.get('name'): {
+                subnet_addr: 'Auto'
+            }
+        }
+
+        gateway_ip_arr = gateway_ip.split('.')
+        last_ip_digit = int(gateway_ip_arr[-1]) + 1
+        gateway_ip_arr[-1] = str(last_ip_digit)
+        next_ip = '.'.join(gateway_ip_arr)
+        ext_net_to_subnet_with_ip_range = {
+            ext_net_resource.get('name'): {
+                subnet_addr: [next_ip + '-' + next_ip]
+            }
+        }
+        ext_net_to_rate_limit = {ext_net_resource.get('name'): {100: 100}}
+        if float(TestNatRule._api_version) <= float(
+                ApiVersion.VERSION_30.value):
+            TestNatRule._gateway = \
+                TestNatRule._vdc.create_gateway_api_version_30(
+                    self._name, [ext_net_resource.get('name')], 'compact',
+                    None,
+                    True, ext_net_resource.get('name'), gateway_ip, True,
+                    False,
+                    False, False, True,
+                    ext_net_to_participated_subnet_with_ip_settings, True,
+                    ext_net_to_subnet_with_ip_range, ext_net_to_rate_limit)
+        else:
+            TestNatRule._gateway = TestNatRule._vdc.create_gateway(
+                self._name, [ext_net_resource.get('name')], 'compact', None,
+                True, ext_net_resource.get('name'), gateway_ip, True, False,
+                False, False, True,
+                ext_net_to_participated_subnet_with_ip_settings, True,
+                ext_net_to_subnet_with_ip_range, ext_net_to_rate_limit)
+
+        result = TestNatRule._client.get_task_monitor().wait_for_success(
+            task=TestNatRule._gateway.Tasks.Task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def __get_subnet_participation(self, gateway, ext_network):
+        for gatewayinf in \
+                gateway.Configuration.GatewayInterfaces.GatewayInterface:
+            if gatewayinf.Name == ext_network:
+                return gatewayinf.SubnetParticipation
+
+    def __validate_ip_range(self, IpRanges, _ip_range1):
+        """ Validate if the ip range present in the existing ip ranges """
+        _ip_ranges = _ip_range1.split('-')
+        _ip_range1_start_address = _ip_ranges[0]
+        _ip_range1_end_address = _ip_ranges[1]
+        for ip_range in IpRanges.IpRange:
+            if ip_range.StartAddress == _ip_range1_start_address:
+                self.assertEqual(ip_range.EndAddress, _ip_range1_end_address)
+
+    def test_0001_convert_to_advanced(self):
+        """Convert the legacy gateway to advance gateway.
+        Invoke the convert_to_advanced method for gateway.
+        """
+        if float(TestNatRule._api_version) >= float(
+                ApiVersion.VERSION_32.value):
+            return
+        gateway_obj = Gateway(TestNatRule._org_client, self._name,
+                              TestNatRule._gateway.get('href'))
+        task = gateway_obj.convert_to_advanced()
+        result = TestNatRule._client.get_task_monitor().wait_for_success(
+            task=task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0005_add_sub_allocated_ip_pools(self):
+        """It adds the sub allocated ip pools to gateway.
+
+        Invokes the add_sub_allocated_ip_pools of the gateway.
+        """
+        gateway_obj = Gateway(TestNatRule._client, self._name,
+                              TestNatRule._gateway.get('href'))
+        ip_allocations = gateway_obj.list_configure_ip_settings()
+        ip_allocation = ip_allocations[0]
+        ext_network = ip_allocation.get('external_network')
+        config = TestNatRule._config['external_network']
+        gateway_sub_allocated_ip_range = \
+            config['gateway_sub_allocated_ip_range']
+        ip_range_list = [gateway_sub_allocated_ip_range]
+
+        task = gateway_obj.add_sub_allocated_ip_pools(ext_network,
+                                                      ip_range_list)
+        result = TestNatRule._client.get_task_monitor().wait_for_success(
+            task=task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        gateway_obj = Gateway(TestNatRule._client, self._name,
+                              TestNatRule._gateway.get('href'))
+        subnet_participation = self.__get_subnet_participation(
+            gateway_obj.get_resource(), ext_network)
+        ip_ranges = gateway_obj.get_sub_allocate_ip_ranges_element(
+            subnet_participation)
+        self.__validate_ip_range(ip_ranges, gateway_sub_allocated_ip_range)
+
+    def test_0010_add_nat_rule(self):
+        """Add Nat Rule's in the gateway."""
+
+        gateway_obj = Gateway(TestNatRule._client, self._name,
+                              TestNatRule._gateway.get('href'))
+        # Create SNAT Rule
+        gateway_obj.add_nat_rule(
+            action=TestNatRule._snat_action,
+            original_address=TestNatRule._snat_orig_addr,
+            translated_address=TestNatRule._snat_trans_addr)
+        # Create DNAT Rule for tcp/udp protocol
+        gateway_obj.add_nat_rule(
+            action=TestNatRule._dnat_action,
+            original_address=TestNatRule._dnat1_orig_addr,
+            translated_address=TestNatRule._dnat1_trans_addr,
+            protocol=TestNatRule._dnat1_protocol,
+            original_port=TestNatRule._dnat1_orig_port,
+            translated_port=TestNatRule._dnat1_trans_port)
+        # Create DNAT Rule for icmp protocol
+        gateway_obj.add_nat_rule(
+            action=TestNatRule._dnat_action,
+            original_address=TestNatRule._dnat2_orig_addr,
+            translated_address=TestNatRule._dnat2_trans_addr,
+            description=TestNatRule._dnat2_protocol,
+            protocol=TestNatRule._dnat2_protocol)
+        nat_rule = gateway_obj.get_nat_rules()
+        #Verify
+        snat_count = 0
+        dnat_count = 0
+        for natRule in nat_rule.natRules.natRule:
+            if natRule.action == 'snat':
+                snat_count += 1
+            if natRule.action == 'dnat':
+                dnat_count += 1
+        self.assertTrue(snat_count == 1)
+        self.assertTrue(dnat_count == 2)
+
+    def test_0098_teardown(self):
+        """Test method to delete a nat rule and gateway.
+
+        Invoke the method for the gateway created by setup.
+
+        This test passes if no errors are generated while deleting the gateway.
+        """
+        gateway_obj = Gateway(TestNatRule._client, self._name,
+                              TestNatRule._gateway.get('href'))
+        nat_rule = gateway_obj.get_nat_rules()
+        for natRule in nat_rule.natRules.natRule:
+            rule_id = natRule.ruleId
+            break
+        nat_obj = NatRule(TestNatRule._client, self._name, rule_id)
+        # deleting single nat rule as gateway deletion will clear all
+        nat_obj.delete_nat_rule()
+
+        vdc = Environment.get_test_vdc(TestNatRule._client)
+        task = vdc.delete_gateway(TestNatRule._name)
+        result = TestNatRule._client.get_task_monitor().wait_for_success(
+            task=task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0099_cleanup(self):
+        """Release all resources held by this object for testing purposes."""
+        TestNatRule._client.logout()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/system_tests/nat_rule_tests.py
+++ b/system_tests/nat_rule_tests.py
@@ -128,15 +128,17 @@ class TestNatRule(BaseTestCase):
             protocol=TestNatRule._dnat2_protocol)
         nat_rule = gateway_obj.get_nat_rules()
         #Verify
-        snat_count = 0
-        dnat_count = 0
+        snat_found = False
+        dnat_found = False
         for natRule in nat_rule.natRules.natRule:
-            if natRule.action == 'snat':
-                snat_count += 1
-            if natRule.action == 'dnat':
-                dnat_count += 1
-        self.assertTrue(snat_count == 1)
-        self.assertTrue(dnat_count == 2)
+            if natRule.action == 'snat' and \
+                natRule.originalAddress == TestNatRule._snat_orig_addr :
+                snat_found = True
+            if natRule.action == 'dnat' and \
+                natRule.originalAddress == TestNatRule._dnat1_orig_addr :
+                dnat_found = True
+        self.assertTrue(snat_found)
+        self.assertTrue(dnat_found)
 
     def test_0090_delete_nat_rule(self):
         """Delete Nat Rule in the gateway.


### PR DESCRIPTION
Add a SNAT or DNAT rule to an edge gateway.
Delete a SNAT or DNAT rule to an edge gateway.
This will support tcp/udp/icmp protocols for NAT rule.

Testing done:
Test cases passed
Setup
Add NAT rule
Delete NAT rule
Teardown

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/385)
<!-- Reviewable:end -->
