### PR TITLE
VP-1795 : [PySDK] delete values from Firewall Service

### DIFF
--- a/pyvcloud/vcd/firewall_rule.py
+++ b/pyvcloud/vcd/firewall_rule.py
@@ -364,3 +364,18 @@ class FirewallRule(GatewayServices):
                         service_obj['Icmp type'] = service.icmpType
                     firewall_rule_services.append(service_obj)
         return firewall_rule_services
+
+    def delete_firewall_rule_service(self, protocol):
+        """Delete firewall rule's service from gateway.
+
+        It will delete all services of given protocol.
+        :param str protocol: protocol to remove services from application.
+        """
+        resource = self._get_resource()
+        if hasattr(resource, 'application'):
+            if hasattr(resource.application, 'service'):
+                for service in resource.application.service:
+                    if service.protocol == protocol:
+                        resource.application.remove(service)
+        return self.client.put_resource(self.href, resource,
+                                        EntityType.DEFAULT_CONTENT_TYPE.value)

--- a/system_tests/firewall_rule_tests.py
+++ b/system_tests/firewall_rule_tests.py
@@ -270,6 +270,16 @@ class TestFirewallRules(BaseTestCase):
             self.assertTrue(
                 object_to_delete not in list_of_values['vnicGroupId'])
 
+    def test_0097_delete_firewall_rule_service(self):
+        object_to_delete = 'tcp'
+        firewall_obj = FirewallRule(TestFirewallRules._org_client,
+                                    TestFirewallRules._name,
+                                    TestFirewallRules._rule_id)
+        firewall_obj.delete_firewall_rule_service(object_to_delete)
+        list_of_services = firewall_obj.list_firewall_rule_service()
+        self.assertFalse(
+            any(object_to_delete in service for service in list_of_services))
+
     def test_0098_teardown(self):
         firewall_obj = FirewallRule(TestFirewallRules._org_client,
                                     TestFirewallRules._name,


### PR DESCRIPTION
VP-1795 : [PySDK] delete values from Firewall Service.

Providing support to delete firewall rule's service of rule id.

Testing Done:
Added test_0097_delete_firewall_rule_service to firewall_rule_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/451)
<!-- Reviewable:end -->
