### PR TITLE
VP-1394, VP-1397: add reset and delete vapp network functions.

### DIFF
--- a/pyvcloud/system_test_framework/utils.py
+++ b/pyvcloud/system_test_framework/utils.py
@@ -28,9 +28,8 @@ def create_empty_vapp(client, vdc, name, description):
 
     :rtype: str
     """
-    vapp_sparse_resouce = vdc.create_vapp(name=name,
-                                          description=description,
-                                          accept_all_eulas=True)
+    vapp_sparse_resouce = vdc.create_vapp(
+        name=name, description=description, accept_all_eulas=True)
 
     client.get_task_monitor().wait_for_success(
         vapp_sparse_resouce.Tasks.Task[0])
@@ -38,7 +37,13 @@ def create_empty_vapp(client, vdc, name, description):
     return vapp_sparse_resouce.get('href')
 
 
-def create_vapp_from_template(client, vdc, name, catalog_name, template_name):
+def create_vapp_from_template(client,
+                              vdc,
+                              name,
+                              catalog_name,
+                              template_name,
+                              power_on=True,
+                              deploy=True):
     """Helper method to create a vApp from template.
 
     :param pyvcloud.vcd.client.Client client: a client that would be used
@@ -57,7 +62,9 @@ def create_vapp_from_template(client, vdc, name, catalog_name, template_name):
         name=name,
         catalog=catalog_name,
         template=template_name,
-        accept_all_eulas=True)
+        accept_all_eulas=True,
+        power_on=power_on,
+        deploy=deploy)
 
     client.get_task_monitor().wait_for_success(
         vapp_sparse_resouce.Tasks.Task[0])
@@ -65,10 +72,16 @@ def create_vapp_from_template(client, vdc, name, catalog_name, template_name):
     return vapp_sparse_resouce.get('href')
 
 
-def create_customized_vapp_from_template(client, vdc, name, catalog_name,
-                                         template_name, description=None,
-                                         memory_size=None, num_cpu=None,
-                                         disk_size=None, vm_name=None,
+def create_customized_vapp_from_template(client,
+                                         vdc,
+                                         name,
+                                         catalog_name,
+                                         template_name,
+                                         description=None,
+                                         memory_size=None,
+                                         num_cpu=None,
+                                         disk_size=None,
+                                         vm_name=None,
                                          vm_hostname=None,
                                          nw_adapter_type=None):
     """Helper method to create a customized vApp from template.
@@ -129,8 +142,8 @@ def create_independent_disk(client, vdc, name, size, description):
 
     :rtype: str
     """
-    disk_sparse = vdc.create_disk(name=name, size=size,
-                                  description=description)
+    disk_sparse = vdc.create_disk(
+        name=name, size=size, description=description)
     client.get_task_monitor().wait_for_success(disk_sparse.Tasks.Task[0])
     # clip 'urn:vcloud:disk:' from the id returned by vCD.
     return disk_sparse.get('id')[16:]

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -101,10 +101,10 @@ class ApiVersion(Enum):
 
 
 # Important! Values must be listed in ascending order.
-API_CURRENT_VERSIONS = [ApiVersion.VERSION_29.value,
-                        ApiVersion.VERSION_30.value,
-                        ApiVersion.VERSION_31.value,
-                        ApiVersion.VERSION_32.value]
+API_CURRENT_VERSIONS = [
+    ApiVersion.VERSION_29.value, ApiVersion.VERSION_30.value,
+    ApiVersion.VERSION_31.value, ApiVersion.VERSION_32.value
+]
 
 
 class EdgeGatewayType(Enum):
@@ -177,6 +177,7 @@ class RelationType(Enum):
     PUBLISH = 'publish'
     RECOMPOSE = 'recompose'
     REMOVE = 'remove'
+    REPAIR = 'repair'
     RIGHTS = 'rights'
     RESOURCE_POOL_VM_LIST = 'resourcePoolVmList'
     SNAPSHOT_CREATE = 'snapshot:create'

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1119,7 +1119,7 @@ class VApp(object):
             EntityType.NETWORK_CONFIG_SECTION.value, network_config_section)
 
     def reset_vapp_network(self, network_name):
-        """resets a vApp network.
+        """Resets a vApp network.
 
         :param str network_name: name of vApp network to be reset.
 
@@ -1138,7 +1138,7 @@ class VApp(object):
             'Can\'t find network \'%s\'' % network_name)
 
     def delete_vapp_network(self, network_name):
-        """deletes a vApp network.
+        """Deletes a vApp network.
 
         :param str network_name: name of vApp network to be deleted.
 

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1118,6 +1118,47 @@ class VApp(object):
             self.resource.NetworkConfigSection, RelationType.EDIT,
             EntityType.NETWORK_CONFIG_SECTION.value, network_config_section)
 
