### PR TITLE
VP-1399, VP-2598

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -215,6 +215,7 @@ class RelationType(Enum):
     SNAPSHOT_CREATE = 'snapshot:create'
     SNAPSHOT_REVERT_TO_CURRENT = 'snapshot:revertToCurrent'
     SNAPSHOT_REMOVE_ALL = 'snapshot:removeAll'
+    SYNC_SYSLOG_SETTINGS = 'syncSyslogSettings'
     TASK_CANCEL = 'task:cancel'
     UNDEPLOY = 'undeploy'
     UNLINK_FROM_TEMPLATE = 'unlinkFromTemplate'

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1326,6 +1326,30 @@ class VApp(object):
         raise EntityNotFoundException(
             'Can\'t find network \'%s\'' % network_name)
 
+    def dns_detail_of_vapp_network(self, network_name):
+        """DNS details of vApp network.
+
+        :param str network_name: name of App network.
+        :return:  Dictionary having Dns1, Dns2 and DnsSuffix.
+        e.g.
+        {'Dns1': '10.1.1.1', 'Dns2': '10.1.1.2', 'DnsSuffix':'example.com'}
+        :rtype: dict
+        :raises: Exception: if the network can't be found.
+        """
+        for network_config in self.resource.NetworkConfigSection.NetworkConfig:
+            if network_config.get('networkName') == network_name:
+                ip_scope = network_config.Configuration.IpScopes.IpScope
+                dns_details = {}
+                if hasattr(ip_scope, 'Dns1'):
+                    dns_details['Dns1'] = ip_scope.Dns1
+                if hasattr(ip_scope, 'Dns2'):
+                    dns_details['Dns2'] = ip_scope.Dns2
+                if hasattr(ip_scope, 'DnsSuffix'):
+                    dns_details['DnsSuffix'] = ip_scope.DnsSuffix
+                return dns_details
+        raise EntityNotFoundException(
+            'Can\'t find network \'%s\'' % network_name)
+
     def list_ip_allocations(self, network_name):
         """List all allocated ip of vApp network.
 

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -813,6 +813,15 @@ class TestVApp(BaseTestCase):
         list_ip_address = vapp.list_ip_allocations(TestVApp._vapp_network_name)
         self.assertTrue(len(list_ip_address) > 0)
 
+    def test_0127_dns_detail_of_vapp_network(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
+        result = vapp.dns_detail_of_vapp_network(TestVApp._vapp_network_name)
+        self.assertEqual(result['Dns1'], TestVApp._vapp_network_dns1)
+        self.assertEqual(result['Dns2'], TestVApp._vapp_network_dns2)
+        self.assertEqual(result['DnsSuffix'],
+                         TestVApp._vapp_network_dns_suffix)
+
     def test_0129_get_vapp_network_list(self):
         vapp = Environment.get_vapp_in_test_vdc(
             client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -93,6 +93,7 @@ class TestVApp(BaseTestCase):
     _ova_file_name = 'test.ova'
     _vapp_copy_name = 'customized_vApp_copy_' + str(uuid1())
     _ovdc_name = 'test_vdc2_ ' + str(uuid1())
+    _ovdc_network_name = 'test-direct-vdc-network'
 
     def test_0000_setup(self):
         """Setup the vApps required for the other tests in this module.
@@ -673,9 +674,8 @@ class TestVApp(BaseTestCase):
             vapp_name=TestVApp._customized_vapp_name)
 
         # connect vapp network to org vdc network
