### PR TITLE
VP-2086,VP-2090,VP-2092,VP-2198

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -179,6 +179,8 @@ class RelationType(Enum):
     ENABLE = 'enable'
     ENABLE_GATEWAY_DISTRIBUTED_ROUTING =\
         'edgeGateway:enableDistributedRouting'
+    ENTER_MAINTENANCE_MODE = 'enterMaintenanceMode'
+    EXIT_MAINTENANCE_MODE = 'exitMaintenanceMode'
     GATEWAY_REDEPLOY = 'edgeGateway:redeploy'
     GATEWAY_SYNC_SYSLOG_SETTINGS = 'edgeGateway:syncSyslogSettings'
     GATEWAY_SYS_SERVER_SETTING_IP = 'edgeGateway:configureSyslogServerSettings'
@@ -215,8 +217,6 @@ class RelationType(Enum):
     VDC_ROUTED_CONVERT_TO_SUB_INTERFACE = 'orgVdcNetwork:convertToSubInterface'
     VDC_ROUTED_CONVERT_TO_INTERNAL_INTERFACE = \
         'orgVdcNetwork:convertToInternalInterface'
-    ENTER_MAINTENANCE_MODE = 'enterMaintenanceMode'
-    EXIT_MAINTENANCE_MODE = 'exitMaintenanceMode'
 
 
 class ResourceType(Enum):

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -215,6 +215,8 @@ class RelationType(Enum):
     VDC_ROUTED_CONVERT_TO_SUB_INTERFACE = 'orgVdcNetwork:convertToSubInterface'
     VDC_ROUTED_CONVERT_TO_INTERNAL_INTERFACE = \
         'orgVdcNetwork:convertToInternalInterface'
+    ENTER_MAINTENANCE_MODE = 'enterMaintenanceMode'
+    EXIT_MAINTENANCE_MODE = 'exitMaintenanceMode'
 
 
 class ResourceType(Enum):

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1375,3 +1375,57 @@ class VApp(object):
 
         return self.client.put_linked_resource(
             self.resource, RelationType.EDIT, EntityType.VAPP.value, vapp)
+
+    def suspend_vapp(self):
+        """Suspend a vApp.
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is suspending the vApp.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+
+        :raises OperationNotSupportedException: if the vApp can't be suspend.
+        """
+        self.get_resource()
+        try:
+            return self.client.post_linked_resource(
+                self.resource, RelationType.POWER_SUSPEND, None, None)
+        except OperationNotSupportedException:
+            power_state = self.get_power_state(self.resource)
+            raise OperationNotSupportedException(
+                'Can\'t {0} vApp. Current state of vApp: {1}.'.format(
+                    'suspend', VCLOUD_STATUS_MAP[power_state]))
+
+    def discard_suspended_state_vapp(self):
+        """Discard suspended state of the vApp.
+
+        :return: an object containing EntityType.TASK XML data which represents
+                    the asynchronous task that is discarding suspended state
+                    of vApp.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        :raises OperationNotSupportedException: if the vApp can't be discard
+            suspended state.
+        """
+        self.get_resource()
+        try:
+            return self.client.post_linked_resource(
+                self.resource, RelationType.DISCARD_SUSPENDED_STATE, None,
+                None)
+        except OperationNotSupportedException:
+            power_state = self.get_power_state(self.resource)
+            raise OperationNotSupportedException(
+                'Can\'t {0} vApp. Current state of vApp: {1}.'.format(
+                    'discard suspend state', VCLOUD_STATUS_MAP[power_state]))
+
+    def enter_maintenance_mode(self):
+        """Enter maintenance mode a vApp."""
+        self.get_resource()
+        return self.client.post_linked_resource(
+            self.resource, RelationType.ENTER_MAINTENANCE_MODE, None, None)
+
+    def exit_maintenance_mode(self):
+        """Exit maintenance mode a vApp."""
+        self.get_resource()
+        return self.client.post_linked_resource(
+            self.resource, RelationType.EXIT_MAINTENANCE_MODE, None, None)

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1383,18 +1383,10 @@ class VApp(object):
             the asynchronous task that is suspending the vApp.
 
         :rtype: lxml.objectify.ObjectifiedElement