+    def reset_vapp_network(self, network_name):
+        """resets a vApp network.
+
+        :param str network_name: name of vApp network to be reset.
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is resetting the vApp network.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+
+        # find the required network
+        for nw in self.resource.NetworkConfigSection.NetworkConfig:
+            if nw.get("networkName") == network_name:
+                return self.client.post_linked_resource(
+                    nw, RelationType.REPAIR, None, None)
+        raise EntityNotFoundException(
+            'Can\'t find network \'%s\'' % network_name)
+
+    def delete_vapp_network(self, network_name):
+        """deletes a vApp network.
+
+        :param str network_name: name of vApp network to be deleted.
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is deleting the vApp network.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        network_config_section = deepcopy(self.resource.NetworkConfigSection)
+        # find the required network
+        for nw in network_config_section.NetworkConfig:
+            if nw.get("networkName") == network_name:
+                network_config_section.remove(nw)
+                return self.client.put_linked_resource(
+                    self.resource.NetworkConfigSection, RelationType.EDIT,
+                    EntityType.NETWORK_CONFIG_SECTION.value,
+                    network_config_section)
+        raise EntityNotFoundException(
+            'Can\'t find network \'%s\'' % network_name)
+
     def edit_name_and_description(self, name, description=None):
         """Edit name and description of the vApp.
 

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1128,7 +1128,7 @@ class VApp(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-
+        self.get_resource()
         # find the required network
         for nw in self.resource.NetworkConfigSection.NetworkConfig:
             if nw.get("networkName") == network_name:
@@ -1147,6 +1147,7 @@ class VApp(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
+        self.get_resource()
         network_config_section = deepcopy(self.resource.NetworkConfigSection)
         # find the required network
         for nw in network_config_section.NetworkConfig:

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -557,6 +557,38 @@ class TestVApp(BaseTestCase):
                 is_network_found = True
         self.assertTrue(is_network_found)
 
+    def test_0120_reset_vapp_network(self):
+        """Test the method vapp.reset_vapp_network().
+
+        This test passes if reset network is successful.
+        """
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
+
+        # make sure the vApp is powered on before resetting
+        task = vapp.undeploy()
+        TestVApp._client.get_task_monitor().wait_for_success(task=task)
+        vapp.reload()
+        task = vapp.deploy(power_on=True)
+        TestVApp._client.get_task_monitor().wait_for_success(task=task)
+        vapp.reload()
+
+        task = vapp.reset_vapp_network(TestVApp._vapp_network_name)
+        TestVApp._client.get_task_monitor().wait_for_success(task=task)
+        vapp.reload()
+
+    def test_0130_delete_vapp_network(self):
+        """Test the method vapp.delete_vapp_network().
+
+        This test passes if delete network is successful.
+        """
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
+
+        task = vapp.delete_vapp_network(TestVApp._vapp_network_name)
+        TestVApp._client.get_task_monitor().wait_for_success(task=task)
+        vapp.reload()
+
     @developerModeAware
     def test_9998_teardown(self):
         """Test the  method vdc.delete_vapp().

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -549,13 +549,15 @@ class TestVApp(BaseTestCase):
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
         # Verification
         vapp.reload()
-        vapp_resource = vapp.get_resource()
-        is_network_found = False
-        for network_config in vapp_resource.NetworkConfigSection.NetworkConfig:
-            if (network_config.get('networkName') == TestVApp.
-                    _vapp_network_name):
-                is_network_found = True
-        self.assertTrue(is_network_found)
+        self.assertTrue(
+            self._is_network_present(vapp.get_resource(),
+                                     TestVApp._vapp_network_name))
+
+    def _is_network_present(vapp, network_name):
+        for network_config in vapp.NetworkConfigSection.NetworkConfig:
+            if (network_config.get('networkName') == network_name):
+                return True
+        return False
 
     def test_0120_reset_vapp_network(self):
         """Test the method vapp.reset_vapp_network().
@@ -572,6 +574,7 @@ class TestVApp(BaseTestCase):
         task = vapp.deploy(power_on=True)
         TestVApp._client.get_task_monitor().wait_for_success(task=task)
         vapp.reload()
+        self.assertTrue(vapp.is_powered_on())
 
         task = vapp.reset_vapp_network(TestVApp._vapp_network_name)
         TestVApp._client.get_task_monitor().wait_for_success(task=task)
@@ -587,7 +590,12 @@ class TestVApp(BaseTestCase):
 
         task = vapp.delete_vapp_network(TestVApp._vapp_network_name)
         TestVApp._client.get_task_monitor().wait_for_success(task=task)
+
+        # Verification
         vapp.reload()
+        self.assertFalse(
+            self._is_network_present(vapp.get_resource(),
+                                     TestVApp._vapp_network_name))
 
     @developerModeAware
     def test_9998_teardown(self):


### PR DESCRIPTION
This CL adds reset_vapp_network and delete_vapp_network functions to vapp.
Added the following test cases to vapp: test_0120_reset_vapp_network, test_0130_delete_vapp_network

Testing done: ran all the vapp tests locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/449)
<!-- Reviewable:end -->
