### PR TITLE
VP-1791 : [PySDK] delete values from Firewall Source

### DIFF
--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -324,7 +324,7 @@ class FirewallRule(GatewayServices):
     def delete_firewall_rule_source(self, source_value):
         """Delete firewall rule's source value of gateway.
 
-        It will delete all duplicate source value.
+        It will delete all source value of given source_value.
         :param str source_value: source value to remove.
         """
         resource = self._get_resource()

--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -327,8 +327,9 @@ class FirewallRule(GatewayServices):
         :param str source_value: source value to remove.
         """
         resource = self._get_resource()
-        for object in resource.source.iter():
-            if object == source_value:
-                resource.source.remove(object)
+        if hasattr(resource, 'source'):
+            for object in resource.source.iter():
+                if object == source_value:
+                    resource.source.remove(object)
         return self.client.put_resource(self.href, resource,
                                         EntityType.DEFAULT_CONTENT_TYPE.value)

--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -320,3 +320,15 @@ class FirewallRule(GatewayServices):
         return self.client.put_resource(self._build_firewall_rules_href(),
                                         firewall_rule,
                                         EntityType.DEFAULT_CONTENT_TYPE.value)
+
+    def delete_firewall_rule_source(self, source_value):
+        """Delete firewall rule's source value of gateway.
+
+        :param str source_value: source value to remove.
+        """
+        resource = self._get_resource()
+        for object in resource.source.iter():
+            if object == source_value:
+                resource.source.remove(object)
+        return self.client.put_resource(self.href, resource,
+                                        EntityType.DEFAULT_CONTENT_TYPE.value)

--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -324,6 +324,7 @@ class FirewallRule(GatewayServices):
     def delete_firewall_rule_source(self, source_value):
         """Delete firewall rule's source value of gateway.
 
+        It will delete all duplicate source value.
         :param str source_value: source value to remove.
         """
         resource = self._get_resource()

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -187,22 +187,6 @@ class TestFirewallRules(BaseTestCase):
         self.assertTrue(len(firewall_rule_info) > 0)
         self.assertEqual(firewall_rule_info['Id'], TestFirewallRules._rule_id)
 
-    def test_0071_delete_firewall_rule_source(self):
-        object_to_delete = 'vnic-0'
-        firewall_obj = FirewallRule(TestFirewallRules._org_client,
-                                    TestFirewallRules._name,
-                                    TestFirewallRules._rule_id)
-        # deleting of object
-        firewall_obj.delete_firewall_rule_source(object_to_delete)
-        list_of_source = firewall_obj.list_firewall_rule_source()
-        if 'vnicGroupId' in list_of_source:
-            self.assertTrue(
-                object_to_delete not in list_of_source['vnicGroupId'])
-        # creating source
-        ext_net_resource = TestFirewallRules._external_network.get_resource()
-        source_object = [ext_net_resource.get('name') + ':gatewayinterface']
-        firewall_obj.edit(source_object, None, None, None)
-
     def test_0081_list_firewall_rule_source(self):
         firewall_obj = FirewallRule(TestFirewallRules._org_client,
                                     TestFirewallRules._name,
@@ -237,6 +221,18 @@ class TestFirewallRules(BaseTestCase):
             sequence_no_after += 1
         self.assertEqual(sequence_no_after, new_index)
         firewall_obj.delete()
+
+    def test_0095_delete_firewall_rule_source(self):
+        object_to_delete = 'vnic-0'
+        firewall_obj = FirewallRule(TestFirewallRules._org_client,
+                                    TestFirewallRules._name,
+                                    TestFirewallRules._rule_id)
+        # deleting of object
+        firewall_obj.delete_firewall_rule_source(object_to_delete)
+        list_of_source = firewall_obj.list_firewall_rule_source()
+        if 'vnicGroupId' in list_of_source:
+            self.assertTrue(
+                object_to_delete not in list_of_source['vnicGroupId'])
 
     def test_0098_teardown(self):
         firewall_obj = FirewallRule(TestFirewallRules._org_client,

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -187,6 +187,20 @@ class TestFirewallRules(BaseTestCase):
         self.assertTrue(len(firewall_rule_info) > 0)
         self.assertEqual(firewall_rule_info['Id'], TestFirewallRules._rule_id)
 
+    def test_0071_delete_firewall_rule_source(self):
+        object_to_delete = 'vnic-0'
+        firewall_obj = FirewallRule(TestFirewallRules._org_client,
+                                    TestFirewallRules._name,
+                                    TestFirewallRules._rule_id)
+        # deleting of object
+        firewall_obj.delete_firewall_rule_source(object_to_delete)
+        list_of_source = firewall_obj.list_firewall_rule_source()
+        self.assertTrue('vnicGroupId' not in list_of_source)
+        # creating source
+        ext_net_resource = TestFirewallRules._external_network.get_resource()
+        source_object = [ext_net_resource.get('name') + ':gatewayinterface']
+        firewall_obj.edit(source_object, None, None, None)
+
     def test_0081_list_firewall_rule_source(self):
         firewall_obj = FirewallRule(TestFirewallRules._org_client,
                                     TestFirewallRules._name,

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -195,7 +195,9 @@ class TestFirewallRules(BaseTestCase):
         # deleting of object
         firewall_obj.delete_firewall_rule_source(object_to_delete)
         list_of_source = firewall_obj.list_firewall_rule_source()
-        self.assertTrue('vnicGroupId' not in list_of_source)
+        if 'vnicGroupId' in list_of_source:
+            self.assertTrue(
+                object_to_delete not in list_of_source['vnicGroupId'])
         # creating source
         ext_net_resource = TestFirewallRules._external_network.get_resource()
         source_object = [ext_net_resource.get('name') + ':gatewayinterface']


### PR DESCRIPTION
VP-1791 : [PySDK] delete values from Firewall Source.

Providing support to delete firewall rule's source value of rule id.

Testing Done:
Added test_0071_delete_firewall_rule_source to firewall_rule_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/441)
<!-- Reviewable:end -->