-
-        :raises OperationNotSupportedException: if the vApp can't be suspend.
         """
         self.get_resource()
-        try:
-            return self.client.post_linked_resource(
-                self.resource, RelationType.POWER_SUSPEND, None, None)
-        except OperationNotSupportedException:
-            power_state = self.get_power_state(self.resource)
-            raise OperationNotSupportedException(
-                'Can\'t {0} vApp. Current state of vApp: {1}.'.format(
-                    'suspend', VCLOUD_STATUS_MAP[power_state]))
+        return self.client.post_linked_resource(
+            self.resource, RelationType.POWER_SUSPEND, None, None)
 
     def discard_suspended_state_vapp(self):
         """Discard suspended state of the vApp.
@@ -1404,19 +1396,10 @@ class VApp(object):
                     of vApp.
 
         :rtype: lxml.objectify.ObjectifiedElement
-        :raises OperationNotSupportedException: if the vApp can't be discard
-            suspended state.
         """
         self.get_resource()
-        try:
-            return self.client.post_linked_resource(
-                self.resource, RelationType.DISCARD_SUSPENDED_STATE, None,
-                None)
-        except OperationNotSupportedException:
-            power_state = self.get_power_state(self.resource)
-            raise OperationNotSupportedException(
-                'Can\'t {0} vApp. Current state of vApp: {1}.'.format(
-                    'discard suspend state', VCLOUD_STATUS_MAP[power_state]))
+        return self.client.post_linked_resource(
+            self.resource, RelationType.DISCARD_SUSPENDED_STATE, None, None)
 
     def enter_maintenance_mode(self):
         """Enter maintenance mode a vApp."""

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -97,6 +97,7 @@ class TestVApp(BaseTestCase):
         logger = Environment.get_default_logger()
         TestVApp._client = Environment.get_client_in_default_org(
             TestVApp._test_runner_role)
+        TestVApp._sys_admin_client = Environment.get_sys_admin_client()
         vdc = Environment.get_test_vdc(TestVApp._client)
 
         logger.debug('Creating empty vApp.')
@@ -337,6 +338,48 @@ class TestVApp(BaseTestCase):
         result = TestVApp._client.get_task_monitor().wait_for_success(task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
         # end state of vApp is deployed and partially powered on.
+
+    def test_0052_suspend_vapp(self):
+        logger = Environment.get_default_logger()
+        vapp_name = TestVApp._customized_vapp_name
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._client, vapp_name=vapp_name)
+        logger.debug('Suspending vApp ' + vapp_name)
+        vapp.reload()
+        task = vapp.suspend_vapp()
+        result = TestVApp._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0053_discard_suspended_state_vapp(self):
+        logger = Environment.get_default_logger()
+        vapp_name = TestVApp._customized_vapp_name
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._client, vapp_name=vapp_name)
+        logger.debug('Discarding suspended state of vApp ' + vapp_name)
+        vapp.reload()
+        task = vapp.discard_suspended_state_vapp()
+        result = TestVApp._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0054_enter_maintenance_mode(self):
+        logger = Environment.get_default_logger()
+        vapp_name = TestVApp._customized_vapp_name
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._sys_admin_client, vapp_name=vapp_name)
+        logger.debug('Entering maintenance mode of vApp ' + vapp_name)
+        vapp.reload()
+        result = vapp.enter_maintenance_mode()
+        self.assertEqual(result, None)
+
+    def test_0055_exit_maintenance_mode(self):
+        logger = Environment.get_default_logger()
+        vapp_name = TestVApp._customized_vapp_name
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._sys_admin_client, vapp_name=vapp_name)
+        logger.debug('Exiting maintenance mode of vApp ' + vapp_name)
+        vapp.reload()
+        result = vapp.exit_maintenance_mode()
+        self.assertEqual(result, None)
 
     def test_0060_vapp_network_connection(self):
         """Test vapp.connect/disconnect_org_vdc_network().


### PR DESCRIPTION
VP-2086:[PySDK]Discard suspended state.
VP-2090:[PySDK] Enter maintenance mode.
VP-2092:[PySDK] Exit maintenance mode.
VP-2198:[PySDK]suspend vapp

This CLN contains above functionalities and corresponding test cases.

Testing Done:
All test cases in vapp_tests class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/504)
<!-- Reviewable:end -->
