### PR TITLE
[VP-1748]: Listing of connected vApps fails for system admin

### DIFF
--- a/pyvcloud/vcd/vdc_network.py
+++ b/pyvcloud/vcd/vdc_network.py
@@ -102,9 +102,11 @@ class VdcNetwork(object):
             self.resource, RelationType.EDIT, EntityType.ORG_VDC_NETWORK.value,
             vdc_network)
 
-    def add_static_ip_pool_and_dns(self, ip_ranges_param=None,
+    def add_static_ip_pool_and_dns(self,
+                                   ip_ranges_param=None,
                                    primary_dns_ip=None,
-                                   secondary_dns_ip=None, dns_suffix=None):
+                                   secondary_dns_ip=None,
+                                   dns_suffix=None):
         """Add static IP pool and DNS for org vdc network.
 
         :param list ip_ranges_param: list of ip ranges.
@@ -334,8 +336,14 @@ class VdcNetwork(object):
         :rtype: list
         """
         vapp_name_list = []
-        vdc = self.client.get_linked_resource(
-            self.get_resource(), RelationType.UP, EntityType.VDC.value)
+        if (self.client.is_sysadmin()):
+            vdc = self.client.get_linked_resource(self.get_resource(),
+                                                  RelationType.UP,
+                                                  EntityType.VDC_ADMIN.value)
+        else:
+            vdc = self.client.get_linked_resource(
+                self.get_resource(), RelationType.UP, EntityType.VDC.value)
+
         for entity in vdc.ResourceEntities.ResourceEntity:
             if entity.get('type') == EntityType.VAPP.value:
                 vapp = self.client.get_resource(entity.get('href'))


### PR DESCRIPTION
It is failing because media type of vDC link in routed network is different in case of org admin and system admin. Added a check look for admin vDC link in case system admin is logged in. Otherwise, look for vDC link.

Testing done:
Added two test cases test_0100_list_connected_vapps_org_admin, test_0110_list_connected_vapps_sys_admin in network_tests.py. All tests in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/398)
<!-- Reviewable:end -->
