### PR TITLE
VP-2593 :[PySDK] Show DNS detail of Vapp Network

### DIFF
--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1326,6 +1326,30 @@ class VApp(object):
         raise EntityNotFoundException(
             'Can\'t find network \'%s\'' % network_name)
 
+    def dns_detail_of_vapp_network(self, network_name):
+        """DNS details of vApp network.
+
+        :param str network_name: name of App network.
+        :return:  Dictionary having Dns1, Dns2 and DnsSuffix.
+        e.g.
+        {'Dns1': '10.1.1.1', 'Dns2': '10.1.1.2', 'DnsSuffix':'example.com'}
+        :rtype: dict
+        :raises: Exception: if the network can't be found.
+        """
+        for network_config in self.resource.NetworkConfigSection.NetworkConfig:
+            if network_config.get('networkName') == network_name:
+                ip_scope = network_config.Configuration.IpScopes.IpScope
+                dns_details = {}
+                if hasattr(ip_scope, 'Dns1'):
+                    dns_details['Dns1'] = ip_scope.Dns1
+                if hasattr(ip_scope, 'Dns2'):
+                    dns_details['Dns2'] = ip_scope.Dns2
+                if hasattr(ip_scope, 'DnsSuffix'):
+                    dns_details['DnsSuffix'] = ip_scope.DnsSuffix
+                return dns_details
+        raise EntityNotFoundException(
+            'Can\'t find network \'%s\'' % network_name)
+
     def list_ip_allocations(self, network_name):
         """List all allocated ip of vApp network.
 

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -813,6 +813,15 @@ class TestVApp(BaseTestCase):
         list_ip_address = vapp.list_ip_allocations(TestVApp._vapp_network_name)
         self.assertTrue(len(list_ip_address) > 0)
 
+    def test_0127_dns_detail_of_vapp_network(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
+        result = vapp.dns_detail_of_vapp_network(TestVApp._vapp_network_name)
+        self.assertEqual(result['Dns1'], TestVApp._vapp_network_dns1)
+        self.assertEqual(result['Dns2'], TestVApp._vapp_network_dns2)
+        self.assertEqual(result['DnsSuffix'],
+                         TestVApp._vapp_network_dns_suffix)
+
     def test_0129_get_vapp_network_list(self):
         vapp = Environment.get_vapp_in_test_vdc(
             client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)


### PR DESCRIPTION
VP-2593 :[PySDK] Show DNS detail of Vapp Network.

This CLN contains show DNS details of Vapp Network functionality.
dns_detail_of_vapp_network() methods is exposed in vapp.py class and corresponding test case added.
Testing Done:
test methods test_0127_dns_detail_of_vapp_network() is added in test class vapp_tests.py.
It is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/550)
<!-- Reviewable:end -->
