### PR TITLE
VP-1927 : [PySDK] Delete IP range from vApp network

### DIFF
--- a/pyvcloud/system_test_framework/depends.py
+++ b/pyvcloud/system_test_framework/depends.py
@@ -2,14 +2,14 @@ from pyvcloud.system_test_framework.environment import Environment
 
 
 def depends(*args):
-    """Decorator function to run unit test with depandancy.
+    """Decorator run a function with dependency.
 
-    :param list args: list of dependent function that return True
-        If depandancy failed Else return False.
+    The decorator either execute or skip the function on the basis of
+        dependent function.
+    It will skip the function if any of dependent function return False.
 
-    :return: a function that either executes the decorated function or skips
-        it, based on the value of a is_skip param.
-
+    :param list args: list of dependent function.
+    :return: a wrapper function that execute or skip the function.
     :rtype: function
     """
 
@@ -17,7 +17,7 @@ def depends(*args):
         def wrapped_f(self):
             is_execute_func = True
             for func in args:
-                if func(self):
+                if not func(self):
                     is_execute_func = False
                     break
             if is_execute_func:

--- a/pyvcloud/system_test_framework/depends.py
+++ b/pyvcloud/system_test_framework/depends.py
@@ -8,7 +8,7 @@ def depends(*args):
         dependent function.
     It will skip the function if any of dependent function return False.
 
-    :param list args: list of dependent function.
+    :param list args: list of dependent functions.
     :return: a wrapper function that execute or skip the function.
     :rtype: function
     """

--- a/pyvcloud/system_test_framework/depends.py
+++ b/pyvcloud/system_test_framework/depends.py
@@ -1,0 +1,32 @@
+from pyvcloud.system_test_framework.environment import Environment
+
+
+def depends(*args):
+    """Decorator function to run unit test with depandancy.
+
+    :param list args: list of dependent function that return True
+        If depandancy failed Else return False.
+
+    :return: a function that either executes the decorated function or skips
+        it, based on the value of a is_skip param.
+
+    :rtype: function
+    """
+
+    def wrap(function):
+        def wrapped_f(self):
+            is_execute_func = True
+            for func in args:
+                if func(self):
+                    is_execute_func = False
+                    break
+            if is_execute_func:
+                function(self)
+            else:
+                Environment.get_default_logger().debug(
+                    'Skipping ' + function.__name__ +
+                    ' due to depandancy failure.')
+
+        return wrapped_f
+
+    return wrap

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1247,6 +1247,33 @@ class VApp(object):
         raise EntityNotFoundException(
             'Can\'t find ip range from \'%s\' to \'%s\'' % start_ip, end_ip)
 
+    def delete_ip_range(self, network_name, start_ip, end_ip):
+        """Delete IP range to vApp network.
+
+        :param str network_name: name of vApp network.
+        :param str start_ip: start IP of IP range.
+        :param str end_ip: last IP of IP range.
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vApp network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        for network_config in self.resource.NetworkConfigSection.NetworkConfig:
+            if network_config.get("networkName") == network_name:
+                IpScope = network_config.Configuration.IpScopes.IpScope
+                if (hasattr(IpScope, 'IpRanges')):
+                    for ip_range in IpScope.IpRanges.IpRange:
+                        if ip_range.StartAddress == start_ip \
+                                and ip_range.EndAddress == end_ip:
+                            IpScope.IpRanges.remove(ip_range)
+                            return self.client.put_linked_resource(
+                                self.resource.NetworkConfigSection,
+                                RelationType.EDIT,
+                                EntityType.NETWORK_CONFIG_SECTION.value,
+                                self.resource.NetworkConfigSection)
+                break
+        raise EntityNotFoundException(
+            'Can\'t find IP range from \'%s\' to \'%s\'' % start_ip, end_ip)
+
     def edit_name_and_description(self, name, description=None):
         """Edit name and description of the vApp.
 

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -79,7 +79,7 @@ class TestVApp(BaseTestCase):
     _end_ip_vapp_network = '10.100.12.100'
     _new_start_ip_vapp_network = '10.42.12.11'
     _new_end_ip_vapp_network = '10.42.12.110'
-    _add_ip_range_fail = False
+    _add_ip_range_success = True
 
     def test_0000_setup(self):
         """Setup the vApps required for the other tests in this module.
@@ -631,13 +631,13 @@ class TestVApp(BaseTestCase):
             self.assertEqual(ip_range.IpRange[0].EndAddress,
                              TestVApp._end_ip_vapp_network)
         except Exception:
-            TestVApp._add_ip_range_fail = True
+            TestVApp._add_ip_range_success = False
             self.assertTrue(False)
 
-    def is_add_ip_range_fail(self):
-        return TestVApp._add_ip_range_fail
+    def is_add_ip_range_success(self):
+        return TestVApp._add_ip_range_success
 
-    @depends(is_add_ip_range_fail)
+    @depends(is_add_ip_range_success)
     def test_0123_update_ip_range(self):
         vapp = Environment.get_vapp_in_test_vdc(
             client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
@@ -659,7 +659,7 @@ class TestVApp(BaseTestCase):
             TestVApp._end_ip_vapp_network)
         TestVApp._client.get_task_monitor().wait_for_success(task=task)
 
-    @depends(is_add_ip_range_fail)
+    @depends(is_add_ip_range_success)
     def test_0124_delete_ip_range(self):
         vapp = Environment.get_vapp_in_test_vdc(
             client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)


### PR DESCRIPTION
VP-1927 : [PySDK] Delete IP range from vApp network.

roviding support to delete IP range in vapp network.

Testing Done:
Added test_0125_add_ip_range to vapp_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/468)
<!-- Reviewable:end -->
