### PR TITLE
VP-2021,VP-2676,VP-2689 :Power on with force Recustomization for a VM

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -193,6 +193,7 @@ class RelationType(Enum):
     GATEWAY_SYNC_SYSLOG_SETTINGS = 'edgeGateway:syncSyslogSettings'
     GATEWAY_SYS_SERVER_SETTING_IP = 'edgeGateway:configureSyslogServerSettings'
     GATEWAY_UPDATE_PROPERTIES = 'edgeGateway:updateProperties'
+    GUEST_CUSTOMIZATION_SECTION = 'guestCustomizationSection'
     INSERT_MEDIA = 'media:insertMedia'
     INSTALL_VMWARE_TOOLS = 'installVmwareTools'
     LINK_TO_TEMPLATE = 'linkToTemplate'

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -357,6 +357,8 @@ class EntityType(Enum):
         'application/vnd.vmware.admin.vmwExternalNetworkReferences+xml'
     INSTANTIATE_VAPP_TEMPLATE_PARAMS = \
         'application/vnd.vmware.vcloud.instantiateVAppTemplateParams+xml'
+    GUEST_CUSTOMIZATION_SECTION = \
+        'application/vnd.vmware.vcloud.guestCustomizationSection+xml'
     LEASE_SETTINGS = 'application/vnd.vmware.vcloud.leaseSettingsSection+xml'
     MEDIA = 'application/vnd.vmware.vcloud.media+xml'
     MEDIA_INSERT_OR_EJECT_PARAMS = \

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -237,12 +237,12 @@ class VDC(object):
         template_networks = template_resource.xpath(
             '//ovf:NetworkSection/ovf:Network',
             namespaces={'ovf': NSMAP['ovf']})
-        assert len(template_networks) > 0
-        network_name_from_template = template_networks[0].get(
-            '{' + NSMAP['ovf'] + '}name')
-        if ((network is None) and (network_name_from_template != 'none')):
-            network = network_name_from_template
-
+        #        assert len(template_networks) > 0
+        if len(template_networks) > 0:
+            network_name_from_template = template_networks[0].get(
+                '{' + NSMAP['ovf'] + '}name')
+            if ((network is None) and (network_name_from_template != 'none')):
+                network = network_name_from_template
         # Find the network in vdc referred to by user, using
         # name of the network
         network_href = network_name = None

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -873,16 +873,20 @@ class VM(object):
 
     def power_on_and_force_recustomization(self):
         """Recustomize VM at power on.
+
         :return: an object containing EntityType.TASK XML data which represents
                     the asynchronous task that is force recustomize VM on
                     power on operation
+
         :rtype: lxml.objectify.ObjectifiedElement
         """
         return self.deploy(power_on=True, force_customization=True)
 
     def get_guest_customization_status(self):
-        """Get guest customization status
+        """Get guest customization status.
+
         :return: returns status of GC.
+
         :rtype: String
         """
         self.get_resource()
@@ -891,10 +895,12 @@ class VM(object):
         return gc_status_resource.GuestCustStatus
 
     def get_guest_customization_section(self):
-        """Get guest customization section
+        """Get guest customization section.
+
         :return: returns lxml.objectify.ObjectifiedElement resource: object
             containing EntityType.GUESTCUSTOMIZATIONSECTION XML data
             representing the guestcustomizationsection.
+
         :rtype: lxml.objectify.ObjectifiedElement
         """
         self.get_resource()
@@ -902,12 +908,15 @@ class VM(object):
         return self.client.get_resource(uri)
 
     def enable_guest_customization(self, is_enabled=False):
-        """Enable guest customization
+        """Enable guest customization.
+
         :param: bool is_enabled: if True, it will enable guest customization.
             If False, it will disable guest customization
+
         :return: returns lxml.objectify.ObjectifiedElement resource: object
             containing EntityType.GUESTCUSTOMIZATIONSECTION XML data
             representing the guestcustomizationsection.
