### PR TITLE
VP-2072: [PySDK] Reload from VC

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -206,6 +206,7 @@ class RelationType(Enum):
     POWER_SUSPEND = 'power:suspend'
     PUBLISH = 'publish'
     RECOMPOSE = 'recompose'
+    RELOAD_FROM_VC = 'reloadFromVc'
     REMOVE = 'remove'
     REPAIR = 'repair'
     RIGHTS = 'rights'

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -779,3 +779,15 @@ class VM(object):
                             disk_setting.StorageProfile.get('name')
                         })
         return storage_profile
+
+    def reload_from_vc(self):
+        """Reload a VM from VC.
+
+        :return: an object containing EntityType.TASK XML data which represents
+                    the asynchronous task that is reloading VM from VC
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        self.get_resource()
+        return self.client.post_linked_resource(
+            self.resource, RelationType.RELOAD_FROM_VC, None, None)

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -16,8 +16,6 @@
 import unittest
 from uuid import uuid1
 
-from lxml import etree
-from lxml import objectify
 from pyvcloud.system_test_framework.base_test import BaseTestCase
 from pyvcloud.system_test_framework.environment import CommonRoles
 from pyvcloud.system_test_framework.environment import developerModeAware
@@ -554,6 +552,20 @@ class TestVM(BaseTestCase):
                     break
 
         return is_disk_attached
+
+    def test_0150_reload_from_vc(self):
+        """Test the method related to reload_from_vc in vm.py.
+        This test passes if reload from VC operation is successful.
+        """
+        logger = Environment.get_default_logger()
+        vm_name = TestVM._test_vapp_first_vm_name
+        vm = VM(TestVM._sys_admin_client, href=TestVM._test_vapp_first_vm_href)
+        vm.reload()
+        logger.debug('Reloading VM:  ' + vm_name + ' from VC.')
+        task = vm.reload_from_vc()
+        result = TestVM._sys_admin_client.\
+            get_task_monitor().wait_for_success(task=task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
     @developerModeAware
     def test_9998_teardown(self):


### PR DESCRIPTION
[PySDK] Reload from VC

This CLN contains VM functionality to reload from VC. Test cases are
also attached in file vm_tests.py file.

Testing Done: Test method test_0150_reload_from_vc is added in
vm_tests.py file and it is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/553)
<!-- Reviewable:end -->
