### PR TITLE
Fix issue configuring IP settings in EdgeGateway

### DIFF
--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -1853,7 +1853,7 @@ class VDC(object):
                             if len(subnet_arr) < 2:
                                 continue
                             if subnet_arr[0] == ip_scope.Gateway.text and \
-                                    subnet_arr[1] == prefix_len:
+                                    int(subnet_arr[1]) == prefix_len:
                                 ip_assigned = \
                                     subnet_with_ip_settings.get(subnet)
                                 if len(ip_assigned) > 0:


### PR DESCRIPTION
When creating EdgeGateway for VDC it is possible to provide IP settings with a ip address. However SDK fail to configure the specified ip in tern edge gateway gets the next available ip in the subnet. Issue is related to comparison of netmask str and int. Solution is to cast the value to int and compare.

Fixes 481

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/482)
<!-- Reviewable:end -->
