### PR TITLE
VP-2112 : [PySDK] List vApp Networks

### DIFF
--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1575,3 +1575,20 @@ class VApp(object):
         self.get_resource()
         return self.client.post_linked_resource(
             self.resource, RelationType.SNAPSHOT_REMOVE_ALL, None, None)
+
+    def get_vapp_network_list(self):
+        """Returns the list of vapp network defined in the vApp.
+
+        :return: list of the vapp network name.
+
+        :rtype: list
+        """
+        self.get_resource()
+        vapp_network_list = []
+        for network_config in self.resource.NetworkConfigSection.NetworkConfig:
+            if network_config.get('networkName') != 'none':
+                vapp_network_list.append({
+                    'name':
+                    network_config.get('networkName')
+                })
+        return vapp_network_list

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -813,6 +813,12 @@ class TestVApp(BaseTestCase):
         list_ip_address = vapp.list_ip_allocations(TestVApp._vapp_network_name)
         self.assertTrue(len(list_ip_address) > 0)
 
+    def test_0129_get_vapp_network_list(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
+        list_of_vapp_net = vapp.get_vapp_network_list()
+        self.assertNotEqual(len(list_of_vapp_net), 0)
+
     def test_0130_delete_vapp_network(self):
         """Test the method vapp.delete_vapp_network().
 


### PR DESCRIPTION
VP-2112 : [PySDK] List vApp Networks.

This CLN contains list vapp network of vapp.
get_vapp_network_list() methods is exposed in vapp.py class and corresponding test case added.
Testing Done:
test methods test_0129_get_vapp_network_list() is added in test class vapp_tests.py.
It is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/538)
<!-- Reviewable:end -->
