### PR TITLE
VP-2039: [PySDK] Delete VM

### DIFF
--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -680,3 +680,13 @@ class VM(object):
                                            "'%s'," % vapp_name)
 
         return records
+
+    def delete(self):
+        """Delete the VM.
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is deleting the VM.
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        self.get_resource()
+        return self.client.delete_linked_resource(self.resource,
+                                                  RelationType.REMOVE, None)

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -683,6 +683,7 @@ class VM(object):
 
     def delete(self):
         """Delete the VM.
+
         :return: an object containing EntityType.TASK XML data which represents
             the asynchronous task that is deleting the VM.
         :rtype: lxml.objectify.ObjectifiedElement

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -424,6 +424,18 @@ class TestVM(BaseTestCase):
         result = TestVM._client.get_task_monitor().wait_for_success(task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
+    def test_0074_delete_vm(self):
+        """Test the method related to delete VM.
+        This test passes if delete VM operation is successful.
+        """
+        target_vapp = VApp(TestVM._client, href=TestVM._empty_vapp_href)
+        vm_resource = target_vapp.get_vm(TestVM._target_vm_name)
+        TestVM._test_vapp_target_vm_href = vm_resource.get('href')
+        vm = VM(TestVM._client, href=TestVM._test_vapp_target_vm_href)
+        task = vm.delete()
+        result = TestVM._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
     def test_0080_vm_nic_operations(self):
         """Test the method add_nic vm.py.
 


### PR DESCRIPTION
VP-2039: [PySDK] Delete VM

This CLN contains functionality to delete a VM and corresponding test
case test_0074_delete_vm is added in vm_tests.py file.

Testing Done:
Method test_0074_delete_vm is added in vm_tests.py file and it is
executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/521)
<!-- Reviewable:end -->
