### PR TITLE
VP-1228: [PYSDK] TestFest bugs IPSEC Vpn

### DIFF
--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -1224,6 +1224,100 @@ class Gateway(object):
         ipsec_vpn_href = self._build_ipsec_vpn_href()
         return self.client.get_resource(ipsec_vpn_href)
 
+    def enable_activation_status_ipsec_vpn(self, is_active):
+        """Enables activation status of IPsec VPN.
+
+        :param bool is_active: flag to enable/disable activation status
+        """
+        ipsec_vpn = self.get_ipsec_vpn()
+        ipsec_vpn.enabled = is_active
+        self.client.put_resource(self._build_ipsec_vpn_href(),
+                                 ipsec_vpn,
+                                 EntityType.DEFAULT_CONTENT_TYPE.value)
+
+    def info_activation_status_ipsec_vpn(self):
+        """Info activation status.
+
+        :return: dict activation status dict
+        """
+        ipsec_vpn_activation_status = {}
+        ipsec_vpn = self.get_ipsec_vpn()
+        ipsec_vpn_activation_status["Activation Status"] = \
+            ipsec_vpn.enabled.text
+        return ipsec_vpn_activation_status
+
+    def change_shared_key_ipsec_vpn(self, shared_key):
+        """Changes shared key.
+
+        :param str shared_key: shared key.
+        """
+        ipsec_vpn = self.get_ipsec_vpn()
+        ip_sec_global = ipsec_vpn.xpath('global', namespaces=NSMAP)
+        ip_sec_global[0].psk = shared_key
+
+        self.client.put_resource(self._build_ipsec_vpn_href(),
+                                 ipsec_vpn,
+                                 EntityType.DEFAULT_CONTENT_TYPE.value)
+
+    def enable_logging_ipsec_vpn(self, is_enable):
+        """Enables logging for IPsec VPN.
+
+        :param bool is_enable: flag to enable/disable logging.
+        """
+        ipsec_vpn = self.get_ipsec_vpn()
+        ipsec_vpn.logging.enable = is_enable
+        self.client.put_resource(self._build_ipsec_vpn_href(),
+                                 ipsec_vpn,
+                                 EntityType.DEFAULT_CONTENT_TYPE.value)
+
+    def set_log_level_ipsec_vpn(self, log_level):
+        """Set log level for Ipsec VPN.
+
+        :param str log_level: log level
+        """
+        log_level_set = set(
+            ["emergency", "alert", "critical", "error", "warning",
+             "notice", "info", "debug"])
+        if log_level not in log_level_set:
+            raise EntityNotFoundException('No associated log level found.')
+
+        ipsec_vpn = self.get_ipsec_vpn()
+        ipsec_vpn.logging.logLevel = log_level
+        self.client.put_resource(self._build_ipsec_vpn_href(),
+                                 ipsec_vpn,
+                                 EntityType.DEFAULT_CONTENT_TYPE.value)
+
+    def info_logging_settings_ipsec_vpn(self):
+        """Provide info for logging settings.
+
+        :return: dict: dict of info of logging settings
+        """
+        ipsec_logging_settings = {}
+        ipsec_vpn = self.get_ipsec_vpn()
+        ipsec_logging_settings["Enable"] = \
+            ipsec_vpn.logging.enable.text
+        ipsec_logging_settings["Log Level"] = \
+            ipsec_vpn.logging.logLevel
+
+        return ipsec_logging_settings
+
+    def list_ipsec_vpn(self):
+        """List IPsec VPN of a gateway.
+
+        :return: list of all ipsec vpn.
+        """
+        out_list = []
+        ipsec_vpn = self.get_ipsec_vpn()
+        vpn_sites = ipsec_vpn.sites
+        if hasattr(vpn_sites, "site"):
+            for site in vpn_sites.site:
+                ipsec_vpn_info = {}
+                ipsec_vpn_info["Name"] = site.name
+                ipsec_vpn_info["local_ip"] = site.localIp
+                ipsec_vpn_info["peer_ip"] = site.peerIp
+                out_list.append(ipsec_vpn_info)
+        return out_list
+
     def list_firewall_object_types(self, type):
         """List firewall object types for editing of rule.
 

--- a/pyvcloud/vcd/ipsec_vpn.py
+++ b/pyvcloud/vcd/ipsec_vpn.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pyvcloud.vcd.client import EntityType
-from pyvcloud.vcd.client import NSMAP
-from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.gateway_services import GatewayServices
 from pyvcloud.vcd.network_url_constants import IPSEC_VPN_URL_TEMPLATE
 

--- a/pyvcloud/vcd/ipsec_vpn.py
+++ b/pyvcloud/vcd/ipsec_vpn.py
@@ -48,54 +48,6 @@ class IpsecVpn(GatewayServices):
     def get_ipsec_config_resource(self):
         return self.client.get_resource(self.href)
 
-    def set_log_level(self, log_level):
-        """Set log level for Ipsec VPN.
-
-        :param str log_level: log level
-        """
-        log_level_set = set(
-            ["emergency", "alert", "critical", "error", "warning",
-             "notice", "info", "debug"])
-        if log_level not in log_level_set:
-            raise EntityNotFoundException('No associated log level found.')
-
-        ipsec_vpn = self.resource
-        ipsec_vpn.logging.logLevel = log_level
-        self.client.put_resource(self.href,
-                                 ipsec_vpn,
-                                 EntityType.DEFAULT_CONTENT_TYPE.value)
-
-    def info_logging_settings(self):
-        """Provide info for logging settings.
-
-        :return: dict: dict of info of logging settings
-        """
-        ipsec_logging_settings = {}
-        ipsec_vpn = self.resource
-        ipsec_logging_settings["Enable"] = \
-            ipsec_vpn.logging.enable.text
-        ipsec_logging_settings["Log Level"] = \
-            ipsec_vpn.logging.logLevel
-
-        return ipsec_logging_settings
-
-    def list_ipsec_vpn(self):
-        """List IPsec VPN of a gateway.
-
-        :return: list of all ipsec vpn.
-        """
-        out_list = []
-        ipsec_vpn = self.resource
-        vpn_sites = ipsec_vpn.sites
-        if hasattr(vpn_sites, "site"):
-            for site in vpn_sites.site:
-                ipsec_vpn_info = {}
-                ipsec_vpn_info["Name"] = site.name
-                ipsec_vpn_info["local_ip"] = site.localIp
-                ipsec_vpn_info["peer_ip"] = site.peerIp
-                out_list.append(ipsec_vpn_info)
-        return out_list
-
     def delete_ipsec_vpn(self):
         """Delete IP sec Vpn."""
         end_points = self.end_point.split('-')
@@ -107,52 +59,6 @@ class IpsecVpn(GatewayServices):
             if site.localIp == local_ip and site.peerIp == peer_ip:
                 vpn_sites.remove(site)
 
-        self.client.put_resource(self.href,
-                                 ipsec_vpn,
-                                 EntityType.DEFAULT_CONTENT_TYPE.value)
-
-    def enable_activation_status(self, is_active):
-        """Enables activation status of IPsec VPN.
-
-        :param bool is_active: flag to enable/disable activation status
-        """
-        ipsec_vpn = self.resource
-        ipsec_vpn.enabled = is_active
-        self.client.put_resource(self.href,
-                                 ipsec_vpn,
-                                 EntityType.DEFAULT_CONTENT_TYPE.value)
-
-    def info_activation_status(self):
-        """Info activation status.
-
-        :return: dict activation status dict
-        """
-        ipsec_vpn_activation_status = {}
-        ipsec_vpn = self.resource
-        ipsec_vpn_activation_status["Activation Status"] = \
-            ipsec_vpn.enabled.text
-        return ipsec_vpn_activation_status
-
-    def change_shared_key(self, shared_key):
-        """Changes shared key.
-
-        :param str shared_key: shared key.
-        """
-        ipsec_vpn = self.resource
-        ip_sec_global = ipsec_vpn.xpath('global', namespaces=NSMAP)
-        ip_sec_global[0].psk = shared_key
-
-        self.client.put_resource(self.href,
-                                 ipsec_vpn,
-                                 EntityType.DEFAULT_CONTENT_TYPE.value)
-
-    def enable_logging(self, is_enable):
-        """Enables logging for IPsec VPN.
-
-        :param bool is_enable: flag to enable/disable logging.
-        """
-        ipsec_vpn = self.resource
-        ipsec_vpn.logging.enable = is_enable
         self.client.put_resource(self.href,
                                  ipsec_vpn,
                                  EntityType.DEFAULT_CONTENT_TYPE.value)

--- a/system_tests/ipsec_vpn_test.py
+++ b/system_tests/ipsec_vpn_test.py
@@ -70,6 +70,7 @@ class TestIpSecVpn(BaseTestCase):
         gateway = Environment.get_test_gateway(TestIpSecVpn._client)
         gateway_obj1 = Gateway(TestIpSecVpn._client, GatewayConstants.name,
                                href=gateway.get('href'))
+        TestIpSecVpn._gateway1 = gateway_obj1
         gateway_obj2 = TestIpSecVpn._gateway_obj
         TestIpSecVpn._local_ip = self.__get_ip_address(
             gateway=gateway_obj1, ext_net_name=TestIpSecVpn._ext_net_name)
@@ -107,14 +108,10 @@ class TestIpSecVpn(BaseTestCase):
 
         Invokes the enable_activation_status of the IpsecVpn.
         """
