### PR TITLE
VP-1840 : [PySDK] List Firewall Destination

### DIFF
--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -268,10 +268,11 @@ class FirewallRule(GatewayServices):
         firewall_rule_info['Action'] = resource.action
         return firewall_rule_info
 
-    def list_firewall_rule_source(self):
-        """Get the list of firewall rule source.
+    def list_firewall_rule_source_destination(self, type):
+        """Get the list of firewall rule source/destination.
 
-        return: dict of firewall rule's source details.
+        :param str type: It can be source/destination
+        return: dict of firewall rule's source/destination details.
         e.g.
         {'exclude':'True','ipAddress':['10.112.12.12','10.232.1.2'],
         'vnicGroupId':['vse','external','internal','vnic-0'],
@@ -281,24 +282,25 @@ class FirewallRule(GatewayServices):
         :rtype: dict
         """
         resource = self._get_resource()
-        firewall_rule_source = {}
-        if hasattr(resource, 'source'):
-            if hasattr(resource.source, 'exclude'):
-                firewall_rule_source['exclude'] = resource.source.exclude
-            if hasattr(resource.source, 'vnicGroupId'):
-                firewall_rule_source['vnicGroupId'] = [
-                    vnicGroupId for vnicGroupId in resource.source.vnicGroupId
+        firewall_rule_source_destination = {}
+        if hasattr(resource, type):
+            if hasattr(resource[type], 'exclude'):
+                firewall_rule_source_destination['exclude'] = resource[
+                    type].exclude
+            if hasattr(resource[type], 'vnicGroupId'):
+                firewall_rule_source_destination['vnicGroupId'] = [
+                    vnicGroupId for vnicGroupId in resource[type].vnicGroupId
                 ]
-            if hasattr(resource.source, 'ipAddress'):
-                firewall_rule_source['ipAddress'] = [
-                    ipAddress for ipAddress in resource.source.ipAddress
+            if hasattr(resource[type], 'ipAddress'):
+                firewall_rule_source_destination['ipAddress'] = [
+                    ipAddress for ipAddress in resource[type].ipAddress
                 ]
-            if hasattr(resource.source, 'groupingObjectId'):
-                firewall_rule_source['groupingObjectId'] = [
+            if hasattr(resource[type], 'groupingObjectId'):
+                firewall_rule_source_destination['groupingObjectId'] = [
                     groupingObjectId
-                    for groupingObjectId in resource.source.groupingObjectId
+                    for groupingObjectId in resource[type].groupingObjectId
                 ]
-        return firewall_rule_source
+        return firewall_rule_source_destination
 
     def _build_firewall_rules_href(self):
         return self.network_url + FIREWALL_URL_TEMPLATE
@@ -334,37 +336,3 @@ class FirewallRule(GatewayServices):
                     resource.source.remove(object)
         return self.client.put_resource(self.href, resource,
                                         EntityType.DEFAULT_CONTENT_TYPE.value)
-
-    def list_firewall_rule_destination(self):
-        """Get the list of firewall rule destination.
-
-        return: dict of firewall rule's destination details.
-        e.g.
-        {'exclude':'True','ipAddress':['10.112.12.12','10.232.1.2'],
-        'vnicGroupId':['vse','external','internal','vnic-0'],
-        'groupingObjectId':['1f0aab71-6d11-4567-994e-2c090fea7350:ipset',
-        'urn:vcloud:network:3ed60402-904f-410d-913c-6da77b43a257:']
-        }
-        :rtype: dict
-        """
-        resource = self._get_resource()
-        firewall_rule_destination = {}
-        if hasattr(resource, 'destination'):
-            if hasattr(resource.destination, 'exclude'):
-                firewall_rule_destination[
-                    'exclude'] = resource.destination.exclude
-            if hasattr(resource.destination, 'vnicGroupId'):
-                firewall_rule_destination['vnicGroupId'] = [
-                    vnicGroupId
-                    for vnicGroupId in resource.destination.vnicGroupId
-                ]
-            if hasattr(resource.destination, 'ipAddress'):
-                firewall_rule_destination['ipAddress'] = [
-                    ipAddress for ipAddress in resource.destination.ipAddress
-                ]
-            if hasattr(resource.destination, 'groupingObjectId'):
-                firewall_rule_destination['groupingObjectId'] = [
-                    groupingObjectId for groupingObjectId in resource.
-                    destination.groupingObjectId
-                ]
-        return firewall_rule_destination

--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -334,3 +334,37 @@ class FirewallRule(GatewayServices):
                     resource.source.remove(object)
         return self.client.put_resource(self.href, resource,
                                         EntityType.DEFAULT_CONTENT_TYPE.value)
+
+    def list_firewall_rule_destination(self):
+        """Get the list of firewall rule destination.
+
+        return: dict of firewall rule's destination details.
+        e.g.
+        {'exclude':'True','ipAddress':['10.112.12.12','10.232.1.2'],
+        'vnicGroupId':['vse','external','internal','vnic-0'],
+        'groupingObjectId':['1f0aab71-6d11-4567-994e-2c090fea7350:ipset',
+        'urn:vcloud:network:3ed60402-904f-410d-913c-6da77b43a257:']
+        }
+        :rtype: dict
+        """
+        resource = self._get_resource()
+        firewall_rule_destination = {}
+        if hasattr(resource, 'destination'):
+            if hasattr(resource.destination, 'exclude'):
+                firewall_rule_destination[
+                    'exclude'] = resource.destination.exclude
+            if hasattr(resource.destination, 'vnicGroupId'):
+                firewall_rule_destination['vnicGroupId'] = [
+                    vnicGroupId
+                    for vnicGroupId in resource.destination.vnicGroupId
+                ]
+            if hasattr(resource.destination, 'ipAddress'):
+                firewall_rule_destination['ipAddress'] = [
+                    ipAddress for ipAddress in resource.destination.ipAddress
+                ]
+            if hasattr(resource.destination, 'groupingObjectId'):
+                firewall_rule_destination['groupingObjectId'] = [
+                    groupingObjectId for groupingObjectId in resource.
+                    destination.groupingObjectId
+                ]
+        return firewall_rule_destination

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -197,6 +197,16 @@ class TestFirewallRules(BaseTestCase):
         self.assertTrue('ipAddress' in result)
         self.assertTrue('exclude' in result)
 
+    def test_0082_list_firewall_rule_destination(self):
+        firewall_obj = FirewallRule(TestFirewallRules._org_client,
+                                    TestFirewallRules._name,
+                                    TestFirewallRules._rule_id)
+        result = firewall_obj.list_firewall_rule_destination()
+        self.assertTrue('vnicGroupId' in result)
+        self.assertTrue('groupingObjectId' in result)
+        self.assertTrue('ipAddress' in result)
+        self.assertTrue('exclude' in result)
+
     def test_0091_update_firewall_rule_sequence(self):
         TestFirewallRules._gateway_obj.add_firewall_rule(
             TestFirewallRules._firewall_rule_name2)

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -191,7 +191,7 @@ class TestFirewallRules(BaseTestCase):
         firewall_obj = FirewallRule(TestFirewallRules._org_client,
                                     TestFirewallRules._name,
                                     TestFirewallRules._rule_id)
-        result = firewall_obj.list_firewall_rule_source()
+        result = firewall_obj.list_firewall_rule_source_destination('source')
         self.assertTrue('vnicGroupId' in result)
         self.assertTrue('groupingObjectId' in result)
         self.assertTrue('ipAddress' in result)
@@ -201,7 +201,8 @@ class TestFirewallRules(BaseTestCase):
         firewall_obj = FirewallRule(TestFirewallRules._org_client,
                                     TestFirewallRules._name,
                                     TestFirewallRules._rule_id)
-        result = firewall_obj.list_firewall_rule_destination()
+        result = firewall_obj.list_firewall_rule_source_destination(
+            'destination')
         self.assertTrue('vnicGroupId' in result)
         self.assertTrue('groupingObjectId' in result)
         self.assertTrue('ipAddress' in result)
@@ -239,7 +240,8 @@ class TestFirewallRules(BaseTestCase):
                                     TestFirewallRules._rule_id)
         # deleting of object
         firewall_obj.delete_firewall_rule_source(object_to_delete)
-        list_of_source = firewall_obj.list_firewall_rule_source()
+        list_of_source = firewall_obj.list_firewall_rule_source_destination(
+            'source')
         if 'vnicGroupId' in list_of_source:
             self.assertTrue(
                 object_to_delete not in list_of_source['vnicGroupId'])


### PR DESCRIPTION
VP-1840 : [PySDK] List Firewall Destination.

Providing support to list firewall rule's destination of rule id.

Testing Done:
Added test_0082_list_firewall_rule_destination to firewall_rule_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/445)
<!-- Reviewable:end -->