+
         :rtype: lxml.objectify.ObjectifiedElement
         """
         self.get_resource()
@@ -915,5 +924,6 @@ class VM(object):
         if hasattr(gc_section, 'Enabled'):
             gc_section.Enabled = E.Enabled(is_enabled)
         uri = self.href + '/guestCustomizationSection/'
-        return self.client.put_resource(uri, gc_section,
-                                        EntityType.GUEST_CUSTOMIZATION_SECTION.value)
+        return self.client.\
+            put_resource(uri, gc_section,
+                         EntityType.GUEST_CUSTOMIZATION_SECTION.value)

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -870,3 +870,50 @@ class VM(object):
         return self.client.post_linked_resource(
             self.resource, RelationType.RECONFIGURE_VM, EntityType.VM.value,
             self.resource)
+
+    def power_on_and_force_recustomization(self):
+        """Recustomize VM at power on.
+        :return: an object containing EntityType.TASK XML data which represents
+                    the asynchronous task that is force recustomize VM on
+                    power on operation
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        return self.deploy(power_on=True, force_customization=True)
+
+    def get_guest_customization_status(self):
+        """Get guest customization status
+        :return: returns status of GC.
+        :rtype: String
+        """
+        self.get_resource()
+        uri = self.href + '/guestcustomizationstatus/'
+        gc_status_resource = self.client.get_resource(uri)
+        return gc_status_resource.GuestCustStatus
+
+    def get_guest_customization_section(self):
+        """Get guest customization section
+        :return: returns lxml.objectify.ObjectifiedElement resource: object
+            containing EntityType.GUESTCUSTOMIZATIONSECTION XML data
+            representing the guestcustomizationsection.
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        self.get_resource()
+        uri = self.href + '/guestCustomizationSection/'
+        return self.client.get_resource(uri)
+
+    def enable_guest_customization(self, is_enabled=False):
+        """Enable guest customization
+        :param: bool is_enabled: if True, it will enable guest customization.
+            If False, it will disable guest customization
+        :return: returns lxml.objectify.ObjectifiedElement resource: object
+            containing EntityType.GUESTCUSTOMIZATIONSECTION XML data
+            representing the guestcustomizationsection.
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        self.get_resource()
+        gc_section = self.get_guest_customization_section()
+        if hasattr(gc_section, 'Enabled'):
+            gc_section.Enabled = E.Enabled(is_enabled)
+        uri = self.href + '/guestCustomizationSection/'
+        return self.client.put_resource(uri, gc_section,
+                                        EntityType.GUEST_CUSTOMIZATION_SECTION.value)

--- a/system_tests/base_config.yaml
+++ b/system_tests/base_config.yaml
@@ -56,7 +56,7 @@ vcd:
 
   default_catalog_name: 'test-cat'
   default_template_file_name: 'test_vapp_template.ova'
-
+  default_template_vmtools_file_name: 'yVM_OS_with_VMTools.ova'
   default_vapp_name: 'test_vapp'
   default_vm_name: 'testvm1'
   default_media_name: 'pb1.iso'

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -76,6 +76,9 @@ class TestVM(BaseTestCase):
     _boot_delay_update = 60
     _enter_bios_setup_update = True
 
