### PR TITLE
VP-1538 : [PySDK] Edit Firewall rule name

### DIFF
--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -69,7 +69,7 @@ class FirewallRule(GatewayServices):
         [value:value_type]
         :param list services: protocol to port mapping.
          e.g., [{'tcp' : {'any' : any}}]
-        :param string new_name: new name of the firewall rule.
+        :param str new_name: new name of the firewall rule.
         """
         self._get_resource()
         self.validate_types(source_values, FirewallRule.__SOURCE)

--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -69,7 +69,7 @@ class FirewallRule(GatewayServices):
         [value:value_type]
         :param list services: protocol to port mapping.
          e.g., [{'tcp' : {'any' : any}}]
-        :param String new_name: new name of the firewall rule.
+        :param string new_name: new name of the firewall rule.
         """
         self._get_resource()
         self.validate_types(source_values, FirewallRule.__SOURCE)

--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -69,6 +69,7 @@ class FirewallRule(GatewayServices):
         [value:value_type]
         :param list services: protocol to port mapping.
          e.g., [{'tcp' : {'any' : any}}]
+        :param String new_name: new name of the firewall rule.
         """
         self._get_resource()
         self.validate_types(source_values, FirewallRule.__SOURCE)
@@ -99,7 +100,7 @@ class FirewallRule(GatewayServices):
                     create_element(FirewallRule.__APPLICATION))
             self._populate_services(firewall_rule_temp, services)
 
-        if new_name is not None:
+        if new_name:
             firewall_rule_temp.name = new_name
         self.client.put_resource(self.href, firewall_rule_temp,
                                  EntityType.DEFAULT_CONTENT_TYPE.value)

--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -56,7 +56,11 @@ class FirewallRule(GatewayServices):
         self._get_resource()
         return self.client.delete_resource(self.href)
 
-    def edit(self, source_values=None, destination_values=None, services=None):
+    def edit(self,
+             source_values=None,
+             destination_values=None,
+             services=None,
+             new_name=None):
         """Edit a Firewall rule.
 
         :param list source_values: list of source values. e.g.,
@@ -95,6 +99,8 @@ class FirewallRule(GatewayServices):
                     create_element(FirewallRule.__APPLICATION))
             self._populate_services(firewall_rule_temp, services)
 
+        if new_name is not None:
+            firewall_rule_temp.name = new_name
         self.client.put_resource(self.href, firewall_rule_temp,
                                  EntityType.DEFAULT_CONTENT_TYPE.value)
 

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -148,7 +148,6 @@ class TestFirewallRules(BaseTestCase):
                 'any': 'any'
             }
         }]
-        name = firewall_obj._get_resource().name
         new_name = 'Rule_New_Name_Test'
         firewall_obj.edit(source_object, destination_object, source, new_name)
         # Verify
@@ -163,7 +162,8 @@ class TestFirewallRules(BaseTestCase):
         self.assertTrue(hasattr(firewall_res.application, 'service'))
         self.assertEqual(firewall_res.name, 'Rule_New_Name_Test')
         # revert back name change to old name
-        firewall_obj.edit(source_object, destination_object, source, name)
+        firewall_obj.edit(source_object, destination_object, source,
+                          TestFirewallRules._firewall_rule_name)
 
     def test_0041_enable_disable_firewall_rule(self):
         firewall_obj = FirewallRule(TestFirewallRules._client,

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -148,6 +148,7 @@ class TestFirewallRules(BaseTestCase):
                 'any': 'any'
             }
         }]
+        name = firewall_obj._get_resource().name
         new_name = 'Rule_New_Name_Test'
         firewall_obj.edit(source_object, destination_object, source, new_name)
         # Verify
@@ -161,6 +162,8 @@ class TestFirewallRules(BaseTestCase):
         self.assertTrue(hasattr(firewall_res.destination, 'ipAddress'))
         self.assertTrue(hasattr(firewall_res.application, 'service'))
         self.assertEqual(firewall_res.name, 'Rule_New_Name_Test')
+        # revert back name change to old name
+        firewall_obj.edit(source_object, destination_object, source, name)
 
     def test_0041_enable_disable_firewall_rule(self):
         firewall_obj = FirewallRule(TestFirewallRules._client,

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -148,7 +148,8 @@ class TestFirewallRules(BaseTestCase):
                 'any': 'any'
             }
         }]
-        firewall_obj.edit(source_object, destination_object, source)
+        new_name = 'Rule_New_Name_Test'
+        firewall_obj.edit(source_object, destination_object, source, new_name)
         # Verify
         firewall_obj._reload()
         firewall_res = firewall_obj.resource
@@ -159,6 +160,7 @@ class TestFirewallRules(BaseTestCase):
         self.assertTrue(hasattr(firewall_res.destination, 'groupingObjectId'))
         self.assertTrue(hasattr(firewall_res.destination, 'ipAddress'))
         self.assertTrue(hasattr(firewall_res.application, 'service'))
+        self.assertEqual(firewall_res.name, 'Rule_New_Name_Test')
 
     def test_0041_enable_disable_firewall_rule(self):
         firewall_obj = FirewallRule(TestFirewallRules._client,


### PR DESCRIPTION
VP-1538 : [PySDK] Edit Firewall rule name
Enhanced the update feature to support edit of firewall rule name as well .

Testing Done:
Enhanced test_0050_edit to firewall_rule_tests.py to verify name edit. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/425)
<!-- Reviewable:end -->
