### PR TITLE
VP-1925 : [PySDK] Update IP range of vApp network

### DIFF
--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1243,6 +1243,7 @@ class VApp(object):
                                 RelationType.EDIT,
                                 EntityType.NETWORK_CONFIG_SECTION.value,
                                 self.resource.NetworkConfigSection)
+                break
         raise EntityNotFoundException(
             'Can\'t find ip range from \'%s\' to \'%s\'' % start_ip, end_ip)
 

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1217,7 +1217,7 @@ class VApp(object):
 
     def update_ip_range(self, network_name, start_ip, end_ip, new_start_ip,
                         new_end_ip):
-        """Update ip range to vApp network.
+        """Update IP range to vApp network.
 
         :param str network_name: name of vApp network.
         :param str start_ip: start IP of IP range.

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -608,9 +608,11 @@ class TestVApp(BaseTestCase):
                 return network_config
         return None
 
-    def test_0122_add_ip_range(self):
+    def test_0122_ip_range_operation(self):
         """Test the method add_ip_range().
         """
+        new_start_ip = '10.42.12.11'
+        new_end_ip = '10.42.12.110'
         vapp = Environment.get_vapp_in_test_vdc(
             client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
         task = vapp.add_ip_range(TestVApp._vapp_network_name,
@@ -624,14 +626,7 @@ class TestVApp(BaseTestCase):
                          TestVApp._start_ip_vapp_network)
         self.assertEqual(ip_range.IpRange[1].EndAddress,
                          TestVApp._end_ip_vapp_network)
-
-    def test_0123_update_ip_range(self):
-        """Test the method update_ip_range().
-        """
-        vapp = Environment.get_vapp_in_test_vdc(
-            client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
-        new_start_ip = '10.42.12.11'
-        new_end_ip = '10.42.12.110'
+        vapp.reload()
         task = vapp.update_ip_range(
             TestVApp._vapp_network_name, TestVApp._start_ip_vapp_network,
             TestVApp._end_ip_vapp_network, new_start_ip, new_end_ip)
@@ -641,10 +636,6 @@ class TestVApp(BaseTestCase):
         ip_range = network_conf.Configuration.IpScopes.IpScope.IpRanges
         self.assertEqual(ip_range.IpRange[0].StartAddress, new_start_ip)
         self.assertEqual(ip_range.IpRange[0].EndAddress, new_end_ip)
-        task = vapp.update_ip_range(
-            TestVApp._vapp_network_name, new_start_ip, new_end_ip,
-            TestVApp._start_ip_vapp_network, TestVApp._end_ip_vapp_network)
-        TestVApp._client.get_task_monitor().wait_for_success(task=task)
 
     def test_0130_delete_vapp_network(self):
         """Test the method vapp.delete_vapp_network().

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -625,6 +625,27 @@ class TestVApp(BaseTestCase):
         self.assertEqual(ip_range.IpRange[1].EndAddress,
                          TestVApp._end_ip_vapp_network)
 
+    def test_0123_update_ip_range(self):
+        """Test the method update_ip_range().
+        """
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
+        new_start_ip = '10.42.12.11'
+        new_end_ip = '10.42.12.110'
+        task = vapp.update_ip_range(
+            TestVApp._vapp_network_name, TestVApp._start_ip_vapp_network,
+            TestVApp._end_ip_vapp_network, new_start_ip, new_end_ip)
+        TestVApp._client.get_task_monitor().wait_for_success(task=task)
+        vapp.reload()
+        network_conf = self._network_present(vapp, TestVApp._vapp_network_name)
+        ip_range = network_conf.Configuration.IpScopes.IpScope.IpRanges
+        self.assertEqual(ip_range.IpRange[0].StartAddress, new_start_ip)
+        self.assertEqual(ip_range.IpRange[0].EndAddress, new_end_ip)
+        task = vapp.update_ip_range(
+            TestVApp._vapp_network_name, new_start_ip, new_end_ip,
+            TestVApp._start_ip_vapp_network, TestVApp._end_ip_vapp_network)
+        TestVApp._client.get_task_monitor().wait_for_success(task=task)
+
     def test_0130_delete_vapp_network(self):
         """Test the method vapp.delete_vapp_network().
 

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -76,6 +76,8 @@ class TestVApp(BaseTestCase):
     _vapp_network_ip_range = '90.80.70.2-90.80.70.100'
     _start_ip_vapp_network = '10.100.12.1'
     _end_ip_vapp_network = '10.100.12.100'
+    _new_start_ip_vapp_network = '10.42.12.11'
+    _new_end_ip_vapp_network = '10.42.12.110'
 
     def test_0000_setup(self):
         """Setup the vApps required for the other tests in this module.
@@ -611,8 +613,6 @@ class TestVApp(BaseTestCase):
     def test_0122_ip_range_operation(self):
         """Test the method add_ip_range().
         """
-        new_start_ip = '10.42.12.11'
-        new_end_ip = '10.42.12.110'
         vapp = Environment.get_vapp_in_test_vdc(
             client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
         task = vapp.add_ip_range(TestVApp._vapp_network_name,
@@ -629,13 +629,16 @@ class TestVApp(BaseTestCase):
         vapp.reload()
         task = vapp.update_ip_range(
             TestVApp._vapp_network_name, TestVApp._start_ip_vapp_network,
-            TestVApp._end_ip_vapp_network, new_start_ip, new_end_ip)
+            TestVApp._end_ip_vapp_network, TestVApp._new_start_ip_vapp_network,
+            TestVApp._new_end_ip_vapp_network)
         TestVApp._client.get_task_monitor().wait_for_success(task=task)
         vapp.reload()
         network_conf = self._network_present(vapp, TestVApp._vapp_network_name)
         ip_range = network_conf.Configuration.IpScopes.IpScope.IpRanges
-        self.assertEqual(ip_range.IpRange[0].StartAddress, new_start_ip)
-        self.assertEqual(ip_range.IpRange[0].EndAddress, new_end_ip)
+        self.assertEqual(ip_range.IpRange[0].StartAddress,
+                         TestVApp._new_start_ip_vapp_network)
+        self.assertEqual(ip_range.IpRange[0].EndAddress,
+                         TestVApp._new_end_ip_vapp_network)
 
     def test_0130_delete_vapp_network(self):
         """Test the method vapp.delete_vapp_network().


### PR DESCRIPTION
VP-1925 : [PySDK] Update IP range of vApp network.

Providing support to update IP range in vapp network.

Testing Done:
Added test_0123_add_ip_range to vapp_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/466)
<!-- Reviewable:end -->
