### PR TITLE
VP-1923 : [PySDK] Add IP range to vApp network

### DIFF
--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1189,6 +1189,32 @@ class VApp(object):
         raise EntityNotFoundException(
             'Can\'t find network \'%s\'' % network_name)
 
+    def add_ip_range(self, network_name, start_ip, end_ip):
+        """Add ip range to vApp network.
+
+        :param str network_name: name of vApp network.
+        :param str start_ip: start ip of ip range.
+        :param str end_ip: last ip of ip range.
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vApp network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        for network_config in self.resource.NetworkConfigSection.NetworkConfig:
+            if network_config.get("networkName") == network_name:
+                iprange = E.IpRange(
+                    E.StartAddress(start_ip), E.EndAddress(end_ip))
+                IpScope = network_config.Configuration.IpScopes.IpScope
+                if hasattr(IpScope, 'IpRanges'):
+                    IpScope.IpRanges.append(iprange)
+                else:
+                    IpScope.append(E.IpRanges(iprange))
+                return self.client.put_linked_resource(
+                    self.resource.NetworkConfigSection, RelationType.EDIT,
+                    EntityType.NETWORK_CONFIG_SECTION.value,
+                    self.resource.NetworkConfigSection)
+        raise EntityNotFoundException(
+            'Can\'t find network \'%s\'' % network_name)
+
     def edit_name_and_description(self, name, description=None):
         """Edit name and description of the vApp.
 

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1190,11 +1190,11 @@ class VApp(object):
             'Can\'t find network \'%s\'' % network_name)
 
     def add_ip_range(self, network_name, start_ip, end_ip):
-        """Add ip range to vApp network.
+        """Add IP range to vApp network.
 
         :param str network_name: name of vApp network.
-        :param str start_ip: start ip of ip range.
-        :param str end_ip: last ip of ip range.
+        :param str start_ip: start IP of IP range.
+        :param str end_ip: last IP of IP range.
         :return: an object containing EntityType.TASK XML data which represents
             the asynchronous task that is updating the vApp network.
         :rtype: lxml.objectify.ObjectifiedElement

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -600,6 +600,26 @@ class TestVApp(BaseTestCase):
                                         None)
         TestVApp._client.get_task_monitor().wait_for_success(task=task)
 
+    def _network_present(self, vapp, network_name):
+        for network_config in vapp.resource.NetworkConfigSection.NetworkConfig:
+            if (network_config.get('networkName') == network_name):
+                return network_config
+        return None
+
+    def test_0122_add_ip_range(self):
+        """Test the method add_ip_range().
+        """
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
+        start_ip = '10.100.12.1'
+        end_ip = '10.100.12.100'
+        task = vapp.add_ip_range(TestVApp._vapp_network_name, start_ip, end_ip)
+        TestVApp._client.get_task_monitor().wait_for_success(task=task)
+        network_conf = self._network_present(vapp, TestVApp._vapp_network_name)
+        self.assertTrue(
+            hasattr(network_conf.Configuration.IpScopes.IpScope.IpRanges,
+                    'IpRange'))
+
     def test_0130_delete_vapp_network(self):
         """Test the method vapp.delete_vapp_network().
 

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -74,6 +74,8 @@ class TestVApp(BaseTestCase):
     _vapp_network_dns2 = '8.8.8.9'
     _vapp_network_dns_suffix = 'example.com'
     _vapp_network_ip_range = '90.80.70.2-90.80.70.100'
+    _start_ip_vapp_network = '10.100.12.1'
+    _end_ip_vapp_network = '10.100.12.100'
 
     def test_0000_setup(self):
         """Setup the vApps required for the other tests in this module.
@@ -611,14 +613,17 @@ class TestVApp(BaseTestCase):
         """
         vapp = Environment.get_vapp_in_test_vdc(
             client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
-        start_ip = '10.100.12.1'
-        end_ip = '10.100.12.100'
-        task = vapp.add_ip_range(TestVApp._vapp_network_name, start_ip, end_ip)
+        task = vapp.add_ip_range(TestVApp._vapp_network_name,
+                                 TestVApp._start_ip_vapp_network,
+                                 TestVApp._end_ip_vapp_network)
         TestVApp._client.get_task_monitor().wait_for_success(task=task)
         network_conf = self._network_present(vapp, TestVApp._vapp_network_name)
-        self.assertTrue(
-            hasattr(network_conf.Configuration.IpScopes.IpScope.IpRanges,
-                    'IpRange'))
+        ip_range = network_conf.Configuration.IpScopes.IpScope.IpRanges
+        self.assertTrue(hasattr(ip_range, 'IpRange'))
+        self.assertEqual(ip_range.IpRange[1].StartAddress,
+                         TestVApp._start_ip_vapp_network)
+        self.assertEqual(ip_range.IpRange[1].EndAddress,
+                         TestVApp._end_ip_vapp_network)
 
     def test_0130_delete_vapp_network(self):
         """Test the method vapp.delete_vapp_network().


### PR DESCRIPTION
VP-1923 : [PySDK] Add IP range to vApp network.

Providing support to add IP range in vapp network.

Testing Done:
Added test_0122_add_ip_range to vapp_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/464)
<!-- Reviewable:end -->