-        ipsec_vpn_obj = IpsecVpn(client=TestIpSecVpn._client,
-                                 gateway_name=TestIpSecVpn._name,
-                                 ipsec_end_point=
-                                 TestIpSecVpn._local_ip + "-" +
-                                 TestIpSecVpn._peer_ip)
-        ipsec_vpn_obj.enable_activation_status(True)
+        gateway_obj1 = TestIpSecVpn._gateway1
+        gateway_obj1.enable_activation_status_ipsec_vpn(True)
         # Verify
-        activation_status = ipsec_vpn_obj.get_ipsec_config_resource().enabled
+        activation_status = gateway_obj1.get_ipsec_vpn().enabled
         self.assertTrue(activation_status.text)
 
     def test_0025_info_activation_status(self):
@@ -122,12 +119,8 @@ class TestIpSecVpn(BaseTestCase):
 
         Invokes the info_activation_status of the IpsecVpn.
         """
-        ipsec_vpn_obj = IpsecVpn(client=TestIpSecVpn._client,
-                                 gateway_name=TestIpSecVpn._name,
-                                 ipsec_end_point=
-                                 TestIpSecVpn._local_ip + "-" +
-                                 TestIpSecVpn._peer_ip)
-        status_dict = ipsec_vpn_obj.info_activation_status()
+        gateway_obj1 = TestIpSecVpn._gateway1
+        status_dict = gateway_obj1.info_activation_status_ipsec_vpn()
         # Verify
         self.assertTrue(status_dict["Activation Status"])
 
@@ -136,14 +129,10 @@ class TestIpSecVpn(BaseTestCase):
 
         Invokes the enable_logging of the IpsecVpn.
         """
