### PR TITLE
VP-2638: [PySDK]show Lease setting in vapp

### DIFF
--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -279,6 +279,27 @@ class VApp(object):
             self.resource.get('href') + '/leaseSettingsSection/', new_section,
             EntityType.LEASE_SETTINGS.value)
 
+    def get_lease(self):
+        """Fetch lease settings data of the vApp.
+
+        :return: an dictionary containing LEASE_SETTINGS Data of the vApp.
+
+        :rtype: dict
+        """
+        self.get_resource()
+        lease_setting = self.resource.LeaseSettingsSection
+        result = {}
+        if hasattr(lease_setting, 'DeploymentLeaseInSeconds'):
+            result['DeploymentLeaseInSeconds'] = \
+                lease_setting.DeploymentLeaseInSeconds
+        if hasattr(lease_setting, 'StorageLeaseInSeconds'):
+            result['StorageLeaseInSeconds'] = \
+                lease_setting.StorageLeaseInSeconds
+        if hasattr(lease_setting, 'DeploymentLeaseInSeconds'):
+            result['StorageLeaseExpiration'] = \
+                lease_setting.StorageLeaseExpiration
+        return result
+
     def change_owner(self, href):
         """Change the ownership of vApp to a given user.
 

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -295,7 +295,7 @@ class VApp(object):
         if hasattr(lease_setting, 'StorageLeaseInSeconds'):
             result['StorageLeaseInSeconds'] = \
                 lease_setting.StorageLeaseInSeconds
-        if hasattr(lease_setting, 'DeploymentLeaseInSeconds'):
+        if hasattr(lease_setting, 'StorageLeaseExpiration'):
             result['StorageLeaseExpiration'] = \
                 lease_setting.StorageLeaseExpiration
         return result

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -1004,6 +1004,37 @@ class TestVApp(BaseTestCase):
         result = TestVApp._client.get_task_monitor().wait_for_success(task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
+    def test_0200_create_vapp_network_from_ovdc_network(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._sys_admin_client,
+            vapp_name=TestVApp._customized_vapp_name)
+        task = vapp.create_vapp_network_from_ovdc_network(
+            TestVApp._ovdc_network_name)
+        result = TestVApp._sys_admin_client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp.reload()
+        vapp_network_href = find_link(
+            resource=vapp.resource,
+            rel=RelationType.DOWN,
+            media_type=EntityType.vApp_Network.value,
+            name=TestVApp._ovdc_network_name).href
+        self.assertIsNotNone(vapp_network_href)
+
+    def test_0201_enable_fence_mode(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._sys_admin_client,
+            vapp_name=TestVApp._customized_vapp_name)
+        task = vapp.enable_fence_mode()
+        result = TestVApp._sys_admin_client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp.reload()
+        task = vapp.delete_vapp_network(TestVApp._ovdc_network_name)
+        result = TestVApp._sys_admin_client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
     @developerModeAware
     def test_9998_teardown(self):
         """Test the  method vdc.delete_vapp().

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -559,7 +559,7 @@ class TestVApp(BaseTestCase):
         result = vapp.get_lease()
         self.assertEqual(result['DeploymentLeaseInSeconds'],
                          TestVApp._empty_vapp_runtime_lease)
-        self.assertEqual(result['DeploymentLeaseInSeconds'],
+        self.assertEqual(result['StorageLeaseInSeconds'],
                          TestVApp._empty_vapp_storage_lease)
 
     def test_0090_change_vapp_owner(self):

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -552,6 +552,16 @@ class TestVApp(BaseTestCase):
             wait_for_success(task=task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
+    def test_0081_get_lease(self):
+        vapp_name = TestVApp._empty_vapp_name
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._client, vapp_name=vapp_name)
+        result = vapp.get_lease()
+        self.assertEqual(result['DeploymentLeaseInSeconds'],
+                         TestVApp._empty_vapp_runtime_lease)
+        self.assertEqual(result['DeploymentLeaseInSeconds'],
+                         TestVApp._empty_vapp_storage_lease)
+
     def test_0090_change_vapp_owner(self):
         """Test the method vapp.change_owner().
 


### PR DESCRIPTION
VP-2638: [PySDK]show Lease setting in vapp.

This CLN contains get lease setting details in vapp.
get_lease() methods is exposed in vapp.py class and corresponding test case added.
Testing Done:
test methods test_0081_get_lease()  is added in test class vapp_tests.py.
It is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/562)
<!-- Reviewable:end -->
