### PR TITLE
Adding support for log roll over

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -746,6 +746,28 @@ class Client(object):
 
     def _get_defaut_logger(self, file_name, log_level=logging.DEBUG,
                            max_bytes=30000000, backup_count=30):
+        """This will set the default logger with Rotating FileHandler.
+
+            Open the specified file and use it as the stream for logging.
+            By default, the file grows indefinitely. You can specify particular
+            values of maxBytes and backupCount to allow the file to rollover at
+            a predetermined size.
+            Rollover occurs whenever the current log file is nearly maxBytes in
+            length. If backupCount is >= 1, the system will successively create
+            new files with the same pathname as the base file, but with extensions
+            ".1", ".2" etc. appended to it. For example, with a backupCount of 5
+            and a base file name of "app.log", you would get "app.log",
+            "app.log.1", "app.log.2", ... through to "app.log.5". The file being
+            written to is always "app.log" - when it gets filled up, it is closed
+            and renamed to "app.log.1", and if files "app.log.1", "app.log.2" etc.
+            exist, then they are renamed to "app.log.2", "app.log.3" etc.
+            respectively.
+
+            :param file_name: name of the log file.
+            :param log_level: log level.
+            :param max_bytes: max size of log file in bytes.
+            :param backup_count: no of backup count.
+        """
         self._logger = logging.getLogger(file_name)
         default_log_handler = handlers.RotatingFileHandler(
             filename=file_name, maxBytes=max_bytes, backupCount=backup_count)

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -714,7 +714,8 @@ class Client(object):
         self._task_monitor = None
         self._verify_ssl_certs = verify_ssl_certs
 
-        self._logger = logging.getLogger(log_file)
+        self._logger = None
+        self._get_defaut_logger(file_name=log_file)
         self._logger.setLevel(logging.DEBUG)
         # This makes sure that we don't append a new handler to the logger
         # every time we create a new client.
@@ -742,6 +743,14 @@ class Client(object):
         self.fsencoding = sys.getfilesystemencoding()
 
         self._is_sysadmin = False
+
+    def _get_defaut_logger(self, file_name, log_level=logging.DEBUG,
+                           max_bytes=30000000, backup_count=30):
+        self._logger = logging.getLogger(file_name)
+        default_log_handler = handlers.RotatingFileHandler(
+            filename=file_name, maxBytes=max_bytes, backupCount=backup_count)
+        default_log_handler.setLevel(log_level)
+        self._logger.addHandler(default_log_handler)
 
     def _get_response_request_id(self, response):
         """Extract request id of a request to vCD from the response.


### PR DESCRIPTION
Before the fix, log get rolled over after the default size and never get captured.

After this fix, log will rollover to new file once the default size of log file (30 mb) will get filled.

Testing Done: Locally I am able to see it creating new files, once the current log file cross the size limit.

@pandeys @kkkothari

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/548)
<!-- Reviewable:end -->
