### PR TITLE
VP-2393: PYPI api version fix

### DIFF
--- a/examples/tenant-onboard.py
+++ b/examples/tenant-onboard.py
@@ -90,7 +90,6 @@ client = Client(cfg.vcd_host, verify_ssl_certs=False,
                 log_requests=True,
                 log_headers=True,
                 log_bodies=True)
-client.set_highest_supported_version()
 client.set_credentials(BasicLoginCredentials(cfg.vcd_admin_user,
                        "System", cfg.vcd_admin_password))
 

--- a/examples/tenant-onboard.py
+++ b/examples/tenant-onboard.py
@@ -26,7 +26,6 @@ import yaml
 # Private utility functions.
 from tenantlib import handle_task
 
-from pyvcloud.vcd.client import API_CURRENT_VERSIONS
 from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.client import FenceMode
@@ -86,9 +85,7 @@ requests.packages.urllib3.disable_warnings()
 # Login. SSL certificate verification is turned off to allow self-signed
 # certificates.  You should only do this in trusted environments.
 print("Logging in...")
-api_version = API_CURRENT_VERSIONS[-1]
 client = Client(cfg.vcd_host, verify_ssl_certs=False,
-                api_version=api_version,
                 log_file='pyvcloud.log',
                 log_requests=True,
                 log_headers=True,

--- a/examples/tenant-remove.py
+++ b/examples/tenant-remove.py
@@ -50,7 +50,6 @@ client = Client(cfg.vcd_host, verify_ssl_certs=False,
                 log_requests=True,
                 log_headers=True,
                 log_bodies=True)
-client.set_highest_supported_version()
 client.set_credentials(BasicLoginCredentials(cfg.vcd_admin_user, "System",
                        cfg.vcd_admin_password))
 

--- a/examples/tenant-remove.py
+++ b/examples/tenant-remove.py
@@ -24,7 +24,6 @@ import yaml
 # Private utility functions.
 from tenantlib import handle_task
 
-from pyvcloud.vcd.client import API_CURRENT_VERSIONS
 from pyvcloud.vcd.client import BasicLoginCredentials
 from pyvcloud.vcd.client import Client
 from pyvcloud.vcd.system import System
@@ -46,9 +45,7 @@ requests.packages.urllib3.disable_warnings()
 # Login. SSL certificate verification is turned off to allow self-signed
 # certificates.  You should only do this in trusted environments.
 print("Logging in...")
-api_version = API_CURRENT_VERSIONS[-1]
 client = Client(cfg.vcd_host, verify_ssl_certs=False,
-                api_version=api_version,
                 log_file='pyvcloud.log',
                 log_requests=True,
                 log_headers=True,


### PR DESCRIPTION
VP-2393: PYPI api version fix

This CLN contains change for refreshing PYPI build. It makes client to
choose API_VERSION from the file not the heighest supported version.

Testing Done:
tenant-onboard.py file is tested and it is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/524)
<!-- Reviewable:end -->
