### PR TITLE
VP-1845 : [PySDK] List Firewall Service

### DIFF
--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -337,3 +337,30 @@ class FirewallRule(GatewayServices):
                     resource[type].remove(object)
         return self.client.put_resource(self.href, resource,
                                         EntityType.DEFAULT_CONTENT_TYPE.value)
+
+    def list_firewall_rule_service(self):
+        """Get the list of firewall rule's services.
+
+        return: list of firewall rule's service details.
+        e.g.
+        [{'protocol': 'tcp', 'port': 200, 'sourcePort': 100},
+         {'protocol': 'udp', 'port': 400, 'sourcePort': 300},
+         {'protocol': 'icmp', 'icmpType': 'any'}]
+        :rtype: list
+        """
+        resource = self._get_resource()
+        firewall_rule_services = []
+        if hasattr(resource, 'application'):
+            if hasattr(resource.application, 'service'):
+                for service in resource.application.service:
+                    service_obj = {}
+                    if hasattr(service, 'protocol'):
+                        service_obj['Protocol'] = service.protocol
+                    if hasattr(service, 'port'):
+                        service_obj['Port'] = service.port
+                    if hasattr(service, 'sourcePort'):
+                        service_obj['Source port'] = service.sourcePort
+                    if hasattr(service, 'icmpType'):
+                        service_obj['Icmp type'] = service.icmpType
+                    firewall_rule_services.append(service_obj)
+        return firewall_rule_services

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -208,6 +208,14 @@ class TestFirewallRules(BaseTestCase):
         self.assertTrue('ipAddress' in result)
         self.assertTrue('exclude' in result)
 
+    def test_0083_list_firewall_rule_service(self):
+        firewall_obj = FirewallRule(TestFirewallRules._org_client,
+                                    TestFirewallRules._name,
+                                    TestFirewallRules._rule_id)
+        result = firewall_obj.list_firewall_rule_service()
+        self.assertTrue(len(result) > 0)
+        self.assertTrue('Protocol' in result[0])
+
     def test_0091_update_firewall_rule_sequence(self):
         TestFirewallRules._gateway_obj.add_firewall_rule(
             TestFirewallRules._firewall_rule_name2)


### PR DESCRIPTION
VP-1845 : [PySDK] List Firewall Service.

Providing support to list firewall rule's services of rule id.

Testing Done:
Added test_0083_list_firewall_rule_service to firewall_rule_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/450)
<!-- Reviewable:end -->
