### PR TITLE
Fixed failing api-extension system tests.

### DIFF
--- a/system_tests/api_extension_tests.py
+++ b/system_tests/api_extension_tests.py
@@ -230,12 +230,11 @@ class TestApiExtension(BaseTestCase):
         self.assertEqual(href, TestApiExtension._service1_href)
 
     def test_007_register_service_right(self):
-        ''' Register a new right for existing API extension. Tests
-            APIExtension.add_service_right() method.
+        """Test the method APIExtension.add_service_right().
 
-            This test passes if the right-name returned after execution of
-            the method matches the expected right-name.
-        '''
+        This test passes if the right-name returned after execution of the
+        method matches the expected right-name.
+        """
         logger = Environment.get_default_logger()
         api_extension = APIExtension(TestApiExtension._client)
 

--- a/system_tests/api_extension_tests.py
+++ b/system_tests/api_extension_tests.py
@@ -237,7 +237,6 @@ class TestApiExtension(BaseTestCase):
             the method matches the expected right-name.
         '''
         logger = Environment.get_default_logger()
-        TestApiExtension._client = Environment.get_sys_admin_client()
         api_extension = APIExtension(TestApiExtension._client)
 
         # Create a new right for CSE RBAC
@@ -284,7 +283,7 @@ class TestApiExtension(BaseTestCase):
 
         ext_info = api_extension.get_extension_info(ext_name,
                                                     namespace=ext_namespace)
-        self.assertEqual(ext_info['routing_key'], test_routing_key)
+        self.assertEqual(ext_info['routingKey'], test_routing_key)
         self.assertEqual(ext_info['exchange'], test_exchange)
 
     @developerModeAware


### PR DESCRIPTION
The api_extension system test was failing because of a wrong key. 
Also fixed client being leaked from another test in the same module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/402)
<!-- Reviewable:end -->
