### PR TITLE
VP-2394: [PYSDK]idisk test case fix

### DIFF
--- a/system_tests/idisk_tests.py
+++ b/system_tests/idisk_tests.py
@@ -36,20 +36,18 @@ class TestDisk(BaseTestCase):
     _client = None
 
     _idisk1_name = 'test_idisk_' + str(uuid1())
-    _idisk1_size = '10'
+    _idisk1_size = '2097152'
     _idisk1_description = 'First disk'
     _idisk1_id = None
     _idisk1_new_name = 'test_idisk_new_name_' + str(uuid1())
-    _idisk1_new_size = '20'
+    _idisk1_new_size = '2097152'
     _idisk1_new_description = 'New description of first disk'
-
     _idisk2_name = 'test_idisk_' + str(uuid1())
-    _idisk2_size = '20'
+    _idisk2_size = '2097152'
     _idisk2_description = 'Second disk'
     _idisk2_id = None
-
     _idisk3_name = _idisk2_name
-    _idisk3_size = '30'
+    _idisk3_size = '2097152'
     _idisk3_description = 'Third disk, namesake of second disk'
     _idisk3_id = None
 


### PR DESCRIPTION
VP-2394: [PYSDK]idisk test case fix

This CLN fix test cases of independent disk which are failing because of
size of them. New VCD accepts at-lease size of 1 mb. Changes has done
accordingly.

Testing Done:
idisk_tests.py is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/525)
<!-- Reviewable:end -->
