### PR TITLE
[VP-1377]: List connected vApps to a org vdc routed network

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -491,12 +491,14 @@ class GatewayBackingConfigType(Enum):
     FULL4 = 'full4'
     XLARGE = 'x-large'
 
+
 class VAppPowerStatus(Enum):
     RUNNING = '4'
     STOPPED = '8'
     SUSPENDED = '3'
     DEPLOYED = '2'
     UNDEPLOYED = '1'
+
 
 class _TaskMonitor(object):
     _DEFAULT_POLL_SEC = 5

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -491,6 +491,12 @@ class GatewayBackingConfigType(Enum):
     FULL4 = 'full4'
     XLARGE = 'x-large'
 
+class VAppPowerStatus(Enum):
+    RUNNING = '4'
+    STOPPED = '8'
+    SUSPENDED = '3'
+    DEPLOYED = '2'
+    UNDEPLOYED = '1'
 
 class _TaskMonitor(object):
     _DEFAULT_POLL_SEC = 5

--- a/pyvcloud/vcd/vdc_network.py
+++ b/pyvcloud/vcd/vdc_network.py
@@ -17,9 +17,7 @@ from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import MetadataDomain
 from pyvcloud.vcd.client import MetadataValueType
 from pyvcloud.vcd.client import MetadataVisibility
-from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.client import RelationType
-from pyvcloud.vcd.client import ResourceType
 from pyvcloud.vcd.client import VAppPowerStatus
 from pyvcloud.vcd.exceptions import InvalidParameterException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException

--- a/system_tests/network_tests.py
+++ b/system_tests/network_tests.py
@@ -343,8 +343,8 @@ class TestNetwork(BaseTestCase):
         vdc_network = VdcNetwork(
             TestNetwork._client, resource=org_vdc_routed_nw)
         connected_vapps = vdc_network.list_connected_vapps()
-        self.assertTrue(len(connected_vapps), 1)
-        self.assertEqual(connected_vapps[0].get('name'), vapp_name)
+        self.assertEqual(len(connected_vapps), 1)
+        self.assertEqual(connected_vapps[0].get('Name'), vapp_name)
         # Delete test vApp after test
         vdc.reload()
         vdc.delete_vapp(vapp_name)

--- a/system_tests/network_tests.py
+++ b/system_tests/network_tests.py
@@ -333,7 +333,23 @@ class TestNetwork(BaseTestCase):
             '/')[0]
         self.assertEqual(allocated_ip_addresses[0]['IP Address'], ip_address)
 
-    def test_0100_delete_routed_orgvdc_networks(self):
+    def test_0100_list_connected_vapps(self):
+        vdc = Environment.get_test_vdc(TestNetwork._client)
+        vapp_name = 'test-connected-vapp'
+        vdc.create_vapp(
+            vapp_name, network=TestNetwork._routed_org_vdc_network_name)
+        org_vdc_routed_nw = vdc.get_routed_orgvdc_network(
+            TestNetwork._routed_org_vdc_network_name)
+        vdc_network = VdcNetwork(
+            TestNetwork._client, resource=org_vdc_routed_nw)
+        connected_vapps = vdc_network.list_connected_vapps()
+        self.assertTrue(len(connected_vapps), 1)
+        self.assertEqual(connected_vapps[0].get('name'), vapp_name)
+        # Delete test vApp after test
+        vdc.reload()
+        vdc.delete_vapp(vapp_name)
+
+    def test_1000_delete_routed_orgvdc_networks(self):
         vdc = Environment.get_test_vdc(TestNetwork._client)
 
         result = vdc.delete_routed_orgvdc_network(


### PR DESCRIPTION
Added functionality to list of vApps connected to an org vdc routed network.

Testing done:
Added a test case test_0100_list_connected_vapps to network_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/390)
<!-- Reviewable:end -->
