### PR TITLE
VP-1827 : [PySDK] Run firewall rule test cases as org admin

### DIFF
--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -69,7 +69,7 @@ class FirewallRule(GatewayServices):
         [value:value_type]
         :param list services: protocol to port mapping.
          e.g., [{'tcp' : {'any' : any}}]
-        :param string new_name: new name of the firewall rule.
+        :param str new_name: new name of the firewall rule.
         """
         self._get_resource()
         self.validate_types(source_values, FirewallRule.__SOURCE)

--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -69,7 +69,7 @@ class FirewallRule(GatewayServices):
         [value:value_type]
         :param list services: protocol to port mapping.
          e.g., [{'tcp' : {'any' : any}}]
-        :param String new_name: new name of the firewall rule.
+        :param string new_name: new name of the firewall rule.
         """
         self._get_resource()
         self.validate_types(source_values, FirewallRule.__SOURCE)

--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -69,6 +69,7 @@ class FirewallRule(GatewayServices):
         [value:value_type]
         :param list services: protocol to port mapping.
          e.g., [{'tcp' : {'any' : any}}]
+        :param String new_name: new name of the firewall rule.
         """
         self._get_resource()
         self.validate_types(source_values, FirewallRule.__SOURCE)
@@ -99,7 +100,7 @@ class FirewallRule(GatewayServices):
                     create_element(FirewallRule.__APPLICATION))
             self._populate_services(firewall_rule_temp, services)
 
-        if new_name is not None:
+        if new_name:
             firewall_rule_temp.name = new_name
         self.client.put_resource(self.href, firewall_rule_temp,
                                  EntityType.DEFAULT_CONTENT_TYPE.value)

--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -56,7 +56,11 @@ class FirewallRule(GatewayServices):
         self._get_resource()
         return self.client.delete_resource(self.href)
 
-    def edit(self, source_values=None, destination_values=None, services=None):
+    def edit(self,
+             source_values=None,
+             destination_values=None,
+             services=None,
+             new_name=None):
         """Edit a Firewall rule.
 
         :param list source_values: list of source values. e.g.,
@@ -95,6 +99,8 @@ class FirewallRule(GatewayServices):
                     create_element(FirewallRule.__APPLICATION))
             self._populate_services(firewall_rule_temp, services)
 
+        if new_name is not None:
+            firewall_rule_temp.name = new_name
         self.client.put_resource(self.href, firewall_rule_temp,
                                  EntityType.DEFAULT_CONTENT_TYPE.value)
 

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -148,7 +148,6 @@ class TestFirewallRules(BaseTestCase):
                 'any': 'any'
             }
         }]
-        name = firewall_obj._get_resource().name
         new_name = 'Rule_New_Name_Test'
         firewall_obj.edit(source_object, destination_object, source, new_name)
         # Verify
@@ -163,7 +162,8 @@ class TestFirewallRules(BaseTestCase):
         self.assertTrue(hasattr(firewall_res.application, 'service'))
         self.assertEqual(firewall_res.name, 'Rule_New_Name_Test')
         # revert back name change to old name
-        firewall_obj.edit(source_object, destination_object, source, name)
+        firewall_obj.edit(source_object, destination_object, source,
+                          TestFirewallRules._firewall_rule_name)
 
     def test_0041_enable_disable_firewall_rule(self):
         firewall_obj = FirewallRule(TestFirewallRules._client,

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -22,6 +22,7 @@ from pyvcloud.system_test_framework.constants.ovdc_network_constant import \
     OvdcNetConstants
 from pyvcloud.vcd.firewall_rule import FirewallRule
 from pyvcloud.vcd.gateway import Gateway
+from pyvcloud.system_test_framework.environment import CommonRoles
 
 
 class TestFirewallRules(BaseTestCase):
@@ -31,22 +32,24 @@ class TestFirewallRules(BaseTestCase):
     _firewall_rule_name = 'Rule Name Test' + str(uuid1())
     _name = GatewayConstants.name
     _rule_id = None
+    _test_runner_role = CommonRoles.ORGANIZATION_ADMINISTRATOR
 
     def test_0000_setup(self):
         """Add Firewall Rules in the gateway.
 
         Invokes the add_firewall_rule of the gateway.
         """
-        TestFirewallRules._client = Environment.get_sys_admin_client()
+        TestFirewallRules._client = Environment.get_client_in_default_org(
+            TestFirewallRules._test_runner_role)
+        TestFirewallRules._system_client = Environment.get_sys_admin_client()
         TestFirewallRules._config = Environment.get_config()
-        gateway = Environment. \
-            get_test_gateway(TestFirewallRules._client)
+        gateway = Environment.get_test_gateway(TestFirewallRules._client)
         TestFirewallRules._gateway_obj = Gateway(
             TestFirewallRules._client,
             TestFirewallRules._name,
             href=gateway.get('href'))
-        TestFirewallRules._external_network = \
-            Environment.get_test_external_network(TestFirewallRules._client)
+        TestFirewallRules._external_network = Environment. \
+            get_test_external_network(TestFirewallRules._system_client)
 
         TestFirewallRules._gateway_obj.add_firewall_rule(
             TestFirewallRules._firewall_rule_name)

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -148,6 +148,7 @@ class TestFirewallRules(BaseTestCase):
                 'any': 'any'
             }
         }]
+        name = firewall_obj._get_resource().name
         new_name = 'Rule_New_Name_Test'
         firewall_obj.edit(source_object, destination_object, source, new_name)
         # Verify