+    _test_vapp_vmtools_name = 'test_vApp_vmtools_' + str(uuid1())
+    _test_vapp_vmtools_vm_name = 'yVM'
+
     def test_0000_setup(self):
         """Setup the vms required for the other tests in this module.
 
@@ -125,6 +128,49 @@ class TestVM(BaseTestCase):
         TestVM._idisk = vdc.create_disk(name=self._idisk_name,
                                  size=self._idisk_size,
                                  description=self._idisk_description)
+
+        # Upload template with vm tools.
+        catalog_author_client = Environment.get_client_in_default_org(
+            CommonRoles.CATALOG_AUTHOR)
+        org_admin_client = Environment.get_client_in_default_org(
+            CommonRoles.ORGANIZATION_ADMINISTRATOR)
+        org = Environment.get_test_org(org_admin_client)
+        catalog_name = Environment.get_config()['vcd']['default_catalog_name']
+        catalog_items = org.list_catalog_items(catalog_name)
+        template_name = Environment.get_config()['vcd'][
+            'default_template_vmtools_file_name']
+        catalog_item_flag = False
+        for item in catalog_items:
+            if item.get('name').lower() == template_name.lower():
+                logger.debug('Reusing existing template ' +
+                             template_name)
+                catalog_item_flag = True
+                break
+        if not catalog_item_flag:
+            logger.debug('Uploading template ' + template_name +
+                         ' to catalog ' + catalog_name + '.')
+            org.upload_ovf(catalog_name=catalog_name, file_name=template_name)
+            # wait for the template import to finish in vCD.
+            catalog_item = org.get_catalog_item(
+                name=catalog_name, item_name=template_name)
+            template = catalog_author_client.get_resource(
+                catalog_item.Entity.get('href'))
+            catalog_author_client.get_task_monitor().wait_for_success(
+                task=template.Tasks.Task[0])
+        # Create Vapp with template of vmware tools
+        logger.debug('Creating vApp ' + TestVM._test_vapp_vmtools_name + '.')
+        TestVM._test_vapp_vmtools_href = create_customized_vapp_from_template(
+            client=TestVM._client,
+            vdc=vdc,
+            name=TestVM._test_vapp_vmtools_name,
+            catalog_name=catalog_name,
+            template_name=template_name)
+        self.assertIsNotNone(TestVM._test_vapp_href)
+        vapp = VApp(TestVM._client, href=TestVM._test_vapp_vmtools_href)
+        TestVM._test_vapp_vmtools = vapp
+        vm_resource = vapp.get_vm(TestVM._test_vapp_vmtools_vm_name)
+        TestVM._test_vapp_vmtools_vm_href = vm_resource.get('href')
+        self.assertIsNotNone(TestVM._test_vapp_vmtools_vm_href)
 
     def test_0010_list_vms(self):
         """Test the method VApp.get_all_vms().
