### PR TITLE
[VP-1365]: Remove static IP pool in routed network under Network Specification

### DIFF
--- a/pyvcloud/vcd/vdc_network.py
+++ b/pyvcloud/vcd/vdc_network.py
@@ -221,6 +221,30 @@ class VdcNetwork(object):
             self.resource, RelationType.EDIT, EntityType.ORG_VDC_NETWORK.value,
             vdc_network)
 
+    def remove_static_ip_pool(self, ip_range_param):
+        """Remove static IP pool of org vdc network.
+
+        :param str ip_range_param: ip range. For ex: 2.3.3.2-2.3.3.10
+
+        :return: object containing EntityType.TASK XML data representing the
+            asynchronous task.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        vdc_network = self.get_resource()
+        ip_scope = vdc_network.Configuration.IpScopes.IpScope
+        if not hasattr(ip_scope, 'IpRanges'):
+            raise OperationNotSupportedException('No IP range found.')
+
+        for ip_range in ip_scope.IpRanges.IpRange:
+            if (ip_range.StartAddress + '-' +
+                    ip_range.EndAddress) == ip_range_param:
+                ip_scope.IpRanges.remove(ip_range)
+
+        return self.client.put_linked_resource(
+            self.resource, RelationType.EDIT, EntityType.ORG_VDC_NETWORK.value,
+            vdc_network)
+
     def get_all_metadata(self):
         """Fetch all metadata entries of the org vdc network.
 

--- a/system_tests/network_tests.py
+++ b/system_tests/network_tests.py
@@ -302,6 +302,31 @@ class TestNetwork(BaseTestCase):
                 match_found = True
         self.assertTrue(match_found)
 
+    def test_0078_remove_static_ip_pool(self):
+        vdc = Environment.get_test_vdc(TestNetwork._client)
+        org_vdc_routed_nw = vdc.get_routed_orgvdc_network(
+            TestNetwork._routed_org_vdc_network_name)
+        vdcNetwork = VdcNetwork(
+            TestNetwork._client, resource=org_vdc_routed_nw)
+        result = vdcNetwork.remove_static_ip_pool(TestNetwork._new_ip_range)
+        task = TestNetwork._client.get_task_monitor().wait_for_success(
+            task=result)
+        self.assertEqual(task.get('status'), TaskStatus.SUCCESS.value)
+        # Verification
+        vdcNetwork.reload()
+        vdc_routed_nw = vdcNetwork.get_resource()
+        ip_scope = vdc_routed_nw.Configuration.IpScopes.IpScope
+        # IPRanges element will be missing if there was only one IP range
+        if not hasattr(ip_scope, 'IpRanges'):
+            return
+        ip_ranges = ip_scope.IpRanges.IpRange
+        match_found = False
+        for ip_range in ip_ranges:
+            if (ip_range.StartAddress + '-' + ip_range.EndAddress) == \
+                    TestNetwork._new_ip_range:
+                match_found = True
+        self.assertFalse(match_found)
+
     def _add_routed_vdc_network_metadata(self, vdc_network, metadata_key,
                                          metadata_value):
         task = vdc_network.set_metadata(metadata_key, metadata_value)


### PR DESCRIPTION
Added a feature to delete static IP pool from a routed network. It also removes if there is just one IP pool.

Testing done:
Added test_0078_remove_static_ip_pool to network_tests.py. All tests cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/399)
<!-- Reviewable:end -->
