### PR TITLE
Added method list_vapp_details() and test-case for list_vapp_details()

### DIFF
--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -2023,4 +2023,3 @@ class VDC(object):
         out_list = list(query.execute())
 
         return out_list
-

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -1997,3 +1997,30 @@ class VDC(object):
             raise MultipleRecordsException("Found multiple gateway named "
                                            "'%s'," % name)
         return records[0]
+
+    def list_vapp_details(self, resource_type, filter=None):
+        """List vApp details.
+
+        :param str filter: filter to fetch the vApp Details based on filter,
+        e.g.,
+        ownerName==<owner-name*>
+        name==<vapp-name>
+        numberOfVMs==<number>
+        vdcName==<vdcname>
+
+        :return: list of vApp based on filter
+        e.g.
+        [{'containerName': 'vapp1', 'ownerName': 'system' ,
+         'numberOfVMs':'7','status':'POWERED_ON','vdcName':'Ovdc1'}]
+        :rtype: list
+
+        """
+        out_list = []
+        query = self.client.get_typed_query(
+            resource_type,
+            query_result_format=QueryResultFormat.RECORDS,
+            qfilter=filter)
+        out_list = list(query.execute())
+
+        return out_list
+

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -820,6 +820,26 @@ class TestVApp(BaseTestCase):
         self.assertFalse(
             self._is_network_present(vapp, TestVApp._vapp_network_name))
 
+    def test_0131_list_vapp_details(self):
+        """Test the method list_vapp_details().
+
+        This test passes if the expected vApp list can be successfully retrieved.
+        """
+        org_vdc = Environment.get_test_vdc(TestVApp._sys_admin_client)
+        resource_type = 'adminVApp'
+
+        vapp_filter = None
+        vapp_list = org_vdc.list_vapp_details(resource_type, vapp_filter)
+        self.assertTrue(len(vapp_list) > 0)
+
+        vapp_filter = 'name==' + TestVApp._customized_vapp_name
+        vapp_list = org_vdc.list_vapp_details(resource_type, vapp_filter)
+        self.assertTrue(len(vapp_list) > 0)
+
+        vapp_filter = 'ownerName==' + TestVApp._customized_vapp_owner_name
+        vapp_list = org_vdc.list_vapp_details(resource_type, vapp_filter)
+        self.assertTrue(len(vapp_list) > 0)
+
     def test_0140_upgrade_virtual_hardware(self):
         logger = Environment.get_default_logger()
         vapp_name = TestVApp._customized_vapp_name


### PR DESCRIPTION
Added method(list_vapp_details) to get vApp Details with filter

" vcd vapp list" command currently not having filter to get vapp list based on some option provided by user. With this change we have added list_vapp_details() methods to get vApp details based on provided filter, it will accept below filters :

vcd vapp list --filter ownerName==ownername
vcd vapp list --filter numberOfVMs==number
vcd vapp list --filter name==vapp-name
vcd vapp list --filter vdcName==ovdc-name

Also we have added the testcase for the same

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/516)
<!-- Reviewable:end -->
