### PR TITLE
Dhcp info

### DIFF
--- a/pyvcloud/vcd/dhcp_pool.py
+++ b/pyvcloud/vcd/dhcp_pool.py
@@ -42,6 +42,38 @@ class DhcpPool(GatewayServices):
                 self.resource = pool
                 break
 
+    def get_pool_info(self):
+        """Get the details of DHCP pool.
+
+        :return: Dictionary having DHCP Pool details.
+        e.g.
+        {'ID': 196609, 'IPRange': '2.2.3.7-2.2.3.10', 'DomainName':
+         'abc.com', 'DefaultGateway': '2.2.3.1', 'PrimaryNameServer':
+         '2.2.3.10', 'SecondaryNameServer': '2.2.3.12', 'LeaseTime': '8640',
+         'SubnetMask': 255.255.255.0, 'AllowHugeRange': False}
+        :rtype: Dictionary
+        """
+        pool_info = {}
+        resource = self._get_resource()
+        pool_info['ID'] = resource.poolId
+        pool_info['IPRange'] = resource.ipRange
+        if hasattr(resource, 'domainName'):
+            pool_info['DomainName'] = resource.domainName
+        if hasattr(resource, 'defaultGateway'):
+            pool_info['DefaultGateway'] = resource.defaultGateway
+        if hasattr(resource, 'primaryNameServer'):
+            pool_info['PrimaryNameServer'] = resource.primaryNameServer
+        if hasattr(resource, 'secondaryNameServer'):
+            pool_info['secondaryNameServer'] = resource.secondaryNameServer
+
+        pool_info['LeaseTime'] = resource.leaseTime
+
+        if hasattr(resource, 'subnetMask'):
+            pool_info['SubnetMask'] = resource.subnetMask
+        if hasattr(resource, 'allowHugeRange'):
+            pool_info['AllowHugeRange'] = resource.allowHugeRange
+        return pool_info
+
     def delete_pool(self):
         """Delete a DHCP Pool from gateway."""
         self._get_resource()

--- a/system_tests/dhcp_tests.py
+++ b/system_tests/dhcp_tests.py
@@ -64,7 +64,7 @@ class TestDhcp(BaseTestCase):
         # Verify
         self.assertTrue(len(dhcp_pool_list) > 0)
 
-    def test_0015_get_dhcp_pool_info(self):
+    def test_002_get_dhcp_pool_info(self):
         """Get the details of DHCP Pool.
 
         Invokes the get_nat_rule_info of the NatRule.

--- a/system_tests/dhcp_tests.py
+++ b/system_tests/dhcp_tests.py
@@ -67,7 +67,7 @@ class TestDhcp(BaseTestCase):
     def test_002_get_dhcp_pool_info(self):
         """Get the details of DHCP Pool.
 
-        Invokes the get_nat_rule_info of the NatRule.
+        Invokes the get_pool_info of the DhcpPool.
         """
         gateway = Environment. \
             get_test_gateway(TestDhcp._client)

--- a/system_tests/dhcp_tests.py
+++ b/system_tests/dhcp_tests.py
@@ -50,11 +50,10 @@ class TestDhcp(BaseTestCase):
         self.assertTrue(matchFound)
 
     def test_0001_list_dhcp_pools(self):
-        """List DHCP pools on the gateway.
+        """List DHCP pools of the gateway.
 
         Invokes the list_dhcp_pools of the gateway.
         """
-        TestDhcp._client = Environment.get_sys_admin_client()
         TestDhcp._config = Environment.get_config()
         gateway = Environment. \
             get_test_gateway(TestDhcp._client)
@@ -64,6 +63,24 @@ class TestDhcp(BaseTestCase):
         dhcp_pool_list = gateway_obj.list_dhcp_pools()
         # Verify
         self.assertTrue(len(dhcp_pool_list) > 0)
+
+    def test_0015_get_dhcp_pool_info(self):
+        """Get the details of DHCP Pool.
+
+        Invokes the get_nat_rule_info of the NatRule.
+        """
+        gateway = Environment. \
+            get_test_gateway(TestDhcp._client)
+        gateway_obj = Gateway(TestDhcp._client,
+                              TestDhcp._name,
+                              href=gateway.get('href'))
+        dhcp_pool_list = gateway_obj.list_dhcp_pools()
+        pool_id = dhcp_pool_list[0]['ID']
+        pool_obj = DhcpPool(TestDhcp._client, self._name, pool_id)
+        pool_info = pool_obj.get_pool_info()
+        #Verify
+        self.assertTrue(len(pool_info) > 0)
+        self.assertEqual(pool_info['IPRange'], TestDhcp._pool_ip_range)
 
     def test_0098_teardown(self):
         """Remove the DHCP ip pools of gateway.


### PR DESCRIPTION
VP-1557:Get DHCP Pool info

PYSDK: User would be able to get the info of particular DHCP Pool

Add get_pool_info in dhcp_pool.py, it returns dictionary having DHCP Pool details.
        e.g.
        {'ID': 196609, 'IPRange': '2.2.3.7-2.2.3.10', 'DomainName':
         'abc.com', 'DefaultGateway': '2.2.3.1', 'PrimaryNameServer':
         '2.2.3.10', 'SecondaryNameServer': '2.2.3.12', 'LeaseTime': '8640',
         'SubnetMask': 255.255.255.0, 'AllowHugeRange': False}  

Test: Testing Done

Added test_0002_get_dhcp_pool_info in dhcp_test.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/392)
<!-- Reviewable:end -->
