### PR TITLE
VP-2642, VP-2643

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -43,6 +43,8 @@ from pyvcloud.vcd.exceptions import AccessForbiddenException, \
 SIZE_1MB = 1024 * 1024
 
 NSMAP = {
+    'ns10':
+    'http://www.vmware.com/vcloud/v1.5',
     'ovf':
     'http://schemas.dmtf.org/ovf/envelope/1',
     'ovfenv':
@@ -400,6 +402,7 @@ class EntityType(Enum):
     RIGHT = 'application/vnd.vmware.admin.right+xml'
     RIGHTS = 'application/vnd.vmware.admin.rights+xml'
     SNAPSHOT_CREATE = 'application/vnd.vmware.vcloud.createSnapshotParams+xml'
+    STARTUP_SECTION = 'application/vnd.vmware.vcloud.startupSection+xml'
     SYSTEM_SETTINGS = 'application/vnd.vmware.admin.systemSettings+xml'
     TASK = 'application/vnd.vmware.vcloud.task+xml'
     TASKS_LIST = 'application/vnd.vmware.vcloud.tasksList+xml'

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1791,3 +1791,48 @@ class VApp(object):
         return self.client.put_linked_resource(
             self.resource.NetworkConfigSection, RelationType.EDIT,
             EntityType.NETWORK_CONFIG_SECTION.value, network_config_section)
+
+    def update_startup_section(self,
+                               vm_name,
+                               order=None,
+                               start_action=None,
+                               start_delay=None,
+                               stop_action=None,
+                               stop_delay=None):
+        """Update startup section of vapp.
+
+        :param str vm_name: name of VM in App.
+        :param int order: start order of vm.
+        :param str start_action: action on VM on start of App.
+        :param int start_delay: start delay of vm.
+        :param str stop_action: action on VM on stop of App.
+        :param int stop_delay: stop delay of vm.
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vApp startup section.
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        startup_section = self.resource.xpath(
+            'ovf:StartupSection', namespaces=NSMAP)
+        startup_section_href = startup_section[0].get('{' + NSMAP['ns10'] +
+                                                      '}href')
+        startup_section_res = self.client.get_resource(startup_section_href)
+        items = startup_section_res.xpath('ovf:Item', namespaces=NSMAP)
+        for item in items:
+            if item.get('{' + NSMAP['ovf'] + '}id') == vm_name:
+                if order is not None:
+                    item.set('{' + NSMAP['ovf'] + '}order', str(order))
+                if start_action is not None:
+                    item.set('{' + NSMAP['ovf'] + '}startAction', start_action)
+                if start_delay is not None:
+                    item.set('{' + NSMAP['ovf'] + '}startDelay',
+                             str(start_delay))
+                if stop_action is not None:
+                    item.set('{' + NSMAP['ovf'] + '}stopAction', stop_action)
+                if stop_delay is not None:
+                    item.set('{' + NSMAP['ovf'] + '}stopDelay',
+                             str(stop_delay))
+        return self.client.put_linked_resource(
+            startup_section_res,
+            rel=RelationType.EDIT,
+            media_type=EntityType.STARTUP_SECTION.value,
+            contents=startup_section_res)

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -1045,6 +1045,16 @@ class TestVApp(BaseTestCase):
         ).wait_for_success(task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
+    def test_0210_update_startup_section(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._sys_admin_client,
+            vapp_name=TestVApp._customized_vapp_name)
+        task = vapp.update_startup_section('custom-vm', 4, 'powerOn', 4,
+                                           'powerOff', 4)
+        result = TestVApp._sys_admin_client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
     @developerModeAware
     def test_9998_teardown(self):
         """Test the  method vdc.delete_vapp().


### PR DESCRIPTION
VP-2642 [PySDK]Start time action in vapp
VP-2643 [PySDK]Stop time action in vapp

This CLN contains update startup section in vapp.
update_startup_section() methods is exposed in vapp.py class and corresponding test case added.
Testing Done:
test methods test_0210_update_startup_section() is added in test class vapp_tests.py.
It is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/566)
<!-- Reviewable:end -->