@@ -590,7 +636,7 @@ class TestVM(BaseTestCase):
             get_task_monitor().wait_for_success(task=task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
-    def test_0170_customize_at_next_poer_on(self):
+    def test_0170_customize_at_next_power_on(self):
         """Test the method related to customize_at_next_power_on in vm.py.
         This test passes if customize at next power on operation is successful.
         """
@@ -599,6 +645,12 @@ class TestVM(BaseTestCase):
         vm = VM(TestVM._sys_admin_client, href=TestVM._test_vapp_first_vm_href)
         vm.reload()
         vm.customize_at_next_power_on()
+        task = vm.power_on()
+        TestVM._sys_admin_client. \
+            get_task_monitor().wait_for_success(task=task)
+        status = vm.get_guest_customization_status()
+        self.assertEqual(status, 'GC_PENDING')
+
 
     def test_0180_update_general_setting(self):
         """Test the method related to update general setting in vm.py.
@@ -636,24 +688,75 @@ class TestVM(BaseTestCase):
             get_task_monitor().wait_for_success(task=task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
+    def test_0190_enable_gc(self):
+        """Test the method related to enable_guest_customization in vm.py.
+        This test passes if enable GC operation is successful.
+        """
+        vm = VM(TestVM._sys_admin_client,
+                href=TestVM._test_vapp_vmtools_vm_href)
+        # Power off VM
+        task = vm.power_off()
+        TestVM._sys_admin_client. \
+            get_task_monitor().wait_for_success(task=task)
+        vm.reload()
+        task = vm.enable_guest_customization(is_enabled=True)
+        TestVM._sys_admin_client. \
+            get_task_monitor().wait_for_success(task=task)
+        vm.reload()
+        gc_section = vm.get_guest_customization_section()
+        self.assertTrue(gc_section.Enabled)
+
+    def test_0200_get_gc_status(self):
+        """Test the method related to get_guest_customization_status in vm.py.
+        This test passes if it gives guest customization status.
+        """
+        vm = VM(TestVM._sys_admin_client,
+                href=TestVM._test_vapp_vmtools_vm_href)
+
+        status = vm.get_guest_customization_status()
+        self.assertEqual(status, 'GC_PENDING')
+
+    def test_0210_poweron_and_force_recustomization(self):
+        """Test the method related to power_on_and_force_recustomization in
+        vm.py. This test passes if force customization at power on operation is
+        successful.
+        """
+        vm = VM(TestVM._sys_admin_client,
+                href=TestVM._test_vapp_vmtools_vm_href)
+        task = vm.power_off()
+        TestVM._sys_admin_client. \
+            get_task_monitor().wait_for_success(task=task)
+        task = vm.undeploy()
+        TestVM._sys_admin_client. \
+            get_task_monitor().wait_for_success(task=task)
+        vm.reload()
+        task = vm.power_on_and_force_recustomization()
+        result = TestVM._sys_admin_client. \
+            get_task_monitor().wait_for_success(task=task)
+        status = vm.get_guest_customization_status()
+        self.assertEqual(status, 'GC_PENDING')
+
     @developerModeAware
     def test_9998_teardown(self):
         """Delete the vApp created during setup.
-
         This test passes if the task for deleting the vApp succeed.
         """
         vapps_to_delete = []
         if TestVM._test_vapp_href is not None:
             vapps_to_delete.append(TestVM._test_vapp_name)
-
+            vapp = VApp(TestVM._client, href=TestVM._test_vapp_href)
+            if vapp.is_powered_on():
+                vapp.power_off()
         if TestVM._empty_vapp_href is not None:
             vapps_to_delete.append(TestVM._empty_vapp_name)
-
+        if TestVM._test_vapp_vmtools_href is not None:
+            vapps_to_delete.append(TestVM._test_vapp_vmtools_name)
+            vapp = VApp(TestVM._client, href=TestVM._test_vapp_vmtools_href)
+            if vapp.is_powered_on():
+                vapp.power_off()
         vdc = Environment.get_test_vdc(TestVM._sys_admin_client)
         vdc.delete_disk(name=self._idisk_name)
-
         vdc = Environment.get_test_vdc(TestVM._client)
-
         for vapp_name in vapps_to_delete:
             task = vdc.delete_vapp(name=vapp_name, force=True)
             result = TestVM._client.get_task_monitor().wait_for_success(task)

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -723,9 +723,11 @@ class TestVM(BaseTestCase):
         """
         vm = VM(TestVM._sys_admin_client,
                 href=TestVM._test_vapp_vmtools_vm_href)
-        task = vm.power_off()
-        TestVM._sys_admin_client. \
-            get_task_monitor().wait_for_success(task=task)
+
+        if vm.is_powered_on():
+            task = vm.power_off()
+            TestVM._sys_admin_client. \
+                get_task_monitor().wait_for_success(task=task)
         task = vm.undeploy()
         TestVM._sys_admin_client. \
             get_task_monitor().wait_for_success(task=task)
@@ -746,14 +748,23 @@ class TestVM(BaseTestCase):
             vapps_to_delete.append(TestVM._test_vapp_name)
             vapp = VApp(TestVM._client, href=TestVM._test_vapp_href)
             if vapp.is_powered_on():
-                vapp.power_off()
+                task = vapp.power_off()
+                TestVM._client.get_task_monitor().wait_for_success(task)
+                task = vapp.undeploy()
+                TestVM._client.get_task_monitor().wait_for_success(task)
+
         if TestVM._empty_vapp_href is not None:
             vapps_to_delete.append(TestVM._empty_vapp_name)
+
         if TestVM._test_vapp_vmtools_href is not None:
             vapps_to_delete.append(TestVM._test_vapp_vmtools_name)
             vapp = VApp(TestVM._client, href=TestVM._test_vapp_vmtools_href)
             if vapp.is_powered_on():
-                vapp.power_off()
+                task = vapp.power_off()
+                TestVM._client.get_task_monitor().wait_for_success(task)
+                task = vapp.undeploy()
+                TestVM._client.get_task_monitor().wait_for_success(task)
+
         vdc = Environment.get_test_vdc(TestVM._sys_admin_client)
         vdc.delete_disk(name=self._idisk_name)
         vdc = Environment.get_test_vdc(TestVM._client)


### PR DESCRIPTION
VP-2021: [PySDK]Power on with force Recustomization for a VM
VP-2676: [PYSDK] Get GuestCustomizationSectionStatus
VP-2689: [PYSDK] Enable GC

This CLN contains above three functionalities. One new OVA file with OS
is added for guest customization related test cases. VP-2021 has
dependency on VP-2676 and VP-2689. All three stories test cases are
added.

Testing Done:
Three test cases are added for above stories in vm_tests.py. Validation
for customize at next power on and power on and force customization is
still not correct by API behavior.It will be changed in next gc related
check-ins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/559)
<!-- Reviewable:end -->