@@ -161,6 +162,8 @@ class TestFirewallRules(BaseTestCase):
         self.assertTrue(hasattr(firewall_res.destination, 'ipAddress'))
         self.assertTrue(hasattr(firewall_res.application, 'service'))
         self.assertEqual(firewall_res.name, 'Rule_New_Name_Test')
+        # revert back name change to old name
+        firewall_obj.edit(source_object, destination_object, source, name)
 
     def test_0041_enable_disable_firewall_rule(self):
         firewall_obj = FirewallRule(TestFirewallRules._client,

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -148,7 +148,8 @@ class TestFirewallRules(BaseTestCase):
                 'any': 'any'
             }
         }]
-        firewall_obj.edit(source_object, destination_object, source)
+        new_name = 'Rule_New_Name_Test'
+        firewall_obj.edit(source_object, destination_object, source, new_name)
         # Verify
         firewall_obj._reload()
         firewall_res = firewall_obj.resource
@@ -159,6 +160,7 @@ class TestFirewallRules(BaseTestCase):
         self.assertTrue(hasattr(firewall_res.destination, 'groupingObjectId'))
         self.assertTrue(hasattr(firewall_res.destination, 'ipAddress'))
         self.assertTrue(hasattr(firewall_res.application, 'service'))
+        self.assertEqual(firewall_res.name, 'Rule_New_Name_Test')
 
     def test_0041_enable_disable_firewall_rule(self):
         firewall_obj = FirewallRule(TestFirewallRules._client,

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -39,13 +39,13 @@ class TestFirewallRules(BaseTestCase):
 
         Invokes the add_firewall_rule of the gateway.
         """
-        TestFirewallRules._client = Environment.get_client_in_default_org(
+        TestFirewallRules._org_client = Environment.get_client_in_default_org(
             TestFirewallRules._test_runner_role)
         TestFirewallRules._system_client = Environment.get_sys_admin_client()
         TestFirewallRules._config = Environment.get_config()
-        gateway = Environment.get_test_gateway(TestFirewallRules._client)
+        gateway = Environment.get_test_gateway(TestFirewallRules._org_client)
         TestFirewallRules._gateway_obj = Gateway(
-            TestFirewallRules._client,
+            TestFirewallRules._org_client,
             TestFirewallRules._name,
             href=gateway.get('href'))
         TestFirewallRules._external_network = Environment. \
@@ -72,9 +72,9 @@ class TestFirewallRules(BaseTestCase):
         """
         TestFirewallRules._config = Environment.get_config()
         gateway = Environment. \
-            get_test_gateway(TestFirewallRules._client)
+            get_test_gateway(TestFirewallRules._org_client)
         gateway_obj = Gateway(
-            TestFirewallRules._client,
+            TestFirewallRules._org_client,
             TestFirewallRules._name,
             href=gateway.get('href'))
         firewall_rules_list = gateway_obj.get_firewall_rules_list()
@@ -83,7 +83,7 @@ class TestFirewallRules(BaseTestCase):
 
     def test_0010_get_created_firewall_rule(self):
         """Get the Firewall Rule created in setup."""
-        firewall_obj = FirewallRule(TestFirewallRules._client,
+        firewall_obj = FirewallRule(TestFirewallRules._org_client,
                                     TestFirewallRules._name,
                                     TestFirewallRules._rule_id)
         firewall_res = firewall_obj._get_resource()
@@ -126,7 +126,7 @@ class TestFirewallRules(BaseTestCase):
             self.assertTrue(len(object_res) > 0)
 
     def test_0050_edit(self):
-        firewall_obj = FirewallRule(TestFirewallRules._client,
+        firewall_obj = FirewallRule(TestFirewallRules._org_client,
                                     TestFirewallRules._name,
                                     TestFirewallRules._rule_id)
         ext_net_resource = TestFirewallRules._external_network.get_resource()
@@ -169,7 +169,7 @@ class TestFirewallRules(BaseTestCase):
                           TestFirewallRules._firewall_rule_name)
 
     def test_0041_enable_disable_firewall_rule(self):
-        firewall_obj = FirewallRule(TestFirewallRules._client,
+        firewall_obj = FirewallRule(TestFirewallRules._org_client,
                                     TestFirewallRules._name,
                                     TestFirewallRules._rule_id)
         result = firewall_obj.enable_disable_firewall_rule(False)
@@ -178,7 +178,7 @@ class TestFirewallRules(BaseTestCase):
         self.assertIsNone(result)
 
     def test_0061_info_firewall_rule(self):
-        firewall_obj = FirewallRule(TestFirewallRules._client,
+        firewall_obj = FirewallRule(TestFirewallRules._org_client,
                                     TestFirewallRules._name,
                                     TestFirewallRules._rule_id)
         firewall_rule_info = firewall_obj.info_firewall_rule()
@@ -187,7 +187,7 @@ class TestFirewallRules(BaseTestCase):
         self.assertEqual(firewall_rule_info['Id'], TestFirewallRules._rule_id)
 
     def test_0098_teardown(self):
-        firewall_obj = FirewallRule(TestFirewallRules._client,
+        firewall_obj = FirewallRule(TestFirewallRules._org_client,
                                     TestFirewallRules._name,
                                     TestFirewallRules._rule_id)
         firewall_obj.delete()
@@ -205,7 +205,7 @@ class TestFirewallRules(BaseTestCase):
 
     def test_0099_cleanup(self):
         """Release all resources held by this object for testing purposes."""
-        TestFirewallRules._client.logout()
+        TestFirewallRules._org_client.logout()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
VP-1827 : [PySDK] Run firewall rule test cases as org admin.

Enhance the feature to run as org admin firewall_rule_tests.py is modified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/429)
<!-- Reviewable:end -->
