### PR TITLE
VP-2049: [PySDK] Detach Disk

### DIFF
--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -512,6 +512,15 @@ class TestVM(BaseTestCase):
         result = TestVM._client.get_task_monitor().wait_for_success(task=task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
+    def test_0120_detach_independent_disk(self):
+        vdc = Environment.get_test_vdc(TestVM._client)
+        idisk = vdc.get_disk(name=TestVM._idisk_name)
+        task = TestVM._test_vapp. \
+            detach_disk_from_vm(disk_href=idisk.get('href'),
+                                vm_name=TestVM._test_vapp_first_vm_name)
+        result = TestVM._client.get_task_monitor().wait_for_success(task=task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
     @developerModeAware
     def test_9998_teardown(self):
         """Delete the vApp created during setup.

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -16,6 +16,8 @@
 import unittest
 from uuid import uuid1
 
+from lxml import etree
+from lxml import objectify
 from pyvcloud.system_test_framework.base_test import BaseTestCase
 from pyvcloud.system_test_framework.environment import CommonRoles
 from pyvcloud.system_test_framework.environment import developerModeAware
@@ -26,6 +28,7 @@ from pyvcloud.system_test_framework.utils import create_empty_vapp
 
 from pyvcloud.vcd.client import IpAddressMode
 from pyvcloud.vcd.client import NetworkAdapterType
+from pyvcloud.vcd.client import NSMAP
 from pyvcloud.vcd.client import TaskStatus
 from pyvcloud.vcd.client import VmNicProperties
 from pyvcloud.vcd.exceptions import EntityNotFoundException
@@ -512,6 +515,10 @@ class TestVM(BaseTestCase):
         result = TestVM._client.get_task_monitor().wait_for_success(task=task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
+        is_disk_attached = self.__validate_is_attached_disk(is_disk_attached=False)
+        self.assertTrue(is_disk_attached)
+
+
     def test_0120_detach_independent_disk(self):
         vdc = Environment.get_test_vdc(TestVM._client)
         idisk = vdc.get_disk(name=TestVM._idisk_name)
@@ -520,6 +527,34 @@ class TestVM(BaseTestCase):
                                 vm_name=TestVM._test_vapp_first_vm_name)
         result = TestVM._client.get_task_monitor().wait_for_success(task=task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+        is_disk_attached = self.__validate_is_attached_disk(is_disk_attached=False)
+        self.assertFalse(is_disk_attached)
+
+    def test_0130_general_setting_detail(self):
+        vm = VM(TestVM._client, href=TestVM._test_vapp_first_vm_href)
+        result = vm.general_setting_detail()
+        self.assertNotEqual(len(result), 0)
+
+    def test_0140_list_storage_profile(self):
+        vm = VM(TestVM._client, href=TestVM._test_vapp_first_vm_href)
+        result = vm.list_storage_profile()
+        self.assertNotEqual(len(result), 0)
+
+    def __validate_is_attached_disk(self,is_disk_attached=False):
+        vm = VM(TestVM._client, href=TestVM._test_vapp_first_vm_href)
+        vm.reload()
+        vm_resource = vm.get_resource()
+        disk_list = TestVM._client.get_resource(
+            vm_resource.get('href') + '/virtualHardwareSection/disks')
+        for disk in disk_list.Item:
+            if disk['{' + NSMAP['rasd'] + '}Description'] == 'Hard disk':
+                if disk.xpath('rasd:HostResource', namespaces=NSMAP)[
+                    0].attrib.get('{' + NSMAP['vcloud'] + '}disk'):
+                    is_disk_attached = True
+                    break
+
+        return is_disk_attached
 
     @developerModeAware
     def test_9998_teardown(self):


### PR DESCRIPTION
[PySDK] Detach Disk

This CLN contains test case for detach independent disk from VM.
Functionality is already included in Vapp.py file.

Testing Done:
Test case test_0120_detach_independent_disk is added in vm_tests.py file
and it is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/536)
<!-- Reviewable:end -->
