### PR TITLE
C to t failure

### DIFF
--- a/examples/tenant-onboard.py
+++ b/examples/tenant-onboard.py
@@ -67,10 +67,10 @@ def _fill_in_netpool_default(client, vdc_kwargs):
             raise Exception("Unable to find default netpool")
 
 # Collect arguments.
-if len(sys.argv) != 2:
-    print("Usage: python3 {0} config_file".format(sys.argv[0]))
-    sys.exit(1)
-config_yaml = sys.argv[1]
+#if len(sys.argv) != 2:Catalog does not exist
+    #print("Usage: python3 {0} config_file".format(sys.argv[0]))
+    #sys.exit(1)
+config_yaml = 'tenant.yaml'
 
 # Load the YAML configuration and convert to an object with properties for
 # top-level entries.  Values are either scalar variables, dictionaries,
@@ -158,9 +158,9 @@ except Exception:
 # permissions.  As with VDC's we reload the org if we create a catalog
 # so that it's visible in future calls.
 try:
-    catalog_resource = org.get_catalog_resource(cfg.catalog['name'])
+    catalog_resource = org.get_catalog(cfg.catalog['name'])
     print("Catalog already exists: {0}".format(cfg.catalog['name']))
-except Exception:
+except Exception as e:
     print("Catalog does not exist, creating: {0}".format(cfg.catalog['name']))
     catalog_kwargs = cfg.catalog
     catalog_resource = org.create_catalog(**catalog_kwargs)

--- a/examples/tenant-onboard.py
+++ b/examples/tenant-onboard.py
@@ -67,10 +67,10 @@ def _fill_in_netpool_default(client, vdc_kwargs):
             raise Exception("Unable to find default netpool")
 
 # Collect arguments.
-#if len(sys.argv) != 2:Catalog does not exist
-    #print("Usage: python3 {0} config_file".format(sys.argv[0]))
-    #sys.exit(1)
-config_yaml = 'tenant.yaml'
+if len(sys.argv) != 2:
+    print("Usage: python3 {0} config_file".format(sys.argv[0]))
+    sys.exit(1)
+config_yaml = sys.argv[1]
 
 # Load the YAML configuration and convert to an object with properties for
 # top-level entries.  Values are either scalar variables, dictionaries,

--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -170,17 +170,25 @@ class Org(object):
                 rel=RelationType.DOWN,
                 media_type=EntityType.CATALOG.value)
         else:
-            links = self.client.get_resource_link_from_query_object(
-                self.resource,
-                media_type=EntityType.RECORDS.value,
-                type='catalog')
-        for link in links:
-            if name == link.name:
-                if is_admin_operation:
-                    href = get_admin_href(link.href)
-                else:
-                    href = link.href
-                return self.client.get_resource(href)
+            if hasattr(self.resource, "Catalogs"):
+                catalogs = self.resource.Catalogs
+                for catalog in catalogs:
+                    if hasattr(catalog, "CatalogReference"):
+                        if name == catalog.CatalogReference.get("name"):
+                            href = catalog.CatalogReference.get("href")
+                            return self.client.get_resource(href)
+            else:
+                links = self.client.get_resource_link_from_query_object(
+                    self.resource,
+                    media_type=EntityType.RECORDS.value,
+                    type='catalog')
+                for link in links:
+                    if name == link.name:
+                        if is_admin_operation:
+                            href = get_admin_href(link.href)
+                        else:
+                            href = link.href
+                        return self.client.get_resource(href)
         raise EntityNotFoundException('Catalog not found (or)'
                                       ' Access to resource is forbidden')
 

--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -770,7 +770,7 @@ def get_admin_href(href):
 
 
 def is_admin(href):
-    """Returns True is provided href has /api/admin into it.
+    """Returns True if provided href has /api/admin into it.
 
     :param str href: href
 

--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -769,6 +769,23 @@ def get_admin_href(href):
         return href.replace('/api/', '/api/admin/')
 
 
+def is_admin(href):
+    """Returns True is provided href has /api/admin into it.
+
+    :param str href: href
+
+    :return: True if admin else False
+
+    :rtype: Boolean
+    """
+    if '/api/admin/extension/' in href:
+        return False
+    elif '/api/admin/' in href:
+        return True
+    else:
+        return False
+
+
 def get_admin_extension_href(href):
     """Returns sys admin version of a given vCD url.
 


### PR DESCRIPTION
vCD code has gone under changes for API version 33 for entities Org and VDC. They started passing the admin vDC link for Org GET if requested by System Admin User.

Fix will check if resource is of type admin then fetch its alternate non-admin resource for performing vapp instantiate operation.

Manually executed the tenant-onboard.py and found to be working fine.

Error stack trace for reference-----

08:45:19 Traceback (most recent call last):
08:45:19   File "/data/jenkins/jenkins-Preflight-pysdk-1.0-STF-245/examples/tenant-onboard.py", line 272, in <module>
08:45:19     vapp_resource = vdc.instantiate_vapp(**vapp_cfg)
08:45:19   File "/data/jenkins/jenkins-Preflight-pysdk-1.0-STF-245/jenkins-venv/lib/python3.7/site-packages/pyvcloud/vcd/vdc.py", line 223, in instantiate_vapp
08:45:19     EntityType.ORG.value).href
08:45:19   File "/data/jenkins/jenkins-Preflight-pysdk-1.0-STF-245/jenkins-venv/lib/python3.7/site-packages/pyvcloud/vcd/client.py", line 1546, in find_link
08:45:19     raise MissingLinkException(resource.get('href'), rel, media_type)
08:45:19 pyvcloud.vcd.exceptions.MissingLinkException: ('https://wdc-vcd-sp-static-34-19.eng.vmware.com/api/admin/vdc/033caea4-faad-4f0e-8881-d8fe0b4bf115', <RelationType.UP: 'up'>, 'application/vnd.vmware.vcloud.org+xml'); href: https://wdc-vcd-sp-static-34-19.eng.vmware.com/api/admin/vdc/033caea4-faad-4f0e-8881-d8fe0b4bf115, rel: RelationType.UP, mediaType: application/vnd.vmware.vcloud.org+xml

@kkkothari

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/544)
<!-- Reviewable:end -->
