### PR TITLE
VP-1590,1594: Get Nat Rule info and list Nat Rules

### DIFF
--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -890,3 +890,36 @@ class Gateway(object):
     def _build_nat_rule_href(self):
         network_url = build_network_url_from_gateway_url(self.href)
         return network_url + NAT_URL_TEMPLATE
+
+    def list_nat_rules(self):
+        """List all nat rules on a gateway.
+
+        :return: list of all nat rules on a gateway.
+        e.g.
+        e.g.
+        {'ID': 196609, 'OriginalAddress': '2.2.3.7', 'OriginalPort':
+         'any', 'TranslatedAddress': '2.2.3.8', 'TranslatedPort':
+         'any', 'Action': 'snat', 'Protocol': 'any', 'Enabled': True,
+         'Logging': False, 'Description': ''}
+        """
+        out_list = []
+        nat_rules_resource = self.get_nat_rules()
+        if (hasattr(nat_rules_resource.natRules, 'natRule')):
+            for nat_rule in nat_rules_resource.natRules.natRule:
+                nat_rule_info = {}
+                nat_rule_info['ID'] = nat_rule.ruleId
+                nat_rule_info['OriginalAddress'] = nat_rule.originalAddress
+                nat_rule_info['OriginalPort'] = nat_rule.originalPort
+                nat_rule_info['TranslatedAddress'] = nat_rule.translatedAddress
+                nat_rule_info['TranslatedPort'] = nat_rule.translatedPort
+                nat_rule_info['Action'] = nat_rule.action
+                nat_rule_info['Protocol'] = nat_rule.protocol
+                nat_rule_info['Enabled'] = nat_rule.enabled
+                nat_rule_info['Logging'] = nat_rule.loggingEnabled
+                nat_rule_info['Description'] = nat_rule.description
+                out_list.append(nat_rule_info)
+        else:
+            raise \
+                InvalidParameterException("No nat rule found on"
+                                          " the gateway")
+        return out_list

--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -896,11 +896,7 @@ class Gateway(object):
 
         :return: list of all nat rules on a gateway.
         e.g.
-        e.g.
-        {'ID': 196609, 'OriginalAddress': '2.2.3.7', 'OriginalPort':
-         'any', 'TranslatedAddress': '2.2.3.8', 'TranslatedPort':
-         'any', 'Action': 'snat', 'Protocol': 'any', 'Enabled': True,
-         'Logging': False, 'Description': ''}
+        [{'ID': 196609, 'Action': 'snat', 'Enabled': True}]
         """
         out_list = []
         nat_rules_resource = self.get_nat_rules()
@@ -908,18 +904,7 @@ class Gateway(object):
             for nat_rule in nat_rules_resource.natRules.natRule:
                 nat_rule_info = {}
                 nat_rule_info['ID'] = nat_rule.ruleId
-                nat_rule_info['OriginalAddress'] = nat_rule.originalAddress
-                nat_rule_info['OriginalPort'] = nat_rule.originalPort
-                nat_rule_info['TranslatedAddress'] = nat_rule.translatedAddress
-                nat_rule_info['TranslatedPort'] = nat_rule.translatedPort
                 nat_rule_info['Action'] = nat_rule.action
-                nat_rule_info['Protocol'] = nat_rule.protocol
                 nat_rule_info['Enabled'] = nat_rule.enabled
-                nat_rule_info['Logging'] = nat_rule.loggingEnabled
-                nat_rule_info['Description'] = nat_rule.description
                 out_list.append(nat_rule_info)
-        else:
-            raise \
-                InvalidParameterException("No nat rule found on"
-                                          " the gateway")
         return out_list

--- a/pyvcloud/vcd/nat_rule.py
+++ b/pyvcloud/vcd/nat_rule.py
@@ -116,3 +116,28 @@ class NatRule(object):
         """Delete a nat rule from gateway."""
         self.get_resource()
         return self.client.delete_resource(self.href)
+
+    def get_nat_rule_info(self):
+        """Get the details of nat rule.
+
+        :return: Dictionary having nat rule details.
+        e.g.
+        {'ID': 196609, 'OriginalAddress': '2.2.3.7', 'OriginalPort':
+         'any', 'TranslatedAddress': '2.2.3.8', 'TranslatedPort':
+         'any', 'Action': 'snat', 'Protocol': 'any', 'Enabled': True,
+         'Logging': False, 'Description': ''}
+        :rtype: Dictionary
+        """
+        nat_rule_info = {}
+        nat_rule = self.get_resource()
+        nat_rule_info['ID'] = nat_rule.ruleId
+        nat_rule_info['OriginalAddress'] = nat_rule.originalAddress
+        nat_rule_info['OriginalPort'] = nat_rule.originalPort
+        nat_rule_info['TranslatedAddress'] = nat_rule.translatedAddress
+        nat_rule_info['TranslatedPort'] = nat_rule.translatedPort
+        nat_rule_info['Action'] = nat_rule.action
+        nat_rule_info['Protocol'] = nat_rule.protocol
+        nat_rule_info['Enabled'] = nat_rule.enabled
+        nat_rule_info['Logging'] = nat_rule.loggingEnabled
+        nat_rule_info['Description'] = nat_rule.description
+        return nat_rule_info

--- a/system_tests/nat_rule_tests.py
+++ b/system_tests/nat_rule_tests.py
@@ -159,10 +159,9 @@ class TestNatRule(BaseTestCase):
         nat_rule_info =  nat_obj.get_nat_rule_info()
         #Verify
         self.assertTrue(len(nat_rule_info) > 0)
-        self.assertTrue(nat_rule_info['Action'] == \
-            TestNatRule._snat_action)
-        self.assertTrue(nat_rule_info['OriginalAddress'] == \
-            TestNatRule._snat_orig_addr)
+        self.assertEqual(nat_rule_info['Action'], TestNatRule._snat_action)
+        self.assertEqual(nat_rule_info['OriginalAddress'],
+                         TestNatRule._snat_orig_addr)
 
     def test_0020_list_nat_rules(self):
         """List all nat rules on a gateway.

