### PR TITLE
VP-2079: [PySDK] CUstomize at Next Power ON

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -169,6 +169,7 @@ class RelationType(Enum):
     CONSOLIDATE = 'consolidate'
     CONTROL_ACCESS = 'controlAccess'
     CONVERT_TO_ADVANCED_GATEWAY = 'edgeGateway:convertToAdvancedGateway'
+    CUSTOMIZE_AT_NEXT_POWERON = 'customizeAtNextPowerOn'
     DEPLOY = 'deploy'
     DISABLE = 'disable'
     DISABLE_GATEWAY_DISTRIBUTED_ROUTING = \

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -803,3 +803,14 @@ class VM(object):
         self.get_resource()
         return self.client.post_linked_resource(
             self.resource, RelationType.CHECK_COMPLIANCE, None, None)
+
+    def customize_at_next_power_on(self):
+        """Customize VM at next power on.
+
+        :return: returns 204 No content
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        self.get_resource()
+        return self.client.post_linked_resource(
+            self.resource, RelationType.CUSTOMIZE_AT_NEXT_POWERON, None, None)

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -581,6 +581,16 @@ class TestVM(BaseTestCase):
             get_task_monitor().wait_for_success(task=task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
+    def test_0170_customize_at_next_poer_on(self):
+        """Test the method related to customize_at_next_power_on in vm.py.
+        This test passes if customize at next power on operation is successful.
+        """
+        logger = Environment.get_default_logger()
+        vm_name = TestVM._test_vapp_first_vm_name
+        vm = VM(TestVM._sys_admin_client, href=TestVM._test_vapp_first_vm_href)
+        vm.reload()
+        vm.customize_at_next_power_on()
+
     @developerModeAware
     def test_9998_teardown(self):
         """Delete the vApp created during setup.


### PR DESCRIPTION
[PySDK] CUstomize at Next Power ON

This CLN contains VM functionality to customize at next power on. Test
case is not included because corresponding API returns 204 no content.

Testing Done:
Manual testing done. In VCD host, guest customization logs tested
manually while powering on the VM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/556)
<!-- Reviewable:end -->
