### PR TITLE
[VCDA-1088] pyvcloud: Support for add, remove compute policy to vm(s) of vapp-template

### DIFF
--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -47,6 +47,7 @@ from pyvcloud.vcd.metadata import Metadata
 from pyvcloud.vcd.system import System
 from pyvcloud.vcd.utils import get_admin_href
 from pyvcloud.vcd.utils import get_safe_members_in_tar_file
+from pyvcloud.vcd.utils import retrieve_compute_policy_id_from_href
 from pyvcloud.vcd.utils import to_dict
 
 # Uptil pyvcloud v20.0.0 1 MB was the default chunk size,
@@ -1770,3 +1771,100 @@ class Org(object):
                 catalog_name, item_name))
         return metadata.remove_metadata(key=key, domain=domain,
                                         use_admin_endpoint=False)
+
+    def get_vapp_template_href(self, catalog_name, catalog_item_name):
+        """Get href of the template resource.
+
+        :param str catalog_name: name of the catalog that has the template
+        :param catalog_item_name: name of the catalog item
+
+        :return: href of the the vapp template resource
+
+        :rtype: str
+        """
+        catalog_item = self.get_catalog_item(catalog_name, catalog_item_name)
+        return catalog_item.Entity.get('href')
+
+    def assign_compute_policy_to_vapp_template_vms(self,
+                                                   catalog_name,
+                                                   catalog_item_name,
+                                                   compute_policy_href):
+        """Add compute policy identified by href to all vms of vapp template.
+
+        :param str catalog_name: catalog name that contains the catalog item
+        :param str catalog_item_name: name of the catalog item
+        :param str compute_policy_href: href of the compute policy
+
+        :return: an object of type EntityType.TASK XML which represents
+        the asynchronous task that is updating virtual application template.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+
+        :raises: EntityNotFoundException: if the vm cannot be located.
+        """
+        policy_id = retrieve_compute_policy_id_from_href(compute_policy_href)
+        template_resource_href = self.get_vapp_template_href(catalog_name,
+                                                             catalog_item_name)
+        template_resource = self.client.get_resource(template_resource_href)
+        if hasattr(template_resource, 'Children') and \
+                hasattr(template_resource.Children, 'Vm'):
+            vms = template_resource.Children.Vm
+            for vm in vms:
+                if hasattr(vm, 'VdcComputePolicy'):
+                    vm.VdcComputePolicy.set('href', compute_policy_href)
+                    vm.VdcComputePolicy.set('id', policy_id)
+                else:
+                    date_created_node = vm.\
+                        find('{http://www.vmware.com/vcloud/v1.5}DateCreated')
+                    policy_element = E.VdcComputePolicy()
+                    policy_element.set('href', compute_policy_href)
+                    policy_element.set('id', policy_id)
+                    date_created_node.addprevious(policy_element)
+
+            return self.client.put_resource(
+                template_resource_href,
+                template_resource,
+                media_type=EntityType.VAPP_TEMPLATE.value)
+
+        raise EntityNotFoundException(f"Vm element not found")
+
+    def remove_compute_policy_from_vapp_template_vms(self,
+                                                     catalog_name,
+                                                     catalog_item_name,
+                                                     compute_policy_href):
+        """Remove compute policy from all vms of the vapp template.
+
+        :param str catalog_name: catalog name that contains the catalog item
+        :param str catalog_item_name: name of the catalog item
+        :param str compute_policy_href: href of the compute policy
+
+        :return: an object of type EntityType.TASK XML which represents
+        the asynchronous task that is updating virtual application template.
+
+        If the given compute policy id is not found, then no TASK XML will be
+        returned.
+
+        :rtype: lxml.objectify.ObjectifiedElement.
+
+        :raises: EntityNotFoundException: if the compute policy not found
+        """
+        policy_id = retrieve_compute_policy_id_from_href(compute_policy_href)
+        template_resource_href = self.get_vapp_template_href(catalog_name,
+                                                             catalog_item_name)
+        template_resource = self.client.get_resource(template_resource_href)
+        is_template_updated = False
+        if hasattr(template_resource, 'Children') and \
+                hasattr(template_resource.Children, 'Vm'):
+            vms = template_resource.Children.Vm
+            for vm in vms:
+                if hasattr(vm, 'VdcComputePolicy'):
+                    vm_compute_policy_id = vm.VdcComputePolicy.get('id')
+                    if policy_id == vm_compute_policy_id:
+                        vm.remove(vm.VdcComputePolicy)
+                        is_template_updated = True
+
+        if is_template_updated:
+            return self.client.put_resource(
+                template_resource_href,
+                template_resource,
+                media_type=EntityType.VAPP_TEMPLATE.value)

--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -910,3 +910,15 @@ def build_network_url_from_gateway_url(gateway_href):
         return network_url.replace(_GATEWAY_ADMIN_API_URL, _NETWORK_URL)
 
     return None
+
+
+def retrieve_compute_policy_id_from_href(href):
+    """Extract compute policy id from href.
+
+    :param str href: URI of the compute policy
+
+    :return: compute policy id
+
+    :rtype: str
+    """
+    return href.split('/')[-1]

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -42,6 +42,7 @@ from pyvcloud.vcd.utils import cidr_to_netmask
 from pyvcloud.vcd.utils import get_admin_href
 from pyvcloud.vcd.utils import is_admin
 from pyvcloud.vcd.utils import netmask_to_cidr_prefix_len
+from pyvcloud.vcd.utils import retrieve_compute_policy_id_from_href
 
 
 class VDC(object):
@@ -2086,7 +2087,7 @@ class VDC(object):
         :rtype: lxml.objectify.ObjectifiedElement
         """
         policy_references = self._fetch_compute_policies()
-        policy_id = self._retrieve_compute_policy_id_from_href(href)
+        policy_id = retrieve_compute_policy_id_from_href(href)
         policy_reference_element = E.VdcComputePolicyReference()
         policy_reference_element.set('href', href)
         policy_reference_element.set('id', policy_id)
@@ -2110,7 +2111,7 @@ class VDC(object):
             be located.
         """
         policy_references = self._fetch_compute_policies()
-        policy_id = self._retrieve_compute_policy_id_from_href(href)
+        policy_id = retrieve_compute_policy_id_from_href(href)
         for policy_reference in policy_references.VdcComputePolicyReference:
             if policy_id == policy_reference.get('id'):
                 policy_references.remove(policy_reference)
@@ -2120,14 +2121,3 @@ class VDC(object):
                     policy_references)
         raise EntityNotFoundException(f"VdcComputePolicyReference "
                                       f"with href '{href}' not found")
-
-    def _retrieve_compute_policy_id_from_href(self, href):
-        """Extract compute policy id from href.
-
-        :param str href: URI of the compute policy
-
-        :return: compute policy id
-
-        :rtype: str
-        """
-        return href.split('/')[-1]


### PR DESCRIPTION

Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

-  Support added to add or remove a given compute policy to all vms of given vapp-template in a catalog.
-  Add and remove methods accept "href" as param. This "href" is an unique identifier of a compute policy generated by /cloudapi/computePolicies.
- Tested and verified with python script and Postman REST client
    - Test for add, remove
    - Test to see right exceptions are thrown while adding unknown policy, existing policy
@rocknes @rajeshk2013 @andrew-ni @harshneelmore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/563)
<!-- Reviewable:end -->
