### PR TITLE
VP-2100 : [PySDK] Copy to vapp

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -325,6 +325,7 @@ class EntityType(Enum):
     CATALOG = 'application/vnd.vmware.vcloud.catalog+xml'
     CAPTURE_VAPP_PARAMS = \
         'application/vnd.vmware.vcloud.captureVAppParams+xml'
+    CLONE_VAPP_PARAMS = 'application/vnd.vmware.vcloud.cloneVAppParams+xml'
     COMPOSE_VAPP_PARAMS = \
         'application/vnd.vmware.vcloud.composeVAppParams+xml'
     CONTROL_ACCESS_PARAMS = 'application/vnd.vmware.vcloud.controlAccess+xml'


### PR DESCRIPTION
VP-2100 : [PySDK] Copy to vapp.

This CLN contains copying Vapp from one vdc  to another vdc or same vdc. 
copy_to() method is exposed in vapp.py class and corresponding test case added. 
This method will take source vapp, target vapp anme and vdc as argument.

Testing Done:
test method test_0150_copy_to() is added in test class vapp_tests.py. 
It is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/517)
<!-- Reviewable:end -->
