### PR TITLE
Fix VDC EdgeGateway Sub-Allocate IP Pool configuration

### DIFF
--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -1574,8 +1574,8 @@ class VDC(object):
         :param bool is_sub_allocate_ip_pools_enabled: is sub allocate ip
         pools enabled
         :param dict ext_net_to_subnet_with_ip_range: external network to sub
-        allocated ip with ip ranges e.g., {"ext_net' : {'10.3.2.1/24' : [
-        10.3.2.2-10.3.2.5, 10.3.2.12-10.3.2.15]}}
+        allocated ip with ip ranges e.g., {'ext_net' : {'10.3.2.1/24' : [
+        '10.3.2.2-10.3.2.5', '10.3.2.12-10.3.2.15']}}
         :param dict ext_net_to_rate_limit: external network to rate limit
         e.g., {'ext_net' : {100 : 100}}
         :param bool is_flips_mode_enabled: is flip mode enabled
@@ -1658,8 +1658,8 @@ class VDC(object):
         :param bool is_sub_allocate_ip_pools_enabled: is sub allocate ip
         pools enabled
         :param dict ext_net_to_subnet_with_ip_range: external network to sub
-        allocated ip with ip ranges e.g., {"ext_net' : {'10.3.2.1/24' : [
-        10.3.2.2-10.3.2.5, 10.3.2.12-10.3.2.15]}}
+        allocated ip with ip ranges e.g., {'ext_net' : {'10.3.2.1/24' : [
+        '10.3.2.2-10.3.2.5', '10.3.2.12-10.3.2.15']}}
         :param dict ext_net_to_rate_limit: external network to rate limit
         e.g., {'ext_net' : {100 : 100}}
 
@@ -1738,8 +1738,8 @@ class VDC(object):
         :param bool is_sub_allocate_ip_pools_enabled: is sub allocate ip
         pools enabled
         :param dict ext_net_to_subnet_with_ip_range: external network to sub
-        allocated ip with ip ranges e.g., {"ext_net' : {'10.3.2.1/24' : [
-        10.3.2.2-10.3.2.5, 10.3.2.12-10.3.2.15]}}
+        allocated ip with ip ranges e.g., {'ext_net' : {'10.3.2.1/24' : [
+        '10.3.2.2-10.3.2.5', '10.3.2.12-10.3.2.15']}}
         :param dict ext_net_to_rate_limit: external network to rate limit
         e.g., {'ext_net' : {100 : 100}}
         :param bool is_flips_mode_enabled: is flip mode enabled
@@ -1880,7 +1880,7 @@ class VDC(object):
                             if len(subnet_arr) < 2:
                                 continue
                             if subnet_arr[0] == ip_scope.Gateway.text and \
-                                    subnet_arr[1] == prefix_len:
+                                    int(subnet_arr[1]) == prefix_len:
                                 ip_ranges = subnet_with_ip_ranges.get(subnet)
                                 if is_default_gw_configured is False and \
                                         is_ip_scope_participating is False:


### PR DESCRIPTION
Comparison of int and str variable prevents configuring Sub-Allocate IP Pool. String parameter cast to int to make the comparison work
Method signature documentation updates

Signed-off-by: Chaminda Divitotawela <cdivitotawela@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/483)
<!-- Reviewable:end -->
