### PR TITLE
VP-1544 : [PySDK] Change the sequence of the firewall rules

### DIFF
--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -304,7 +304,7 @@ class FirewallRule(GatewayServices):
         return self.network_url + FIREWALL_URL_TEMPLATE
 
     def update_firewall_rule_sequence(self, index):
-        """Change firewall rule's sequence from gateway.
+        """Change firewall rule's sequence of gateway.
 
         :param int index: new sequence index of firewall rule.
         """

--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -306,7 +306,7 @@ class FirewallRule(GatewayServices):
     def update_firewall_rule_sequence(self, index):
         """Change firewall rule's sequence from gateway.
 
-        :param int index: new sequance index of firewall rule.
+        :param int index: new sequence index of firewall rule.
         """
         index = int(index)
         gateway_res = Gateway(self.client, resource=self.parent)

--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -303,7 +303,7 @@ class FirewallRule(GatewayServices):
     def _build_firewall_rules_href(self):
         return self.network_url + FIREWALL_URL_TEMPLATE
 
-    def update_firewall_rule_sequance(self, index):
+    def update_firewall_rule_sequence(self, index):
         """Change firewall rule's sequence from gateway.
 
         :param int index: new sequance index of firewall rule.

--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -303,35 +303,20 @@ class FirewallRule(GatewayServices):
     def _build_firewall_rules_href(self):
         return self.network_url + FIREWALL_URL_TEMPLATE
 
-    def update_firewall_rule_sequance(self, is_up):
+    def update_firewall_rule_sequance(self, index):
         """Change firewall rule's sequence from gateway.
 
-        :param bool is_up: flag to up/down the firewall rule.
+        :param int index: new sequance index of firewall rule.
         """
+        index = int(index)
         gateway_res = Gateway(self.client, resource=self.parent)
         firewall_rule = gateway_res.get_firewall_rules()
         resource = self._get_resource()
-        change_required = False
         for rule in firewall_rule.firewallRules.firewallRule:
             if rule.id == resource.id:
-                previous = rule.getprevious()
-                next = rule.getnext()
-                if is_up and previous is not None:
-                    if previous.ruleType == 'user':
-                        index = firewall_rule.firewallRules.index(rule)
-                        firewall_rule.firewallRules.remove(rule)
-                        firewall_rule.firewallRules.insert(index - 1, rule)
-                        change_required = True
-                elif not is_up and next is not None:
-                    if next.ruleType == 'user':
-                        index = firewall_rule.firewallRules.index(rule)
-                        firewall_rule.firewallRules.remove(rule)
-                        firewall_rule.firewallRules.insert(index + 1, rule)
-                        change_required = True
+                firewall_rule.firewallRules.remove(rule)
+                firewall_rule.firewallRules.insert(index, rule)
                 break
-        if change_required:
-            return self.client.put_resource(
-                self._build_firewall_rules_href(), firewall_rule,
-                EntityType.DEFAULT_CONTENT_TYPE.value)
-        else:
-            return
+        return self.client.put_resource(self._build_firewall_rules_href(),
+                                        firewall_rule,
+                                        EntityType.DEFAULT_CONTENT_TYPE.value)

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -196,13 +196,11 @@ class TestFirewallRules(BaseTestCase):
         self.assertTrue('ipAddress' in result)
         self.assertTrue('exclude' in result)
 
-    def test_0091_update_firewall_rule_sequance(self):
+    def test_0091_update_firewall_rule_sequence(self):
         firewall_obj = FirewallRule(TestFirewallRules._org_client,
                                     TestFirewallRules._name,
                                     TestFirewallRules._rule_id)
-        result = firewall_obj.update_firewall_rule_sequance(True)
-        self.assertIsNone(result)
-        result = firewall_obj.update_firewall_rule_sequance(False)
+        result = firewall_obj.update_firewall_rule_sequence(1)
         self.assertIsNone(result)
 
     def test_0098_teardown(self):

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -196,6 +196,15 @@ class TestFirewallRules(BaseTestCase):
         self.assertTrue('ipAddress' in result)
         self.assertTrue('exclude' in result)
 
