### PR TITLE
VP-1929 : [PySDK] Add DNS details to vApp network

### DIFF
--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1274,6 +1274,13 @@ class VApp(object):
         raise EntityNotFoundException(
             'Can\'t find IP range from \'%s\' to \'%s\'' % start_ip, end_ip)
 
+    def update_dns_detail(self, IpScope, type, value):
+        element = etree.Element(type)
+        element.text = value
+        if hasattr(IpScope, type):
+            IpScope.remove(IpScope[type])
+        IpScope.insert(IpScope.index(IpScope.IsEnabled), element)
+
     def add_update_dns_vapp_network(self,
                                     network_name,
                                     primary_dns_ip=None,
@@ -1293,23 +1300,11 @@ class VApp(object):
             if network_config.get('networkName') == network_name:
                 IpScope = network_config.Configuration.IpScopes.IpScope
                 if primary_dns_ip:
-                    dns1 = etree.Element('Dns1')
-                    dns1.text = primary_dns_ip
-                    if hasattr(IpScope, 'Dns1'):
-                        IpScope.remove(IpScope.Dns1)
-                    IpScope.insert(IpScope.index(IpScope.IsEnabled), dns1)
+                    self.update_dns_detail(IpScope, 'Dns1', primary_dns_ip)
                 if secondary_dns_ip:
-                    dns2 = etree.Element('Dns2')
-                    dns2.text = secondary_dns_ip
-                    if hasattr(IpScope, 'Dns2'):
-                        IpScope.remove(IpScope.Dns2)
-                    IpScope.insert(IpScope.index(IpScope.IsEnabled), dns2)
+                    self.update_dns_detail(IpScope, 'Dns2', secondary_dns_ip)
                 if dns_suffix:
-                    dns_suff = etree.Element('DnsSuffix')
-                    dns_suff.text = dns_suffix
-                    if hasattr(IpScope, 'DnsSuffix'):
-                        IpScope.remove(IpScope.DnsSuffix)
-                    IpScope.insert(IpScope.index(IpScope.IsEnabled), dns_suff)
+                    self.update_dns_detail(IpScope, 'DnsSuffix', dns_suffix)
                 return self.client.put_linked_resource(
                     self.resource.NetworkConfigSection, RelationType.EDIT,
                     EntityType.NETWORK_CONFIG_SECTION.value,

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1274,7 +1274,15 @@ class VApp(object):
         raise EntityNotFoundException(
             'Can\'t find IP range from \'%s\' to \'%s\'' % start_ip, end_ip)
 
-    def update_dns_detail(self, IpScope, type, value):
+    def _update_dns_detail(self, IpScope, type, value):
+        """Update DNS details to IpScope.
+
+        :param Element IpScope: parent element.
+        :param str type: type is tag.
+        :param str value: value of tag.
+        """
+        if value is None:
+            return
         element = etree.Element(type)
         element.text = value
         if hasattr(IpScope, type):
@@ -1299,12 +1307,9 @@ class VApp(object):
         for network_config in self.resource.NetworkConfigSection.NetworkConfig:
             if network_config.get('networkName') == network_name:
                 IpScope = network_config.Configuration.IpScopes.IpScope
-                if primary_dns_ip:
-                    self.update_dns_detail(IpScope, 'Dns1', primary_dns_ip)
-                if secondary_dns_ip:
-                    self.update_dns_detail(IpScope, 'Dns2', secondary_dns_ip)
-                if dns_suffix:
-                    self.update_dns_detail(IpScope, 'DnsSuffix', dns_suffix)
+                self.update_dns_detail(IpScope, 'Dns1', primary_dns_ip)
+                self.update_dns_detail(IpScope, 'Dns2', secondary_dns_ip)
+                self.update_dns_detail(IpScope, 'DnsSuffix', dns_suffix)
                 return self.client.put_linked_resource(
                     self.resource.NetworkConfigSection, RelationType.EDIT,
                     EntityType.NETWORK_CONFIG_SECTION.value,

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1274,7 +1274,7 @@ class VApp(object):
         raise EntityNotFoundException(
             'Can\'t find IP range from \'%s\' to \'%s\'' % start_ip, end_ip)
 
-    def _update_dns_detail(self, IpScope, type, value):
+    def update_dns_detail(self, ip_scope, type, value):
         """Update DNS details to IpScope.
 
         :param Element IpScope: parent element.
@@ -1285,15 +1285,15 @@ class VApp(object):
             return
         element = etree.Element(type)
         element.text = value
-        if hasattr(IpScope, type):
-            IpScope.remove(IpScope[type])
-        IpScope.insert(IpScope.index(IpScope.IsEnabled), element)
+        if hasattr(ip_scope, type):
+            ip_scope.remove(ip_scope[type])
+        ip_scope.insert(ip_scope.index(ip_scope.IsEnabled), element)
 
-    def add_update_dns_vapp_network(self,
-                                    network_name,
-                                    primary_dns_ip=None,
-                                    secondary_dns_ip=None,
-                                    dns_suffix=None):
+    def update_dns_vapp_network(self,
+                                network_name,
+                                primary_dns_ip=None,
+                                secondary_dns_ip=None,
+                                dns_suffix=None):
         """Add DNS details to vApp network.
 
         :param str network_name: name of vApp network.
@@ -1306,10 +1306,10 @@ class VApp(object):
         """
         for network_config in self.resource.NetworkConfigSection.NetworkConfig:
             if network_config.get('networkName') == network_name:
-                IpScope = network_config.Configuration.IpScopes.IpScope
-                self.update_dns_detail(IpScope, 'Dns1', primary_dns_ip)
-                self.update_dns_detail(IpScope, 'Dns2', secondary_dns_ip)
-                self.update_dns_detail(IpScope, 'DnsSuffix', dns_suffix)
+                ip_scope = network_config.Configuration.IpScopes.IpScope
+                self.update_dns_detail(ip_scope, 'Dns1', primary_dns_ip)
+                self.update_dns_detail(ip_scope, 'Dns2', secondary_dns_ip)
+                self.update_dns_detail(ip_scope, 'DnsSuffix', dns_suffix)
                 return self.client.put_linked_resource(
                     self.resource.NetworkConfigSection, RelationType.EDIT,
                     EntityType.NETWORK_CONFIG_SECTION.value,

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -675,10 +675,10 @@ class TestVApp(BaseTestCase):
         ip_ranges = network_conf.Configuration.IpScopes.IpScope.IpRanges
         self.assertEqual(len(ip_ranges), 1)
 
-    def test_0125_add_update_dns_vapp_network(self):
+    def test_0125_update_dns_vapp_network(self):
         vapp = Environment.get_vapp_in_test_vdc(
             client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
-        task = vapp.add_update_dns_vapp_network(
+        task = vapp.update_dns_vapp_network(
             TestVApp._vapp_network_name, TestVApp._new_vapp_network_dns1,
             TestVApp._new_vapp_network_dns2,
             TestVApp._new_vapp_network_dns_suffix)
@@ -690,7 +690,7 @@ class TestVApp(BaseTestCase):
         self.assertEqual(IpScope.Dns2, TestVApp._new_vapp_network_dns2)
         self.assertEqual(IpScope.DnsSuffix,
                          TestVApp._new_vapp_network_dns_suffix)
-        task = vapp.add_update_dns_vapp_network(
+        task = vapp.update_dns_vapp_network(
             TestVApp._vapp_network_name, TestVApp._vapp_network_dns1,
             TestVApp._vapp_network_dns2, TestVApp._vapp_network_dns_suffix)
         TestVApp._client.get_task_monitor().wait_for_success(task=task)

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -80,6 +80,9 @@ class TestVApp(BaseTestCase):
     _new_start_ip_vapp_network = '10.42.12.11'
     _new_end_ip_vapp_network = '10.42.12.110'
     _add_ip_range_success = True
+    _new_vapp_network_dns1 = '8.8.8.10'
+    _new_vapp_network_dns2 = '8.8.8.11'
+    _new_vapp_network_dns_suffix = 'newexample.com'
 
     def test_0000_setup(self):
         """Setup the vApps required for the other tests in this module.
@@ -671,6 +674,26 @@ class TestVApp(BaseTestCase):
         network_conf = self._network_present(vapp, TestVApp._vapp_network_name)
         ip_ranges = network_conf.Configuration.IpScopes.IpScope.IpRanges
         self.assertEqual(len(ip_ranges), 1)
+
+    def test_0125_add_update_dns_vapp_network(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
+        task = vapp.add_update_dns_vapp_network(
+            TestVApp._vapp_network_name, TestVApp._new_vapp_network_dns1,
+            TestVApp._new_vapp_network_dns2,
+            TestVApp._new_vapp_network_dns_suffix)
+        TestVApp._client.get_task_monitor().wait_for_success(task=task)
+        vapp.reload()
+        network_conf = self._network_present(vapp, TestVApp._vapp_network_name)
+        IpScope = network_conf.Configuration.IpScopes.IpScope
+        self.assertEqual(IpScope.Dns1, TestVApp._new_vapp_network_dns1)
+        self.assertEqual(IpScope.Dns2, TestVApp._new_vapp_network_dns2)
+        self.assertEqual(IpScope.DnsSuffix,
+                         TestVApp._new_vapp_network_dns_suffix)
+        task = vapp.add_update_dns_vapp_network(
+            TestVApp._vapp_network_name, TestVApp._vapp_network_dns1,
+            TestVApp._vapp_network_dns2, TestVApp._vapp_network_dns_suffix)
+        TestVApp._client.get_task_monitor().wait_for_success(task=task)
 
     def test_0130_delete_vapp_network(self):
         """Test the method vapp.delete_vapp_network().


### PR DESCRIPTION
VP-1929 : [PySDK] Add DNS details to vApp network.

Providing support to add and update DNS details in vapp network.

Testing Done:
Added test_0125_add_update_dns_vapp_network to vapp_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/470)
<!-- Reviewable:end -->
