### PR TITLE
Enable configuring organization settings when orgnization is created

### DIFF
--- a/pyvcloud/vcd/org_settings.py
+++ b/pyvcloud/vcd/org_settings.py
@@ -1,0 +1,175 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2014-2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyvcloud.vcd.client import E
+from pyvcloud.vcd.utils import Transform
+
+
+class OrgSettings(object):
+    """Representation of Settings resource for organization."""
+
+    def __init__(self):
+        self.vapp_lease_settings = None
+        self.vapp_template_lease_settings = None
+        self.ldap_settings = None
+
+    def get_settings(self):
+        """Generates the objectified resource of Settings and return.
+
+        :return: returns objectified element of Settings
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        settings = E.Settings()
+
+        if self.vapp_lease_settings is not None:
+            settings.append(self.vapp_lease_settings)
+
+        if self.vapp_template_lease_settings is not None:
+            settings.append(self.vapp_template_lease_settings)
+
+        if self.ldap_settings is not None:
+            settings.append(self.ldap_settings)
+
+        return settings
+
+    def set_vapp_lease_settings(self,
+                                delete_on_storage_expiration=None,
+                                deployment_lease_seconds=None,
+                                storage_lease_seconds=None):
+        """Generates VAppLeaseSettings objectified resource.
+
+        :param bool delete_on_storage_expiration: storage cleanup policy
+        :param int deployment_lease_seconds: maximum runtiime lease in seconds
+        :param int storage_lease_seconds: maximu storage lease in seconds
+        """
+        self.vapp_lease_settings = E.VAppLeaseSettings()
+
+        if delete_on_storage_expiration is not None:
+            self.vapp_lease_settings.append(
+                E.DeleteOnStorageLeaseExpiration(delete_on_storage_expiration))
+
+        if deployment_lease_seconds is not None:
+            self.vapp_lease_settings.append(
+                E.DeploymentLeaseSeconds(int(deployment_lease_seconds)))
+
+        if storage_lease_seconds is not None:
+            self.vapp_lease_settings.append(
+                E.StorageLeaseSeconds(int(storage_lease_seconds)))
+
+    def set_vapp_template_lease_settings(
+            self,
+            delete_on_storage_lease_expiration=None,
+            storage_lease_seconds=None):
+        """Generates VAppTemplateLeaseSettings objectified resource.
+
+        Note: VAppTemplateLeaseSettings configuration requires
+              VAppLeaseSettings resource with values. Otherwise
+              it result in 500/INTERNAL_SERVER_ERROR.
+
+        :param bool delete_on_storage_lease_expiration: storage cleanup
+        :param int storage_lease_seconds: maximum storage lease
+        """
+        self.vapp_template_lease_settings = E.VAppTemplateLeaseSettings()
+
+        if delete_on_storage_lease_expiration is not None:
+            self.vapp_template_lease_settings.append(
+                E.DeleteOnStorageLeaseExpiration(
+                    delete_on_storage_lease_expiration))
+
+        if storage_lease_seconds is not None:
+            self.vapp_template_lease_settings.append(
+                E.StorageLeaseSeconds(int(storage_lease_seconds)))
+
+    def set_org_ldap_settings(self,
+                              org_ldap_mode=None,
+                              sys_users_ou=None,
+                              cus_hostname=None,
+                              cus_port=None,
+                              cus_is_ssl=None,
+                              cus_is_ssl_accept_all=None,
+                              cus_truststore=None,
+                              cus_relam=None,
+                              cus_search_base=None,
+                              cus_username=None,
+                              cus_password=None,
+                              cus_auth_mechanism=None,
+                              cus_group_search_base=None,
+                              cus_is_grp_search_base_enabled=None,
+                              cus_connector_type=None,
+                              cus_user_object_class=None,
+                              cus_user_object_id=None,
+                              cus_user_username=None,
+                              cus_user_email=None,
+                              cus_user_full_name=None,
+                              cus_user_given_name=None,
+                              cus_user_surname=None,
+                              cus_user_telephone=None,
+                              cus_user_grp_membership_id=None,
+                              cus_user_grp_back_link_id=None,
+                              cus_grp_object_class=None,
+                              cus_grp_object_id=None,
+                              cus_grp_grp_name=None,
+                              cus_grp_membership=None,
+                              cus_grp_membership_id=None,
+                              cus_grp_back_link_id=None,
+                              cus_use_external_kerberos=None):
+
+        # Note: At the moment model does not support restricting
+        #       fields for specific versions. This can be enhanced
+        #       by updating model and transform utility. User must
+        #       provide the correct parameters as supported by the version
+        data = [
+            {'OrgLdapMode': org_ldap_mode},
+            {'CustomUsersOu': sys_users_ou},
+            {'CustomOrgLdapSettings': [
+                {'HostName': cus_hostname},
+                {'Port': cus_port},
+                {'IsSsl': cus_is_ssl},
+                {'IsSslAcceptAll': cus_is_ssl_accept_all},
+                {'CustomTruststore': cus_truststore},
+                {'Realm': cus_relam},
+                {'SearchBase': cus_search_base},
+                {'UserName': cus_username},
+                {'Password': cus_password},
+                {'AuthenticationMechanism': cus_auth_mechanism},
+                {'GroupSearchBase': cus_group_search_base},
+                {'IsGroupSearchBaseEnabled': cus_is_grp_search_base_enabled},
+                {'ConnectorType': cus_connector_type},
+                {'UserAttributes': [
+                    {'ObjectClass': cus_user_object_class},
+                    {'ObjectIdentifier': cus_user_object_id},
+                    {'UserName': cus_user_username},
+                    {'Email': cus_user_email},
+                    {'FullName': cus_user_full_name},
+                    {'GivenName': cus_user_given_name},
+                    {'Surname': cus_user_surname},
+                    {'Telephone': cus_user_telephone},
+                    {'GroupMembershipIdentifier': cus_user_grp_membership_id},
+                    {'GroupBackLinkIdentifier': cus_user_grp_back_link_id}
+                ]},
+                {'GroupAttributes': [
+                    {'ObjectClass': cus_grp_object_class},
+                    {'ObjectIdentifier': cus_grp_object_id},
+                    {'GroupName': cus_grp_grp_name},
+                    {'Membership': cus_grp_membership},
+                    {'MembershipIdentifier': cus_grp_membership_id},
+                    {'BackLinkIdentifier': cus_grp_back_link_id}
+                ]},
+                {'UseExternalKerberos': cus_use_external_kerberos}]}]
+
+        transform = Transform()
+        (self.ldap_settings, flag_children_added) = \
+            transform.list_to_objectify(data, 'OrgLdapSettings')

--- a/pyvcloud/vcd/system.py
+++ b/pyvcloud/vcd/system.py
@@ -43,7 +43,11 @@ class System(object):
         if admin_resource is not None:
             self.admin_href = self.client.get_admin().get('href')
 
-    def create_org(self, org_name, full_org_name, is_enabled=False):
+    def create_org(self,
+                   org_name,
+                   full_org_name,
+                   is_enabled=False,
+                   settings=None):
         """Create new organization.
 
         :param str org_name: name of the organization.