-        ipsec_vpn_obj = IpsecVpn(client=TestIpSecVpn._client,
-                                 gateway_name=TestIpSecVpn._name,
-                                 ipsec_end_point=
-                                 TestIpSecVpn._local_ip + "-" +
-                                 TestIpSecVpn._peer_ip)
-        ipsec_vpn_obj.enable_logging(True)
+        gateway_obj1 = TestIpSecVpn._gateway1
+        gateway_obj1.enable_logging_ipsec_vpn(True)
         # Verify
-        logging_status = ipsec_vpn_obj.get_ipsec_config_resource().\
+        logging_status = gateway_obj1.get_ipsec_vpn(). \
             logging.enable
         self.assertTrue(logging_status.text)
 
@@ -152,42 +141,30 @@ class TestIpSecVpn(BaseTestCase):
 
         Invokes the change_shared_key of the IpsecVpn.
         """
-        ipsec_vpn_obj = IpsecVpn(client=TestIpSecVpn._client,
-                                 gateway_name=TestIpSecVpn._name,
-                                 ipsec_end_point=
-                                 TestIpSecVpn._local_ip + "-" +
-                                 TestIpSecVpn._peer_ip)
-        ipsec_vpn_obj.change_shared_key(TestIpSecVpn._changed_psk)
-        #Verify
-        #verification not possible because values saved in encrypted form.
+        gateway_obj1 = TestIpSecVpn._gateway1
+        gateway_obj1.change_shared_key_ipsec_vpn(TestIpSecVpn._changed_psk)
+        # Verify
+        # verification not possible because values saved in encrypted form.
 
     def test_0040_set_log_level(self):
         """Set log level.
 
         Invokes the set_log_level of the IpsecVpn.
         """
-        ipsec_vpn_obj = IpsecVpn(client=TestIpSecVpn._client,
-                                 gateway_name=TestIpSecVpn._name,
-                                 ipsec_end_point=
-                                 TestIpSecVpn._local_ip + "-" +
-                                 TestIpSecVpn._peer_ip)
-        ipsec_vpn_obj.set_log_level(TestIpSecVpn._log_level)
+        gateway_obj1 = TestIpSecVpn._gateway1
+        gateway_obj1.set_log_level_ipsec_vpn(TestIpSecVpn._log_level)
         # Verify
-        log_level = ipsec_vpn_obj.get_ipsec_config_resource().\
+        log_level = gateway_obj1.get_ipsec_vpn(). \
             logging.logLevel
-        self.assertEqual(TestIpSecVpn._log_level,log_level)
+        self.assertEqual(TestIpSecVpn._log_level, log_level)
 
     def test_0045_info_logging_settings(self):
         """Info logging settings.
 
         Invokes the info_logging_settings of the IpsecVpn.
         """
-        ipsec_vpn_obj = IpsecVpn(client=TestIpSecVpn._client,
-                                 gateway_name=TestIpSecVpn._name,
-                                 ipsec_end_point=
-                                 TestIpSecVpn._local_ip + "-" +
-                                 TestIpSecVpn._peer_ip)
-        logging_dict = ipsec_vpn_obj.info_logging_settings()
+        gateway_obj1 = TestIpSecVpn._gateway1
+        logging_dict = gateway_obj1.info_logging_settings_ipsec_vpn()
         # Verify
         self.assertTrue(logging_dict["Enable"])
 
@@ -196,12 +173,8 @@ class TestIpSecVpn(BaseTestCase):
 
         Invokes the list_ipsec_vpn of the IpsecVpn.
         """
