### PR TITLE
VP-2094 : [PySDK] Upgrade Virtual Hardware version vapp

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -834,7 +834,7 @@ class TestVApp(BaseTestCase):
 
         logger.debug('Upgrading virtual hardware of vApp ' + vapp_name)
         no_of_vm_upgraded = vapp.upgrade_virtual_hardware()
-        self.assertNotEqual(no_of_vm_upgraded, 0)
+        self.assertEqual(no_of_vm_upgraded, len(vapp.get_all_vms()))
 
     @developerModeAware
     def test_9998_teardown(self):

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -820,6 +820,22 @@ class TestVApp(BaseTestCase):
         self.assertFalse(
             self._is_network_present(vapp, TestVApp._vapp_network_name))
 
+    def test_0140_upgrade_virtual_hardware(self):
+        logger = Environment.get_default_logger()
+        vapp_name = TestVApp._customized_vapp_name
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._sys_admin_client, vapp_name=vapp_name)
+
+        logger.debug('Un-deploying vApp ' + vapp_name)
+        task = vapp.undeploy()
+        result = TestVApp._sys_admin_client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+        logger.debug('Upgrading virtual hardware of vApp ' + vapp_name)
+        no_of_vm_upgraded = vapp.upgrade_virtual_hardware()
+        self.assertNotEqual(no_of_vm_upgraded, 0)
+
     @developerModeAware
     def test_9998_teardown(self):
         """Test the  method vdc.delete_vapp().


### PR DESCRIPTION
VP-2094 : [PySDK] Upgrade Virtual Hardware version vapp.

Adding a support to upgrade virtual hardware of all vm belongs to vapp.

Testing Done:
Added def_0100_upgrade_virtual_hardware to vapp_tests.py. All test cases in this class are passing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/510)
<!-- Reviewable:end -->
