### PR TITLE
Jenkin'e test failure

### DIFF
--- a/system_tests/extnet_tests.py
+++ b/system_tests/extnet_tests.py
@@ -16,7 +16,7 @@
 import unittest
 from uuid import uuid1
 
-from system_tests.helpers.portgroup_helper import PortgroupHelper
+from helpers.portgroup_helper import PortgroupHelper
 from pyvcloud.system_test_framework.base_test import BaseTestCase
 from pyvcloud.system_test_framework.environment import developerModeAware
 from pyvcloud.system_test_framework.environment import Environment

--- a/system_tests/vdc_tests.py
+++ b/system_tests/vdc_tests.py
@@ -124,9 +124,8 @@ class TestOrgVDC(BaseTestCase):
         """
         org = Environment.get_test_org(TestOrgVDC._client)
         try:
-            org.get_vdc(TestOrgVDC._non_existent_vdc_name)
-            self.fail('Should not be able to fetch vdc ' +
-                      TestOrgVDC._non_existent_vdc_name)
+            resource = org.get_vdc(TestOrgVDC._non_existent_vdc_name)
+            self.assertIsNone(resource)
         except EntityNotFoundException as e:
             pass
 


### PR DESCRIPTION
Extnet_tests were failing with ModuleNotFound Error.

  https://sp-taas-vcd-butler.svc.eng.vmware.com/job/Preflight-pysdk-1.0-STF/55/console

Removed the system_tests suffix.

It also included the fix for getVdc for not available vdc

Testing Done: Executed the external tests successfully.

@guptaankit52 @kousgy123

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/436)
<!-- Reviewable:end -->