-        ipsec_vpn_obj = IpsecVpn(client=TestIpSecVpn._client,
-                                 gateway_name=TestIpSecVpn._name,
-                                 ipsec_end_point=
-                                 TestIpSecVpn._local_ip + "-" +
-                                 TestIpSecVpn._peer_ip)
-        ipsec_vpn_list = ipsec_vpn_obj.list_ipsec_vpn()
+        gateway_obj1 = TestIpSecVpn._gateway1
+        ipsec_vpn_list = gateway_obj1.list_ipsec_vpn()
         # Verify
         self.assertTrue(len(ipsec_vpn_list) > 0)
 
@@ -364,7 +337,7 @@ class TestIpSecVpn(BaseTestCase):
         TestIpSecVpn._routednet_obj = VdcNetwork(TestIpSecVpn._client,
                                                  href=TestIpSecVpn.
                                                  _routednet_href)
-        TestIpSecVpn._routednet_resource = TestIpSecVpn.\
+        TestIpSecVpn._routednet_resource = TestIpSecVpn. \
             _routednet_obj.get_resource()
 
     if __name__ == '__main__':


### PR DESCRIPTION
This CLN contains bugs reported for ipsec vpn. This fix is in pysdk.
These methods does not require id because they are at global level.
Methods moved to gateway class.Test cases also modified.
vcd gateway services ipsec_vpn
enable-activation-status -h
Usage: vcd gateway services ipsec_vpn enable-activation-status
[OPTIONS] <gateway name> <IPsec VPN id>
Options:
--enable / --disable enable/disable IPsec VPN
-h, --help Show this message and exit.

2=> IPsec VPN id should not be required.remove this.

vcd gateway services ipsec_vpn
enable-logging -h
Usage: vcd gateway services ipsec_vpn enable-logging [OPTIONS] <gateway
name>
<IPsec VPN id>

Options:
--enable / --disable enable/disable global logging of IPsec VPN
-h, --help Show this message and exit.

3=> IPsec VPN id should not be required.remove this.

vcd gateway services ipsec_vpn
info-activation-status -h
Usage: vcd gateway services ipsec_vpn info-activation-status
[OPTIONS] <gateway name> <IPsec VPN id>

Options:
-h, --help Show this message and exit.

4=> IPsec VPN id should not be required.remove this.

vcd gateway services ipsec_vpn
info-logging-settings -h
Usage: vcd gateway services ipsec_vpn info-logging-settings
[OPTIONS] <gateway name> <IPsec VPN id>

Options:
-h, --help Show this message and exit.

5=> IPsec VPN id should not be required.remove this.

Testing Done:
All test cases in ipsec_vpn_test class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/452)
<!-- Reviewable:end -->
