### PR TITLE
VP-1608: Delete Static Routes

### DIFF
--- a/pyvcloud/vcd/static_route.py
+++ b/pyvcloud/vcd/static_route.py
@@ -1,0 +1,45 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2014-2019 VMware, Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyvcloud.vcd.client import EntityType
+from pyvcloud.vcd.gateway_services import GatewayServices
+from pyvcloud.vcd.network_url_constants import STATIC_ROUTE_URL_TEMPLATE
+
+
+class StaticRoute(GatewayServices):
+    """This class will be used to configure static routes on gateway."""
+
+    def __init__(self, client, gateway_name=None, route_network_id=None,
+                 route_resource=None, href=None):
+        super(StaticRoute, self).__init__(client, gateway_name=gateway_name,
+                                          resource_id=route_network_id,
+                                          resource=route_resource,
+                                          resource_href=href)
+
+    def _build_self_href(self, network):
+        static_route_href = (self.network_url + STATIC_ROUTE_URL_TEMPLATE)
+        self.href = static_route_href
+
+    def _reload(self):
+        """Reloads the resource representation of static route."""
+        self.resource = self.client.get_resource(self.href)
+
+    def delete_static_route(self):
+        """Delete a static route from gateway."""
+        static_resource = self._get_resource()
+        for static_route in static_resource.staticRoutes.route:
+            if static_route.network == self.resource_id:
+                static_resource.staticRoutes.remove(static_route)
+        self.client.put_resource(self.href, static_resource,
+                                 EntityType.DEFAULT_CONTENT_TYPE.value)

--- a/system_tests/static_route_tests.py
+++ b/system_tests/static_route_tests.py
@@ -18,6 +18,7 @@ from pyvcloud.system_test_framework.environment import Environment
 from pyvcloud.system_test_framework.constants.gateway_constants import \
     GatewayConstants
 from pyvcloud.vcd.gateway import Gateway
+from pyvcloud.vcd.static_route import StaticRoute
 
 
 class TestStaticRoute(BaseTestCase):
@@ -26,6 +27,7 @@ class TestStaticRoute(BaseTestCase):
     _next_hop = '2.2.3.80'
     _network = '192.169.1.0/24'
     _name = GatewayConstants.name
+    _network_id = None
 
     def test_0000_setup(self):
         """Add Static Route in the gateway.
@@ -46,7 +48,8 @@ class TestStaticRoute(BaseTestCase):
         match_found = False
         for route in static_route.staticRoutes.route:
             if route.nextHop == TestStaticRoute._next_hop and \
-                route.network == TestStaticRoute._network :
+               route.network == TestStaticRoute._network:
+                TestStaticRoute._network_id = route.network
                 match_found = True
                 break
         self.assertTrue(match_found)
@@ -67,8 +70,23 @@ class TestStaticRoute(BaseTestCase):
         self.assertTrue(len(static_route_list) > 0)
 
     def test_0098_teardown(self):
-        """Remove the Static Route from the gateway."""
-        # Will add code for delete Static Route
+        """Remove the static route from the gateway.
+
+        Invokes the delete_static_route of the gateway
+        """
+        static_object = StaticRoute(TestStaticRoute._client,
+                                    TestStaticRoute._name,
+                                    TestStaticRoute._network_id)
+        static_object.delete_static_route()
+        # Verify
+        gateway = Environment. \
+            get_test_gateway(TestStaticRoute._client)
+        gateway_obj = Gateway(TestStaticRoute._client,
+                              TestStaticRoute._name,
+                              href=gateway.get('href'))
+        static_route = gateway_obj.get_static_routes()
+        #Verify
+        self.assertFalse(hasattr(static_route.staticRoutes, 'route'))
 
     def test_0099_cleanup(self):
         """Release all resources held by this object for testing purposes."""


### PR DESCRIPTION
Delete the static route from gateway based on network_id.
Created a new class StaticRoute for configure services on gateway.

Testing Done:
test_0098_teardown to delete the static route.
status: passed