--- a/system_tests/nat_rule_tests.py
+++ b/system_tests/nat_rule_tests.py
@@ -140,6 +140,44 @@ class TestNatRule(BaseTestCase):
         self.assertTrue(snat_found)
         self.assertTrue(dnat_found)
 
+    def test_0015_get_nat_rule_info(self):
+        """Get the details of nat rule.
+
+        Invokes the get_nat_rule_info of the NatRule.
+        """
+        gateway = Environment. \
+            get_test_gateway(TestNatRule._client)
+        gateway_obj = Gateway(TestNatRule._client,
+                              TestNatRule._name,
+                              href=gateway.get('href'))
+        nat_rule = gateway_obj.get_nat_rules()
+        for natRule in nat_rule.natRules.natRule:
+            if natRule.action == 'snat':
+                rule_id = natRule.ruleId
+                break
+        nat_obj = NatRule(TestNatRule._client, self._name, rule_id)
+        nat_rule_info =  nat_obj.get_nat_rule_info()
+        #Verify
+        self.assertTrue(len(nat_rule_info) > 0)
+        self.assertTrue(nat_rule_info['Action'] == \
+            TestNatRule._snat_action)
+        self.assertTrue(nat_rule_info['OriginalAddress'] == \
+            TestNatRule._snat_orig_addr)
+
+    def test_0020_list_nat_rules(self):
+        """List all nat rules on a gateway.
+
+        Invokes the list_nat_rules of the Gateway.
+        """
+        gateway = Environment. \
+            get_test_gateway(TestNatRule._client)
+        gateway_obj = Gateway(TestNatRule._client,
+                              TestNatRule._name,
+                              href=gateway.get('href'))
+        nat_rule_list = gateway_obj.list_nat_rules()
+        #Verify
+        self.assertTrue(len(nat_rule_list) > 0)
+
     def test_0090_delete_nat_rule(self):
         """Delete Nat Rule in the gateway.
 


### PR DESCRIPTION
Get all details of a Nat Rule.
List all the Nat Rules associated with gateway
     e.g.
      {'ID': 196609, 'OriginalAddress': '2.2.3.7', 'OriginalPort':
       'any', 'TranslatedAddress': '2.2.3.8', 'TranslatedPort':
       'any', 'Action': 'snat', 'Protocol': 'any', 'Enabled': True,
       'Logging': False, 'Description': ''}
Testing done:
Added below tests:
test_0015_get_nat_rule_info
test_0020_list_nat_rules

test cases status: passed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/387)
<!-- Reviewable:end -->
