### PR TITLE
VP-2106 : [PySDK] create snapshot of vapp

### DIFF
--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1531,3 +1531,23 @@ class VApp(object):
         """
         vapp_name = self.resource.get('name')
         return self.vapp_clone(vdc_href, vapp_name, None, True)
+
+    def create_snapshot(self, memory=False, quiesce=False):
+        """Create snapshot of vapp.
+
+        :param bool memory: True, if the snapshot should include the virtual
+            machine's memory.
+        :param bool quiesce: True, if the file system of the virtual machine
+            should be quiesced before the snapshot is created. Requires VMware
+            tools to be installed on the vm.
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is moving the vApp.
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        snapshot_vapp_params = E.CreateSnapshotParams()
+        snapshot_vapp_params.set('memory', str(memory).lower())
+        snapshot_vapp_params.set('quiesce', str(quiesce).lower())
+        return self.client.post_linked_resource(
+            self.resource, RelationType.SNAPSHOT_CREATE,
+            EntityType.SNAPSHOT_CREATE.value, snapshot_vapp_params)

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -939,11 +939,9 @@ class TestVApp(BaseTestCase):
 
     def test_0170_create_snapshot(self):
         vapp = Environment.get_vapp_in_test_vdc(
-            client=TestVApp._sys_admin_client,
-            vapp_name=TestVApp._customized_vapp_name)
+            client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
         task = vapp.create_snapshot()
-        result = TestVApp._sys_admin_client.get_task_monitor(
-        ).wait_for_success(task)
+        result = TestVApp._client.get_task_monitor().wait_for_success(task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
     @developerModeAware

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -925,14 +925,23 @@ class TestVApp(BaseTestCase):
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
         target_vdc = org.get_vdc(TestVApp._ovdc_name)
-        target_vdc_obj = VDC(TestVApp._sys_admin_client,
-                             href=target_vdc.get('href'))
+        target_vdc_obj = VDC(
+            TestVApp._sys_admin_client, href=target_vdc.get('href'))
         vapp_resource = target_vdc_obj.get_vapp(TestVApp._customized_vapp_name)
         vapp = VApp(TestVApp._sys_admin_client, resource=vapp_resource)
 
         target_vdc = Environment.get_test_vdc(TestVApp._client)
         logger.debug('Move back vApp ' + TestVApp._customized_vapp_name)
         task = vapp.move_to(target_vdc.href)
+        result = TestVApp._sys_admin_client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0170_create_snapshot(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._sys_admin_client,
+            vapp_name=TestVApp._customized_vapp_name)
+        task = vapp.create_snapshot()
         result = TestVApp._sys_admin_client.get_task_monitor(
         ).wait_for_success(task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)


### PR DESCRIPTION
VP-2106 : [PySDK] create snapshot of vapp.  
This CLN contains creating a snapshot of a vapp.  
create_snapshot() method is exposed in vapp.py class and corresponding test case added.  

Testing Done:  
test method test_0170_create_snapshot() is added in test class vapp_tests.py.  
It is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/533)
<!-- Reviewable:end -->
