### PR TITLE
Fix get_catalog for API version less than 33

### DIFF
--- a/pyvcloud/system_test_framework/environment.py
+++ b/pyvcloud/system_test_framework/environment.py
@@ -781,8 +781,9 @@ class Environment(object):
                 name=catalog_name, item_name=media_name)
             media = catalog_author_client.get_resource(
                 catalog_item.Entity.get('href'))
-            catalog_author_client.get_task_monitor().wait_for_success(
-                task=media.Tasks.Task[0])
+            if hasattr(media, "Tasks"):
+                catalog_author_client.get_task_monitor().wait_for_success(
+                    task=media.Tasks.Task[0])
 
             cls._media_resource = org.get_catalog_item(catalog_name,
                                                        media_name)

--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -182,13 +182,14 @@ class Org(object):
                     self.resource,
                     media_type=EntityType.RECORDS.value,
                     type='catalog')
-                for link in links:
-                    if name == link.name:
-                        if is_admin_operation:
-                            href = get_admin_href(link.href)
-                        else:
-                            href = link.href
-                        return self.client.get_resource(href)
+        if links:
+            for link in links:
+                if name == link.name:
+                    if is_admin_operation:
+                        href = get_admin_href(link.href)
+                    else:
+                        href = link.href
+                    return self.client.get_resource(href)
         raise EntityNotFoundException('Catalog not found (or)'
                                       ' Access to resource is forbidden')
 


### PR DESCRIPTION
For API version lesser than 33, evaluating the link was not getting called. Result in CToT failure.

After the fix, Tested locally against API version 33 and 32 and found to be working fine.

@kkkothari

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/545)
<!-- Reviewable:end -->
