### PR TITLE
VP-1908, VP-1921, VP-2633

### DIFF
--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -1004,6 +1004,37 @@ class TestVApp(BaseTestCase):
         result = TestVApp._client.get_task_monitor().wait_for_success(task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
+    def test_0200_create_vapp_network_from_ovdc_network(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._sys_admin_client,
+            vapp_name=TestVApp._customized_vapp_name)
+        task = vapp.create_vapp_network_from_ovdc_network(
+            TestVApp._ovdc_network_name)
+        result = TestVApp._sys_admin_client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp.reload()
+        vapp_network_href = find_link(
+            resource=vapp.resource,
+            rel=RelationType.DOWN,
+            media_type=EntityType.vApp_Network.value,
+            name=TestVApp._ovdc_network_name).href
+        self.assertIsNotNone(vapp_network_href)
+
+    def test_0201_enable_fence_mode(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._sys_admin_client,
+            vapp_name=TestVApp._customized_vapp_name)
+        task = vapp.enable_fence_mode()
+        result = TestVApp._sys_admin_client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp.reload()
+        task = vapp.delete_vapp_network(TestVApp._ovdc_network_name)
+        result = TestVApp._sys_admin_client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
     @developerModeAware
     def test_9998_teardown(self):
         """Test the  method vdc.delete_vapp().


### PR DESCRIPTION
VP-1908 : [PySDK] Create vApp network using orgVdc network
VP-1921: [PySDK] Enable vApp Fence
VP-2633: [PySDK] Enable disble download in vapp	


This CLN contains Create vApp network using orgVdc network, Enable vApp Fence and  Enable disble download in vapp.
disable_download(),  create_vapp_network_from_ovdc_network() and enable_fence_mode() methods are exposed in vapp.py class and corresponding test case added.
Testing Done:
test methods test_0200_create_vapp_network_from_ovdc_network() and test_0201_enable_fence_mode are added in test class vapp.py.
It is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/561)
<!-- Reviewable:end -->