+    def test_0091_update_firewall_rule_sequance(self):
+        firewall_obj = FirewallRule(TestFirewallRules._org_client,
+                                    TestFirewallRules._name,
+                                    TestFirewallRules._rule_id)
+        result = firewall_obj.update_firewall_rule_sequance(True)
+        self.assertIsNone(result)
+        result = firewall_obj.update_firewall_rule_sequance(False)
+        self.assertIsNone(result)
+
     def test_0098_teardown(self):
         firewall_obj = FirewallRule(TestFirewallRules._org_client,
                                     TestFirewallRules._name,

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -201,12 +201,10 @@ class TestFirewallRules(BaseTestCase):
         firewall_rules_resource = \
             TestFirewallRules._gateway_obj.get_firewall_rules()
         rule_id = None
-        sequence_no_before = 0
         for firewallRule in firewall_rules_resource.firewallRules.firewallRule:
             if firewallRule['name'] == 'Test2':
                 rule_id = firewallRule.id
                 break
-            sequence_no_before += 1
 
         firewall_obj = FirewallRule(TestFirewallRules._org_client,
                                     TestFirewallRules._name, rule_id)

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -210,7 +210,8 @@ class TestFirewallRules(BaseTestCase):
 
         firewall_obj = FirewallRule(TestFirewallRules._org_client,
                                     TestFirewallRules._name, rule_id)
-        firewall_obj.update_firewall_rule_sequence(1)
+        new_index = 1
+        firewall_obj.update_firewall_rule_sequence(new_index)
         sequence_no_after = 0
         firewall_rules_resource = \
             TestFirewallRules._gateway_obj.get_firewall_rules()
@@ -218,7 +219,7 @@ class TestFirewallRules(BaseTestCase):
             if firewallRule['name'] == 'Test2':
                 break
             sequence_no_after += 1
-        self.assertEqual(sequence_no_after, 1)
+        self.assertEqual(sequence_no_after, new_index)
         firewall_obj.delete()
 
     def test_0098_teardown(self):

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -197,11 +197,29 @@ class TestFirewallRules(BaseTestCase):
         self.assertTrue('exclude' in result)
 
     def test_0091_update_firewall_rule_sequence(self):
+        TestFirewallRules._gateway_obj.add_firewall_rule('Test2')
+        firewall_rules_resource = \
+            TestFirewallRules._gateway_obj.get_firewall_rules()
+        rule_id = None
+        sequence_no_before = 0
+        for firewallRule in firewall_rules_resource.firewallRules.firewallRule:
+            if firewallRule['name'] == 'Test2':
+                rule_id = firewallRule.id
+                break
+            sequence_no_before += 1
+
         firewall_obj = FirewallRule(TestFirewallRules._org_client,
-                                    TestFirewallRules._name,
-                                    TestFirewallRules._rule_id)
-        result = firewall_obj.update_firewall_rule_sequence(1)
-        self.assertIsNone(result)
+                                    TestFirewallRules._name, rule_id)
+        firewall_obj.update_firewall_rule_sequence(1)
+        sequence_no_after = 0
+        firewall_rules_resource = \
+            TestFirewallRules._gateway_obj.get_firewall_rules()
+        for firewallRule in firewall_rules_resource.firewallRules.firewallRule:
+            if firewallRule['name'] == 'Test2':
+                break
+            sequence_no_after += 1
+        self.assertEqual(sequence_no_after, 1)
+        firewall_obj.delete()
 
     def test_0098_teardown(self):
         firewall_obj = FirewallRule(TestFirewallRules._org_client,

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -30,6 +30,7 @@ class TestFirewallRules(BaseTestCase):
     # All tests in this module should be run as System Administrator.
     # Firewall Rule
     _firewall_rule_name = 'Rule Name Test' + str(uuid1())
+    _firewall_rule_name2 = 'Rule Name Test2' + str(uuid1())
     _name = GatewayConstants.name
     _rule_id = None
     _test_runner_role = CommonRoles.ORGANIZATION_ADMINISTRATOR
@@ -197,12 +198,13 @@ class TestFirewallRules(BaseTestCase):
         self.assertTrue('exclude' in result)
 
     def test_0091_update_firewall_rule_sequence(self):
-        TestFirewallRules._gateway_obj.add_firewall_rule('Test2')
+        TestFirewallRules._gateway_obj.add_firewall_rule(
+            TestFirewallRules._firewall_rule_name2)
         firewall_rules_resource = \
             TestFirewallRules._gateway_obj.get_firewall_rules()
         rule_id = None
         for firewallRule in firewall_rules_resource.firewallRules.firewallRule:
-            if firewallRule['name'] == 'Test2':
+            if firewallRule['name'] == TestFirewallRules._firewall_rule_name2:
                 rule_id = firewallRule.id
                 break
 
@@ -214,7 +216,7 @@ class TestFirewallRules(BaseTestCase):
         firewall_rules_resource = \
             TestFirewallRules._gateway_obj.get_firewall_rules()
         for firewallRule in firewall_rules_resource.firewallRules.firewallRule:
-            if firewallRule['name'] == 'Test2':
+            if firewallRule['name'] == TestFirewallRules._firewall_rule_name2:
                 break
             sequence_no_after += 1
         self.assertEqual(sequence_no_after, new_index)


### PR DESCRIPTION
VP-1544 : [PySDK] Change the sequence of the firewall rules.

Providing support to change firewall rule's sequence of rule id.

Testing Done:
Added test_0091_update_firewall_rule_sequance to firewall_rule_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/439)
<!-- Reviewable:end -->
