### PR TITLE
[Fix]: listing of vsphere network and direct org vdc network

### DIFF
--- a/pyvcloud/vcd/external_network.py
+++ b/pyvcloud/vcd/external_network.py
@@ -569,9 +569,12 @@ class ExternalNetwork(object):
         :raises: EntityNotFoundException: if any direct org vDC network
          cannot be found.
         """
+        query_filter = 'connectedTo==' + self.name
+        if filter:
+            query_filter += ';' + filter
         query = self.client.get_typed_query(
             ResourceType.ORG_VDC_NETWORK.value,
-            qfilter=filter,
+            qfilter=query_filter,
             query_result_format=QueryResultFormat.RECORDS)
         records = list(query.execute())
 
@@ -586,16 +589,19 @@ class ExternalNetwork(object):
 
         :param str filter: filter to fetch the vSphere Networks,
         e.g., networkName==Ext*
-        :return: list of associated provider vdcs
+        :return: list of associated vSphere networks
         e.g.
         [{'vCenter': 'vc1', 'Name': 'test-dvpg'}]
         :rtype: list
         """
         out_list = []
+        query_filter = 'networkName==' + self.name
+        if filter:
+            query_filter += ';' + filter
         query = self.client.get_typed_query(
             ResourceType.PORT_GROUP.value,
             query_result_format=QueryResultFormat.RECORDS,
-            qfilter=filter)
+            qfilter=query_filter)
         records = query.execute()
         if records is None:
             raise EntityNotFoundException('No associated vSphere'

--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -466,9 +466,14 @@ class TestExtNet(BaseTestCase):
             TestExtNet._common_ext_net_name)
         extnet_obj = ExternalNetwork(TestExtNet._sys_admin_client,
                                      resource=ext_net_resource)
-        direct_ovdc_networks = extnet_obj.list_associated_direct_org_vdc_networks(
-            'connectedTo==Ext*')
-        self.assertTrue(len(direct_ovdc_networks) > 0)
+        ovdc_network_name = 'test-direct-vdc-network'
+        filter = 'name==' + ovdc_network_name
+        direct_ovdc_networks = \
+            extnet_obj.list_associated_direct_org_vdc_networks(filter)
+        match_found = False
+        if ovdc_network_name in direct_ovdc_networks:
+            match_found = True
+        self.assertTrue(match_found)
 
     def test_0105_list_vsphere_network(self):
         """List associated vSphere Networks.
@@ -478,8 +483,14 @@ class TestExtNet(BaseTestCase):
             TestExtNet._name)
         extnet_obj = ExternalNetwork(TestExtNet._sys_admin_client,
                                      resource=ext_net_resource)
-        vSphere_network_list = extnet_obj.list_vsphere_network('networkName==Ext*')
-        self.assertTrue(len(vSphere_network_list) > 0)
+        portgroup_name = 'VM Network'
+        vSphere_network_list = \
+            extnet_obj.list_vsphere_network('name==' + portgroup_name)
+        match_found = False
+        for dic in vSphere_network_list:
+            if dic['Name'] == portgroup_name:
+                match_found = True
+        self.assertTrue(match_found)
 
     def __add_sub_allocate_ip_pool(self):
         gateway = Environment. \


### PR DESCRIPTION
Fix the following in external network:
1. list-direct-org-vdc-network
2. list-vsphere-network

Added filter for external network

Testing done: 
Below commands returning correct result
vcd network external list-direct-org-vdc-network extnw1
vcd network external list-direct-org-vdc-network extnw1 --filter connectedTo==*

vcd network external list-vsphere-network ExtNw
vcd network external list-vsphere-network ExtNw --filter networkName==*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/426)
<!-- Reviewable:end -->