@@ -60,8 +64,14 @@ class System(object):
         org_params = E.AdminOrg(
             E.FullName(full_org_name),
             E.IsEnabled(is_enabled),
-            E.Settings,
             name=org_name)
+
+        # Append setting if provided
+        if settings is None:
+            org_params.append(E.Settings())
+        else:
+            org_params.append(settings.get_settings())
+
         return self.client.post_linked_resource(
             self.admin_resource, RelationType.ADD, EntityType.ADMIN_ORG.value,
             org_params)

--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -21,6 +21,7 @@ from os.path import realpath
 
 import humanfriendly
 from lxml import etree
+from lxml import objectify
 from lxml.objectify import NoneElement
 from pygments import formatters
 from pygments import highlight
@@ -885,3 +886,56 @@ def build_network_url_from_gateway_url(gateway_href):
         return network_url.replace(_GATEWAY_ADMIN_API_URL, _NETWORK_URL)
 
     return None
+
+
+class Transform(object):
+    """Provides advanced transformations."""
+
+    def list_to_objectify(self, data, root):
+        """Convert a specific formatted list into a objectify object.
+
+        Ex: List maintains the order of the elements.
+            Sub-elements are provided with inner list
+        data = [ { 'Tag1': 'Value1' },
+                 { 'SubRoot1': [
+                    { 'SubTag1': 'SubValue1'}] }
+        ]
+
+        :param list data: list containing the children elements of the root
+        :param str root: root element where children to be added
+        :return: objectified root element with children added
+
+        :rtype: objectified element of list data
+        """
+        root_element = objectify.Element(root)
+        flag_child_added = False
+        for item in data:
+            if (type(item) is not dict):
+                raise ValueError('Dictionary expected. Got ' + item)
+
+            if (len(item) != 1):
+                raise ValueError(
+                    "Expecting only one element got {}".
+                    format(str(len(item))))
+
+            for key in item:
+                value = item[key]
+
+                # If the value is a list call the function again
+                if (type(value) is list):
+                    sub_root_element = key
+                    sub_item = item[key]
+                    tr = Transform()
+                    (sub_element, sub_flag_child_added) = \
+                        tr.list_to_objectify(sub_item, sub_root_element)
+                    if sub_flag_child_added:
+                        root_element.append(sub_element)
+                else:
+                    if value is not None:
+                        root_element[key] = value
+                        flag_child_added = True
+
+        # Clean and remove namespaces
+        objectify.deannotate(root_element)
+        etree.cleanup_namespaces(root_element)
+        return (root_element, flag_child_added)

