### PR TITLE
Fix CToT failure in case of file_name is not provided.

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -744,7 +744,8 @@ class Client(object):
 
         self._is_sysadmin = False
 
-    def _get_defaut_logger(self, file_name, log_level=logging.DEBUG,
+    def _get_defaut_logger(self, file_name="vcd_pysdk.log",
+                           log_level=logging.DEBUG,
                            max_bytes=30000000, backup_count=30):
         """This will set the default logger with Rotating FileHandler.
 
@@ -768,7 +769,10 @@ class Client(object):
         :param max_bytes: max size of log file in bytes.
         :param backup_count: no of backup count.
         """
+        if file_name is None:
+            file_name = "vcd_pysdk.log"
         self._logger = logging.getLogger(file_name)
+        Path(file_name).parent.mkdir(parents=True, exist_ok=True)
         default_log_handler = handlers.RotatingFileHandler(
             filename=file_name, maxBytes=max_bytes, backupCount=backup_count)
         default_log_handler.setLevel(log_level)


### PR DESCRIPTION
CToT is failing while executing list-vdc-resource.py

Error stack trace-------

16:40:36 Logging in: host=wdc-vcd-sp-static-34-63.eng.vmware.com, org=Test1, user=user1
16:40:36 Traceback (most recent call last):
16:40:36   File "/data/jenkins/jenkins-Preflight-pysdk-1.0-STF-261/examples/list-vdc-resources.py", line 39, in <module>
16:40:36     client = Client(host, verify_ssl_certs=False)
16:40:36   File "/data/jenkins/jenkins-Preflight-pysdk-1.0-STF-261/jenkins-venv/lib/python3.7/site-packages/pyvcloud/vcd/client.py", line 718, in __init__
16:40:36     self._get_defaut_logger(file_name=log_file)
16:40:36   File "/data/jenkins/jenkins-Preflight-pysdk-1.0-STF-261/jenkins-venv/lib/python3.7/site-packages/pyvcloud/vcd/client.py", line 773, in _get_defaut_logger
16:40:36     filename=file_name, maxBytes=max_bytes, backupCount=backup_count)
16:40:36   File "/usr/local/lib/python3.7/logging/handlers.py", line 147, in __init__
16:40:36     BaseRotatingHandler.__init__(self, filename, mode, encoding, delay)
16:40:36   File "/usr/local/lib/python3.7/logging/handlers.py", line 54, in __init__
16:40:36     logging.FileHandler.__init__(self, filename, mode, encoding, delay)
16:40:36   File "/usr/local/lib/python3.7/logging/__init__.py", line 1079, in __init__
16:40:36     filename = os.fspath(filename)
16:40:36 TypeError: expected str, bytes or os.PathLike object, not NoneType

Testing Done: Locally executed the test case list_vdc_resource.py and found to be working.

@pandeys

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/551)
<!-- Reviewable:end -->
