### PR TITLE
VP-1793 : [PySDK] delete values from Firewall Destination

### DIFF
--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -323,16 +323,17 @@ class FirewallRule(GatewayServices):
                                         firewall_rule,
                                         EntityType.DEFAULT_CONTENT_TYPE.value)
 
-    def delete_firewall_rule_source(self, source_value):
-        """Delete firewall rule's source value of gateway.
+    def delete_firewall_rule_source_destination(self, value, type):
+        """Delete firewall rule's source/destination value of gateway.
 
-        It will delete all source value of given source_value.
-        :param str source_value: source value to remove.
+        It will delete all source/destination value of given value.
+        :param str value: value to remove from source/destination.
+        :param str type: It can be source/destination
         """
         resource = self._get_resource()
-        if hasattr(resource, 'source'):
-            for object in resource.source.iter():
-                if object == source_value:
-                    resource.source.remove(object)
+        if hasattr(resource, type):
+            for object in resource[type].iter():
+                if object == value:
+                    resource[type].remove(object)
         return self.client.put_resource(self.href, resource,
                                         EntityType.DEFAULT_CONTENT_TYPE.value)

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -239,12 +239,28 @@ class TestFirewallRules(BaseTestCase):
                                     TestFirewallRules._name,
                                     TestFirewallRules._rule_id)
         # deleting of object
-        firewall_obj.delete_firewall_rule_source(object_to_delete)
-        list_of_source = firewall_obj.list_firewall_rule_source_destination(
+        firewall_obj.delete_firewall_rule_source_destination(
+            object_to_delete, 'source')
+        list_of_values = firewall_obj.list_firewall_rule_source_destination(
             'source')
-        if 'vnicGroupId' in list_of_source:
+        if 'vnicGroupId' in list_of_values:
             self.assertTrue(
-                object_to_delete not in list_of_source['vnicGroupId'])
+                object_to_delete not in list_of_values['vnicGroupId'])
+
+    def test_0096_delete_firewall_rule_destination(self):
+        object_to_delete = 'vnic-0'
+        firewall_obj = FirewallRule(TestFirewallRules._org_client,
+                                    TestFirewallRules._name,
+                                    TestFirewallRules._rule_id)
+        # deleting of object
+        firewall_obj.delete_firewall_rule_source_destination(
+            object_to_delete, 'destination')
+        list_of_values = \
+            firewall_obj.list_firewall_rule_source_destination(
+                'destination')
+        if 'vnicGroupId' in list_of_values:
+            self.assertTrue(
+                object_to_delete not in list_of_values['vnicGroupId'])
 
     def test_0098_teardown(self):
         firewall_obj = FirewallRule(TestFirewallRules._org_client,


### PR DESCRIPTION
VP-1793 : [PySDK] delete values from Firewall Destination.

Providing support to delete firewall rule's destination value of rule id.

Testing Done:
Added test_0096_delete_firewall_rule_destination to firewall_rule_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/447)
<!-- Reviewable:end -->