--- a/tests/vcd_org_settings.py
+++ b/tests/vcd_org_settings.py
@@ -1,0 +1,265 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import calendar
+import time
+
+from pyvcloud.vcd.system import System
+from pyvcloud.vcd.test import TestCase
+from pyvcloud.vcd.org_settings import OrgSettings
+
+from lxml import etree
+
+class TestOrgWithSettings(TestCase):
+
+    def get_org_data(self):
+        org_name = "UnitTest_"+ str(calendar.timegm(time.gmtime()))
+        org_desc = "Unit test organization - " + str(calendar.timegm(time.gmtime()))
+        return (org_name, org_desc)
+
+    def test_01_create_org_vapp_lease_settings_not_default(self):
+        ''' Create organization with non default values '''
+
+        sys_admin = self.client.get_admin()
+        system = System(self.client, admin_resource=sys_admin)
+
+        # Test Data
+        (org_name, org_desc) = self.get_org_data()
+        vapp_lease_delete_on_storage_lease_expiration = True
+        vapp_lease_deployment_lease_seconds = 18000
+        vapp_lease_storage_lease_seconds = 7200
+
+        # Set up settings object
+        settings = OrgSettings()
+        settings.set_vapp_lease_settings(vapp_lease_delete_on_storage_lease_expiration,
+                                         vapp_lease_deployment_lease_seconds,
+                                         vapp_lease_storage_lease_seconds)
+
+        org = system.create_org(org_name,
+                                org_desc,
+                                settings=settings)
+
+        assert org.get('name') == org_name
+
+        vls = org.Settings.VAppLeaseSettings
+        assert vls.DeleteOnStorageLeaseExpiration.text == str(vapp_lease_delete_on_storage_lease_expiration).lower()
+        assert vls.DeploymentLeaseSeconds.text == str(vapp_lease_deployment_lease_seconds)
+        assert vls.StorageLeaseSeconds.text ==  str(vapp_lease_storage_lease_seconds)
+
+        # Cleanup delete the organization
+        system.delete_org(org_name, True, True)
+
+    def test_02_create_org_vapp_lease_settings_never_expire(self):
+        ''' Create organization with lease never expire'''
+
+        sys_admin = self.client.get_admin()
+        system = System(self.client, admin_resource=sys_admin)
+
+        # Test Data
+        (org_name, org_desc) = self.get_org_data()
+        vapp_lease_delete_on_storage_lease_expiration = False
+        vapp_lease_deployment_lease_seconds = 0
+        vapp_lease_storage_lease_seconds = 0
+
+        # Set up settings object
+        settings = OrgSettings()
+        settings.set_vapp_lease_settings(vapp_lease_delete_on_storage_lease_expiration,
+                                         vapp_lease_deployment_lease_seconds,
+                                         vapp_lease_storage_lease_seconds)
+
+        org = system.create_org(org_name,
+                                org_desc,
+                                settings=settings)
+
+        assert org.get('name') == org_name
+
+        vls = org.Settings.VAppLeaseSettings
+        assert vls.DeleteOnStorageLeaseExpiration.text == str(vapp_lease_delete_on_storage_lease_expiration).lower()
+        assert vls.DeploymentLeaseSeconds.text == str(vapp_lease_deployment_lease_seconds)
+        assert vls.StorageLeaseSeconds.text ==  str(vapp_lease_storage_lease_seconds)
+
+        # Cleanup delete the organization
+        system.delete_org(org_name, True, True)
+
+    def test_03_create_org_vapp__template_lease_settings_not_default(self):
+        ''' Create organization with vApp template lease setting non default values'''
+
+        sys_admin = self.client.get_admin()
+        system = System(self.client, admin_resource=sys_admin)
+
+        # Test Data
+        (org_name, org_desc) = self.get_org_data()
+        vapp_lease_template_delete_on_storage = True
+        vapp_lease_template_delete_on_storage_lease_expiration = 7200
+        vapp_lease_delete_on_storage_lease_expiration = False
+        vapp_lease_deployment_lease_seconds = 0
+        vapp_lease_storage_lease_seconds = 0
+
+        # Set up settings object
+        settings = OrgSettings()
+        settings.set_vapp_lease_settings(vapp_lease_delete_on_storage_lease_expiration,
+                                         vapp_lease_deployment_lease_seconds,
+                                         vapp_lease_storage_lease_seconds)
+        settings.set_vapp_template_lease_settings(vapp_lease_template_delete_on_storage,
+                                                  vapp_lease_template_delete_on_storage_lease_expiration)
+
+        org = system.create_org(org_name,
+                                org_desc,
+                                settings=settings)
+
+        assert org.get('name') == org_name
+
+        vtls = org.Settings.VAppTemplateLeaseSettings
+        assert vtls.DeleteOnStorageLeaseExpiration.text == str(vapp_lease_template_delete_on_storage).lower()
+        assert vtls.StorageLeaseSeconds.text == str(vapp_lease_template_delete_on_storage_lease_expiration)
+
+        # Cleanup delete the organization
+        system.delete_org(org_name, True, True)
+
+    def test_04_create_org_ldap_settings_system(self):
+        ''' Create organization with LDAP settings SYSTEM '''
+
+        sys_admin = self.client.get_admin()
+        system = System(self.client, admin_resource=sys_admin)
+
+        # Test data
+        (org_name, org_desc) = self.get_org_data()
+        ldap_mode = 'SYSTEM'
+        sys_users_ou = 'ou=Users,dc=example,dc=local'
+
+        settings = OrgSettings()
+        settings.set_org_ldap_settings( org_ldap_mode=ldap_mode,
+                                        sys_users_ou=sys_users_ou
+                                       )
+
+        org = system.create_org(org_name,
+                                org_desc,
+                                settings=settings)
+        ldap = org.Settings.OrgLdapSettings
+
+        # Verifications
+        assert org.get('name') == org_name
+        assert ldap.OrgLdapMode.text == ldap_mode
+        assert ldap.CustomUsersOu.text == sys_users_ou
+
+        # Cleanup delete the organization
+        system.delete_org(org_name, True, True)
+
+    def test_05_create_org_ldap_settings_custom(self):
+        ''' Create organization with LDAP settings CUSTOM '''
+
+        sys_admin = self.client.get_admin()
+        system = System(self.client, admin_resource=sys_admin)
+
+        # Test data
+        (org_name, org_desc) = self.get_org_data()
+        ldap_mode = 'CUSTOM'
+        custom_hostname = 'localhost'
+        custom_port = 8080
+        custom_is_ssl = True
+        custom_is_ssl_accept_all = True
+        custom_username = 'cn="ldap-admin", c="example", dc="com"'
+        custom_password = 'veryscretpassword'
+        custom_auth_mechanism = 'SIMPLE'
+        custom_connector_type = 'OPEN_LDAP'
+        custom_is_group_search_base_enabled = False
+        custom_user_object_class = 'user'
+        custom_user_object_identifier = 'objectGuid'
+        custom_user_username = 'userPrincipalName'
+        custom_user_email = 'test@testers.dom'
+        custom_user_full_name = 'First Last'
+        custom_user_given_name = 'First'
+        custom_user_surname = 'Last'
+        custom_user_telephone = '+61430088000'
+        custom_user_group_membership_identifier = 'dn'
+        custom_user_group_back_link_identifier = 'abc'
+        custom_group_object_class = 'group'
+        custom_group_object_identifier = 'dn'
+        custom_group_group_name = 'cn'
+        custom_group_membership = 'member'
+        custom_group_membership_identifier = 'dn'
+        custom_group_back_link_identifier = 'abc'
+        custom_use_external_kerberos = False
+
+        settings = OrgSettings()
+        settings.set_org_ldap_settings(org_ldap_mode=ldap_mode,
+                                       cus_hostname=custom_hostname,
+                                       cus_port=custom_port,
+                                       cus_is_ssl=custom_is_ssl,
+                                       cus_is_ssl_accept_all=custom_is_ssl_accept_all,
+                                       cus_username=custom_username,
+                                       cus_password=custom_password,
+                                       cus_auth_mechanism=custom_auth_mechanism,
+                                       cus_connector_type=custom_connector_type,
+                                       cus_is_grp_search_base_enabled=custom_is_group_search_base_enabled,
+                                       cus_user_object_class=custom_user_object_class,
+                                       cus_user_object_id=custom_user_object_identifier,
+                                       cus_user_username=custom_user_username,
+                                       cus_user_email=custom_user_email,
+                                       cus_user_full_name=custom_user_full_name,
+                                       cus_user_given_name=custom_user_given_name,
+                                       cus_user_surname=custom_user_surname,
+                                       cus_user_telephone=custom_user_telephone,
+                                       cus_user_grp_membership_id=custom_user_group_membership_identifier,
+                                       cus_user_grp_back_link_id=custom_user_group_back_link_identifier,
+                                       cus_grp_object_class=custom_group_object_class,
+                                       cus_grp_object_id=custom_group_object_identifier,
+                                       cus_grp_grp_name=custom_group_group_name,
+                                       cus_grp_membership=custom_group_membership,
+                                       cus_grp_membership_id=custom_group_membership_identifier,
+                                       cus_grp_back_link_id=custom_group_back_link_identifier,
+                                       cus_use_external_kerberos=custom_use_external_kerberos)
+
+        org = system.create_org(org_name,
+                                org_desc,
+                                settings=settings)
+        ldap = org.Settings.OrgLdapSettings
+
+        # Verifications
+        assert org.get('name') == org_name
+        assert ldap.OrgLdapMode.text == ldap_mode
+        assert ldap.CustomOrgLdapSettings.HostName.text == custom_hostname
+        assert int(ldap.CustomOrgLdapSettings.Port.text) == custom_port
+        assert ldap.CustomOrgLdapSettings.IsSsl.text == str(custom_is_ssl).lower()
+        assert ldap.CustomOrgLdapSettings.IsSslAcceptAll.text == str(custom_is_ssl_accept_all).lower()
+        assert ldap.CustomOrgLdapSettings.UserName.text == custom_username
+        # Password is not returned so no assert for password
+        assert ldap.CustomOrgLdapSettings.AuthenticationMechanism.text == custom_auth_mechanism
+        assert ldap.CustomOrgLdapSettings.IsGroupSearchBaseEnabled.text == str(custom_is_group_search_base_enabled).lower()
+        assert ldap.CustomOrgLdapSettings.ConnectorType.text == custom_connector_type
+        assert ldap.CustomOrgLdapSettings.UserAttributes.ObjectClass.text == custom_user_object_class
+        assert ldap.CustomOrgLdapSettings.UserAttributes.ObjectIdentifier.text == custom_user_object_identifier
+        assert ldap.CustomOrgLdapSettings.UserAttributes.UserName.text == custom_user_username
+        assert ldap.CustomOrgLdapSettings.UserAttributes.Email.text == custom_user_email
+        assert ldap.CustomOrgLdapSettings.UserAttributes.FullName.text == custom_user_full_name
+        assert ldap.CustomOrgLdapSettings.UserAttributes.GivenName.text == custom_user_given_name
+        assert ldap.CustomOrgLdapSettings.UserAttributes.Surname.text == custom_user_surname
+        assert ldap.CustomOrgLdapSettings.UserAttributes.Telephone.text == custom_user_telephone
+        assert ldap.CustomOrgLdapSettings.UserAttributes.GroupMembershipIdentifier.text == custom_user_group_membership_identifier
+        assert ldap.CustomOrgLdapSettings.UserAttributes.GroupBackLinkIdentifier.text == custom_user_group_back_link_identifier
+        assert ldap.CustomOrgLdapSettings.GroupAttributes.ObjectClass.text == custom_group_object_class
+        assert ldap.CustomOrgLdapSettings.GroupAttributes.ObjectIdentifier.text == custom_group_object_identifier
+        assert ldap.CustomOrgLdapSettings.GroupAttributes.GroupName.text == custom_group_group_name
+        assert ldap.CustomOrgLdapSettings.GroupAttributes.Membership.text == custom_group_membership
+        assert ldap.CustomOrgLdapSettings.GroupAttributes.MembershipIdentifier.text == custom_group_membership_identifier
+        assert ldap.CustomOrgLdapSettings.GroupAttributes.BackLinkIdentifier.text == custom_group_back_link_identifier
+        assert ldap.CustomOrgLdapSettings.UseExternalKerberos.text == str(custom_use_external_kerberos).lower()
+
+        # Cleanup delete the organization
+        system.delete_org(org_name, True, True)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* Ability to configure VAppLease settings
* Ability to configure LDAP settings
* Backward compatibility is maintained by keeping new parameter settings options with default value

Unit tests:
Unit test vcd_org_settings.py added covering VAppLease and LDAP configuration

Signed-off-by: Chaminda Divitotawela <cdivitotawela@gmail.com>

Fixes #406

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/476)
<!-- Reviewable:end -->
