### PR TITLE
metadata support for vcloud organization

### DIFF
--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -36,10 +36,14 @@ from pyvcloud.vcd.client import NSMAP
 from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.client import RelationType
 from pyvcloud.vcd.client import ResourceType
+from pyvcloud.vcd.client import MetadataDomain
+from pyvcloud.vcd.client import MetadataValueType
+from pyvcloud.vcd.client import MetadataVisibility
 from pyvcloud.vcd.exceptions import DownloadException
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import InvalidParameterException
 from pyvcloud.vcd.exceptions import UploadException
+from pyvcloud.vcd.metadata import Metadata
 from pyvcloud.vcd.system import System
 from pyvcloud.vcd.utils import get_admin_href
 from pyvcloud.vcd.utils import get_safe_members_in_tar_file
@@ -80,6 +84,15 @@ class Org(object):
         organization in vCD.
         """
         self.resource = self.client.get_resource(self.href)
+
+    def get_resource(self):
+        """Fetches the XML representation of the org from vCD.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        if self.resource is None:
+            self.reload()
+        return self.resource
 
     def get_name(self):
         """Retrieves the name of the organization.
@@ -1579,3 +1592,118 @@ class Org(object):
         for v in get_links(self.resource, media_type=EntityType.VDC.value):
             result.append({'name': v.name, 'href': v.href})
         return result
+
+    def get_all_metadata(self):
+        """Fetch all metadata entries of the org.
+
+        :return: an object containing EntityType.METADATA XML data which
+            represents the metadata entries associated with the org.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        self.client.get_resource()
+        return self.client.get_linked_resource(
+            self.resource, RelationType.DOWN, EntityType.METADATA.value)
+
+    def get_metadata_value(self, key, domain=MetadataDomain.GENERAL):
+        """Fetch a metadata value identified by the domain and key.
+
+        :param str key: key of the value to be fetched.
+        :param client.MetadataDomain domain: domain of the value to be fetched.
+
+        :return: an object containing EntityType.METADATA_VALUE XML data which
+            represents the metadata value.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        metadata = Metadata(client=self.client,
+                            resource=self.get_all_metadata())
+        return metadata.get_metadata_value(key, domain)
+
+    def set_metadata(self,
+                     key,
+                     value,
+                     domain=MetadataDomain.GENERAL,
+                     visibility=MetadataVisibility.READ_WRITE,
+                     metadata_value_type=MetadataValueType.STRING):
+        """Add a metadata entry to the org.
+
+        Only admins can perform this operation. If an entry with the same key
+        exists, it will be updated with the new value.
+
+        :param str key: an arbitrary key name. Length cannot exceed 256 UTF-8
+            characters.
+        :param str value: value of the metadata entry
+        :param client.MetadataDomain domain: domain where the new entry would
+            be put.
+        :param client.MetadataVisibility visibility: visibility of the metadata
+            entry.
+        :param client.MetadataValueType metadata_value_type:
+
+        :return: an object of type EntityType.TASK XML which represents
+            the asynchronous task that is updating the metadata on the org.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        metadata = Metadata(client=self.client,
+                            resource=self.get_all_metadata())
+        return metadata.set_metadata(key=key,
+                                     value=value,
+                                     domain=domain,
+                                     visibility=visibility,
+                                     metadata_value_type=metadata_value_type,
+                                     use_admin_endpoint=True)
+
+    def set_multiple_metadata(self,
+                              key_value_dict,
+                              domain=MetadataDomain.GENERAL,
+                              visibility=MetadataVisibility.READ_WRITE,
+                              metadata_value_type=MetadataValueType.STRING):
+        """Add multiple metadata entries to the org.
+
+        Only Sys admins can perform this operation. If an entry with the same
+        key exists, it will be updated with the new value.
+
+        :param dict key_value_dict: a dict containing key-value pairs to be
+            added/updated.
+        :param client.MetadataDomain domain: domain where the new entries would
+            be put.
+        :param client.MetadataVisibility visibility: visibility of the metadata
+            entries.
+        :param client.MetadataValueType metadata_value_type:
+
+        :return: an object of type EntityType.TASK XML which represents
+            the asynchronous task that is updating the metadata on the org.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        metadata = Metadata(client=self.client,
+                            resource=self.get_all_metadata())
+        return metadata.set_multiple_metadata(
+            key_value_dict=key_value_dict,
+            domain=domain,
+            visibility=visibility,
+            metadata_value_type=metadata_value_type,
+            use_admin_endpoint=True)
+
+    def remove_metadata(self, key, domain=MetadataDomain.GENERAL):
+        """Remove a metadata entry from the org.
+
+        Only admins can perform this operation.
+
+        :param str key: key of the metadata to be removed.
+        :param client.MetadataDomain domain: domain of the entry to be removed.
+
+        :return: an object of type EntityType.TASK XML which represents
+            the asynchronous task that is deleting the metadata on the org.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+
+        :raises: AccessForbiddenException: If there is no metadata entry
+            corresponding to the key provided.
+        """
+        metadata = Metadata(client=self.client,
+                            resource=self.get_all_metadata())
+        return metadata.remove_metadata(key=key,
+                                        domain=domain,
+                                        use_admin_endpoint=True)


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

- Ability to inject metadata for Organization

- I was referencing to VCD metadata set/get/remove and tested based on real vcloud environment but sadly I am not good enough to write test for it now. I believe it can boost process of this functionality be available in core library.
