### PR TITLE
Update test config.yml with missing parameters

### DIFF
--- a/tests/config.yml
+++ b/tests/config.yml
@@ -8,6 +8,8 @@ vcd:
   template: 'ubuntu-16.04-server-cloudimg-amd64.ova'
   vm: 'ubuntu-xenial-16.04-cloudimg-20171011'
   local_template: '/Users/vmware/sw/photon-custom-hw10-1.0-62c543d.ova'
+  org_name: 'UnitTestOrgnistaion01'
+  org_full_name: 'Unit test organization - 01'
   org_to_use: org1
   vdc: vdc1
   new_vdc: v2

--- a/tests/vcd_org.py
+++ b/tests/vcd_org.py
@@ -43,7 +43,8 @@ class TestOrg(TestCase):
         self.assertFalse(updated_org['IsEnabled'])
 
     def test_04_delete_org(self):
-        system = System(self.client)
+        sys_admin = self.client.get_admin()
+        system = System(self.client, admin_resource=sys_admin)
         system.delete_org(self.config['vcd']['org_name'], True, True)
 
 

--- a/tests/vcd_system.py
+++ b/tests/vcd_system.py
@@ -28,7 +28,8 @@ class TestSystem(TestCase):
         assert org.get('name') == self.config['vcd']['org_name']
 
     def test_delete_org(self):
-        system = System(self.client)
+        sys_admin = self.client.get_admin()
+        system = System(self.client,admin_resource=sys_admin)
         system.delete_org(self.config['vcd']['org_name'], True, True)
 
 


### PR DESCRIPTION
* Unit tests vcd_org and vcd_system fails as they look for parameters config['vcd']['org_name] and config['vcd']['org_full_name'] which are missing. Added these parameters with sensible values
* Delete org test fails. Updated to get system resource with admin resource

Signed-off-by: Chaminda Divitotawela <cdivitotawela@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/472)
<!-- Reviewable:end -->
