### PR TITLE
VP-2035: [PYSDK]Copy to VM from one vApp to another

### DIFF
--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -640,16 +640,14 @@ class VM(object):
         resource_type = ResourceType.VAPP.value
         if self.is_powered_off(vm_resource):
             records1 = self.___validate_vapp_records(
-                vapp_name=source_vapp_name, resource_type = resource_type)
+                vapp_name=source_vapp_name, resource_type=resource_type)
 
-            for r in records1:
-                source_vapp_href = r.get('href')
+            source_vapp_href = records1[0].get('href')
 
             records2 = self.___validate_vapp_records(
                 vapp_name=target_vapp_name, resource_type=resource_type)
 
-            for r in records2:
-                target_vapp_href = r.get('href')
+            target_vapp_href = records2[0].get('href')
 
             source_vapp = VApp(self.client, href=source_vapp_href)
             target_vapp = VApp(self.client, href=target_vapp_href)

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -626,9 +626,9 @@ class VM(object):
     def copy_to(self, source_vapp_name, target_vapp_name, target_vm_name):
         """Copy VM from one vApp to another.
 
-        :param: source vApp name
-        :param: target vApp name
-        :param: target VM name
+        :param: str source vApp name
+        :param: str target vApp name
+        :param: str target VM name
 
         :return: an object containing EntityType.TASK XML data which represents
                     the asynchronous task that is copying VM
@@ -645,12 +645,9 @@ class VM(object):
                 query_result_format=QueryResultFormat.REFERENCES,
                 equality_filter=name_filter)
             records1 = list(q1.execute())
-            if records1 is None or len(records1) == 0:
-                raise EntityNotFoundException(
-                    'Vapp with name \'%s\' not found.' % source_vapp_name)
-            elif len(records1) > 1:
-                raise MultipleRecordsException("Found multiple vapp named "
-                                               "'%s'," % source_vapp_name)
+            self.___validate_vapp_records(records=records1,
+                                          vapp_name=source_vapp_name)
+
             for r in records1:
                 source_vapp_href = r.get('href')
 
@@ -660,12 +657,8 @@ class VM(object):
                 query_result_format=QueryResultFormat.REFERENCES,
                 equality_filter=name_filter)
             records2 = list(q2.execute())
-            if records2 is None or len(records2) == 0:
-                raise EntityNotFoundException(
-                    'Vapp with name \'%s\' not found.' % target_vapp_name)
-            elif len(records2) > 1:
-                raise MultipleRecordsException("Found multiple vapp named "
-                                               "'%s'," % target_vapp_name)
+            self.___validate_vapp_records(records=records2,
+                                          vapp_name=target_vapp_name)
             for r in records2:
                 target_vapp_href = r.get('href')
 
@@ -684,3 +677,11 @@ class VM(object):
                                        )
         else:
             raise InvalidStateException("VM Must be powered off.")
+
+    def ___validate_vapp_records(self, records, vapp_name):
+        if records is None or len(records) == 0:
+            raise EntityNotFoundException(
+                'Vapp with name \'%s\' not found.' % vapp_name)
+        elif len(records) > 1:
+            raise MultipleRecordsException("Found multiple vapp named "
+                                           "'%s'," % vapp_name)

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -639,26 +639,15 @@ class VM(object):
         vm_resource = self.get_resource()
         resource_type = ResourceType.VAPP.value
         if self.is_powered_off(vm_resource):
-            name_filter = ('name', source_vapp_name)
-            q1 = self.client.get_typed_query(
-                resource_type,
-                query_result_format=QueryResultFormat.REFERENCES,
-                equality_filter=name_filter)
-            records1 = list(q1.execute())
-            self.___validate_vapp_records(records=records1,
-                                          vapp_name=source_vapp_name)
+            records1 = self.___validate_vapp_records(
+                vapp_name=source_vapp_name, resource_type = resource_type)
 
             for r in records1:
                 source_vapp_href = r.get('href')
 
-            name_filter = ('name', target_vapp_name)
-            q2 = self.client.get_typed_query(
-                resource_type,
-                query_result_format=QueryResultFormat.REFERENCES,
-                equality_filter=name_filter)
-            records2 = list(q2.execute())
-            self.___validate_vapp_records(records=records2,
-                                          vapp_name=target_vapp_name)
+            records2 = self.___validate_vapp_records(
+                vapp_name=target_vapp_name, resource_type=resource_type)
+
             for r in records2:
                 target_vapp_href = r.get('href')
 
@@ -678,10 +667,18 @@ class VM(object):
         else:
             raise InvalidStateException("VM Must be powered off.")
 
-    def ___validate_vapp_records(self, records, vapp_name):
+    def ___validate_vapp_records(self, vapp_name, resource_type):
+        name_filter = ('name', vapp_name)
+        q1 = self.client.get_typed_query(
+            resource_type,
+            query_result_format=QueryResultFormat.REFERENCES,
+            equality_filter=name_filter)
+        records = list(q1.execute())
         if records is None or len(records) == 0:
             raise EntityNotFoundException(
                 'Vapp with name \'%s\' not found.' % vapp_name)
         elif len(records) > 1:
             raise MultipleRecordsException("Found multiple vapp named "
                                            "'%s'," % vapp_name)
+
+        return records

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -17,10 +17,15 @@ from pyvcloud.vcd.client import E
 from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import IpAddressMode
 from pyvcloud.vcd.client import NSMAP
+from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.client import RelationType
+from pyvcloud.vcd.client import ResourceType
 from pyvcloud.vcd.client import VCLOUD_STATUS_MAP
 from pyvcloud.vcd.client import VmNicProperties
+from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import InvalidParameterException
+from pyvcloud.vcd.exceptions import InvalidStateException
+from pyvcloud.vcd.exceptions import MultipleRecordsException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
 
 
@@ -617,3 +622,65 @@ class VM(object):
         self.get_resource()
         return self.client.post_linked_resource(
             self.resource, RelationType.CONSOLIDATE, None, None)
+
+    def copy_to(self, source_vapp_name, target_vapp_name, target_vm_name):
+        """Copy VM from one vApp to another.
+
+        :param: source vApp name
+        :param: target vApp name
+        :param: target VM name
+
+        :return: an object containing EntityType.TASK XML data which represents
+                    the asynchronous task that is copying VM
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        from pyvcloud.vcd.vapp import VApp
+        vm_resource = self.get_resource()
+        resource_type = ResourceType.VAPP.value
+        if self.is_powered_off(vm_resource):
+            name_filter = ('name', source_vapp_name)
+            q1 = self.client.get_typed_query(
+                resource_type,
+                query_result_format=QueryResultFormat.REFERENCES,
+                equality_filter=name_filter)
+            records1 = list(q1.execute())
+            if records1 is None or len(records1) == 0:
+                raise EntityNotFoundException(
+                    'Vapp with name \'%s\' not found.' % source_vapp_name)
+            elif len(records1) > 1:
+                raise MultipleRecordsException("Found multiple vapp named "
+                                               "'%s'," % source_vapp_name)
+            for r in records1:
+                source_vapp_href = r.get('href')
+
+            name_filter = ('name', target_vapp_name)
+            q2 = self.client.get_typed_query(
+                resource_type,
+                query_result_format=QueryResultFormat.REFERENCES,
+                equality_filter=name_filter)
+            records2 = list(q2.execute())
+            if records2 is None or len(records2) == 0:
+                raise EntityNotFoundException(
+                    'Vapp with name \'%s\' not found.' % target_vapp_name)
+            elif len(records2) > 1:
+                raise MultipleRecordsException("Found multiple vapp named "
+                                               "'%s'," % target_vapp_name)
+            for r in records2:
+                target_vapp_href = r.get('href')
+
+            source_vapp = VApp(self.client, href=source_vapp_href)
+            target_vapp = VApp(self.client, href=target_vapp_href)
+            target_vapp.reload()
+            spec = {
+                'vapp': source_vapp.get_resource(),
+                'source_vm_name': self.get_resource().get('name'),
+                'target_vm_name': target_vm_name
+            }
+            return target_vapp.add_vms([spec],
+                                       deploy=False,
+                                       power_on=False,
+                                       all_eulas_accepted=True
+                                       )
+        else:
+            raise InvalidStateException("VM Must be powered off.")


### PR DESCRIPTION
VP-2035: [PYSDK]Copy to VM from one vApp to another

This CLN contains copying VM from one vApp to another vApp. copy_to()
method is exposed in vm.py class and corresponding test case added. This
method will take source vapp, target vapp and VM name as argument.

Testing Done:
test method test_0072_copy_to() is added in test class vm_tests.py. It
is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/514)
<!-- Reviewable:end -->