-        ovdc_network_name = Environment.get_default_orgvdc_network_name()
         task = vapp.connect_vapp_network_to_ovdc_network(
-            TestVApp._vapp_network_name, ovdc_network_name)
+            TestVApp._vapp_network_name, TestVApp._ovdc_network_name)
         result = TestVApp._client.get_task_monitor().wait_for_success(task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -828,7 +828,36 @@ class TestVApp(BaseTestCase):
         list_of_vapp_net = vapp.get_vapp_network_list()
         self.assertNotEqual(len(list_of_vapp_net), 0)
 
-    def test_0130_delete_vapp_network(self):
+    def test_0130_connect_vapp_network_to_ovdc_network(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._sys_admin_client,
+            vapp_name=TestVApp._customized_vapp_name)
+
+        # undeploy a vapp
+        task = vapp.undeploy()
+        TestVApp._client.get_task_monitor().wait_for_success(task=task)
+        vapp.reload()
+
+        # connect vapp network to org vdc network
+        ovdc_network_name = Environment.get_default_orgvdc_network_name()
+        task = vapp.connect_vapp_network_to_ovdc_network(
+            TestVApp._vapp_network_name, ovdc_network_name)
+        result = TestVApp._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+        # deploy a vapp
+        task = vapp.deploy(power_on=True)
+        TestVApp._client.get_task_monitor().wait_for_success(task=task)
+        vapp.reload()
+
+    def test_0131_sync_syslog_settings(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
+        task = vapp.sync_syslog_settings(TestVApp._vapp_network_name)
+        result = TestVApp._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0132_delete_vapp_network(self):
         """Test the method vapp.delete_vapp_network().
 
         This test passes if delete network is successful.
@@ -844,7 +873,7 @@ class TestVApp(BaseTestCase):
         self.assertFalse(
             self._is_network_present(vapp, TestVApp._vapp_network_name))
 
-    def test_0131_list_vapp_details(self):
+    def test_0135_list_vapp_details(self):
         """Test the method list_vapp_details().
 
         This test passes if the expected vApp list can be successfully retrieved.

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -667,6 +667,25 @@ class TestVApp(BaseTestCase):
                 return True
         return False
 
+    def test_0111_connect_vapp_network_to_ovdc_network(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._sys_admin_client,
+            vapp_name=TestVApp._customized_vapp_name)
+
+        # connect vapp network to org vdc network
+        ovdc_network_name = Environment.get_default_orgvdc_network_name()
+        task = vapp.connect_vapp_network_to_ovdc_network(
+            TestVApp._vapp_network_name, ovdc_network_name)
+        result = TestVApp._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0112_sync_syslog_settings(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
+        task = vapp.sync_syslog_settings(TestVApp._vapp_network_name)
+        result = TestVApp._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
     def test_0120_reset_vapp_network(self):
         """Test the method vapp.reset_vapp_network().
 
@@ -828,36 +847,7 @@ class TestVApp(BaseTestCase):
         list_of_vapp_net = vapp.get_vapp_network_list()
         self.assertNotEqual(len(list_of_vapp_net), 0)
 
-    def test_0130_connect_vapp_network_to_ovdc_network(self):
-        vapp = Environment.get_vapp_in_test_vdc(
-            client=TestVApp._sys_admin_client,
-            vapp_name=TestVApp._customized_vapp_name)
-
-        # undeploy a vapp
-        task = vapp.undeploy()
-        TestVApp._client.get_task_monitor().wait_for_success(task=task)
-        vapp.reload()
-
-        # connect vapp network to org vdc network
-        ovdc_network_name = Environment.get_default_orgvdc_network_name()
-        task = vapp.connect_vapp_network_to_ovdc_network(
-            TestVApp._vapp_network_name, ovdc_network_name)
-        result = TestVApp._client.get_task_monitor().wait_for_success(task)
-        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
-
-        # deploy a vapp
-        task = vapp.deploy(power_on=True)
-        TestVApp._client.get_task_monitor().wait_for_success(task=task)
-        vapp.reload()
-
-    def test_0131_sync_syslog_settings(self):
-        vapp = Environment.get_vapp_in_test_vdc(
-            client=TestVApp._client, vapp_name=TestVApp._customized_vapp_name)
-        task = vapp.sync_syslog_settings(TestVApp._vapp_network_name)
-        result = TestVApp._client.get_task_monitor().wait_for_success(task)
-        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
-
-    def test_0132_delete_vapp_network(self):
+    def test_0130_delete_vapp_network(self):
         """Test the method vapp.delete_vapp_network().
 
         This test passes if delete network is successful.
@@ -873,7 +863,7 @@ class TestVApp(BaseTestCase):
         self.assertFalse(
             self._is_network_present(vapp, TestVApp._vapp_network_name))
 
-    def test_0135_list_vapp_details(self):
+    def test_0131_list_vapp_details(self):
         """Test the method list_vapp_details().
 
         This test passes if the expected vApp list can be successfully retrieved.

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -26,11 +26,14 @@ from pyvcloud.system_test_framework.utils import \
     create_customized_vapp_from_template
 from pyvcloud.system_test_framework.utils import create_empty_vapp
 
+from pyvcloud.vcd.client import find_link
 from pyvcloud.vcd.client import IpAddressMode
 from pyvcloud.vcd.client import MetadataDomain
 from pyvcloud.vcd.client import MetadataVisibility
 from pyvcloud.vcd.client import NetworkAdapterType
 from pyvcloud.vcd.client import NSMAP
+from pyvcloud.vcd.client import RelationType
+from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import TaskStatus
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.system import System
@@ -678,6 +681,15 @@ class TestVApp(BaseTestCase):
             TestVApp._vapp_network_name, TestVApp._ovdc_network_name)
         result = TestVApp._client.get_task_monitor().wait_for_success(task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp_network_href = find_link(
+            resource=vapp.resource,
+            rel=RelationType.DOWN,
+            media_type=EntityType.vApp_Network.value,
+            name=TestVApp._vapp_network_name).href
+        vapp_net_res = TestVApp._client.get_resource(vapp_network_href)
+        self.assertEqual(
+            vapp_net_res.Configuration.ParentNetwork.get('name'),
+            TestVApp._ovdc_network_name)
 
     def test_0112_sync_syslog_settings(self):
         vapp = Environment.get_vapp_in_test_vdc(


### PR DESCRIPTION
VP-1399 : [PySdk] Synchronize syslog server settings
VP-2598 : [PySdk] Make connection of vapp network

This CLN contains Make connection of vapp network with org vdc network of Vapp and
Synchronize syslog server settings.
sync_syslog_settings() and connect_vapp_network_to_ovdc_network() methods is exposed in vapp.py class and corresponding test case added.
Testing Done:
test methods test_0130_connect_vapp_network_to_ovdc_network()  and test_0131_sync_syslog_settings are added in test class vapp_tests.py.
It is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/555)
<!-- Reviewable:end -->
