### PR TITLE
Comment update of external network test case as it gets stuck in vCD

### DIFF
--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -92,6 +92,7 @@ class TestExtNet(BaseTestCase):
 
         logger.debug('Created external network ' + TestExtNet._name + '.')
 
+    @unittest.skip("Update task gets stuck in vCD. Commenting for now.")
     def test_0010_update(self):
         """Test the method Platform.update_external_network()
 


### PR DESCRIPTION
Update of external network gets stuck in vCD. We have observed this behavior in multiple run. Commenting for now.

Reference: https://sp-taas-vcd-butler.svc.eng.vmware.com/view/all/job/Preflight-pysdk-1.0-STF/43/consoleFull

@shashim22

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/408)
<!-- Reviewable:end -->
