### PR TITLE
VCDA-1081:[pyvcloud] Add support to list/add/remove vdc compute policy from org VDC

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -411,6 +411,8 @@ class EntityType(Enum):
     VAPP_TEMPLATE = 'application/vnd.vmware.vcloud.vAppTemplate+xml'
     VDC = 'application/vnd.vmware.vcloud.vdc+xml'
     VDC_ADMIN = 'application/vnd.vmware.admin.vdc+xml'
+    VDC_COMPUTE_POLICY_REFERENCES = \
+        "application/vnd.vmware.vcloud.vdcComputePolicyReferences+xml"
     VDC_REFERENCES = 'application/vnd.vmware.admin.vdcReferences+xml'
     VDCS_PARAMS = 'application/vnd.vmware.admin.createVdcParams+xml'
     VIM_SERVER_REFS = 'application/vnd.vmware.admin.vmwVimServerReferences+xml'


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- Support added to handle list, add, remove vdc compute policy from org vDC
- Add and remove methods accept "href" as param. This "href" is an unique identifier of a policy generated by /cloudapi/computePolicies. 
- Tested and verified with scripts that uses these new API and Postman rest client.
- NOTE: Since these methods need a valid unique "href" generated by /cloudapi/ end point and it is not supported by pyvcloud, system tests are skipped for this PR.

@rocknes @rajeshk2013 @andrew-ni @harshneelmore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/560)
<!-- Reviewable:end -->
