### PR TITLE
Jenkin's test failure with error "The following IP addresses are already"

### DIFF
--- a/system_tests/gateway_tests.py
+++ b/system_tests/gateway_tests.py
@@ -56,6 +56,7 @@ class TestGateway(BaseTestCase):
     _host_name = 'xyzName'
     _binding_ip_address = '10.20.30.40'
     _syslog_server_ip1 = '10.40.40.40'
+    _ip_address_for_config_ip_setting = '2.2.3.3'
 
     def test_0000_setup(self):
         """Setup the gateway required for the other tests in this module.
@@ -87,7 +88,7 @@ class TestGateway(BaseTestCase):
         subnet_addr = gateway_ip + '/' + str(prefix_len)
         ext_net_to_participated_subnet_with_ip_settings = {
             ext_net_resource.get('name'): {
-                subnet_addr: 'Auto'
+                subnet_addr: self._ip_address_for_config_ip_setting
             }
         }
 


### PR DESCRIPTION
Test case is failing with error The following IP addresses are already
------------------
12:19:26 pyvcloud.vcd.exceptions.BadRequestException: Status code: 400/BAD_REQUEST, [ 0d35f753-becc-4183-b3a7-579528f2bbc7 ] The following IP addresses are already
 being used: 2.2.3.2. (request id: 0d35f753-becc-4183-b3a7-579528f2bbc7)
-----------------
https://sp-taas-vcd-butler.svc.eng.vmware.com/job/Preflight-pysdk-1.0-STF/104/consoleFull

Testing Done: Executed the gateway_tests successfully

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/484)
<!-- Reviewable:end -->
