### PR TITLE
VP-2637, VP-2720, VP-2725

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -381,6 +381,7 @@ class EntityType(Enum):
     ORG_RIGHTS = 'application/vnd.vmware.admin.org.rights+xml'
     ORG_VDC_NETWORK = 'application/vnd.vmware.vcloud.orgVdcNetwork+xml'
     OWNER = 'application/vnd.vmware.vcloud.owner+xml'
+    PRODUCT_SECTIONS = 'application/vnd.vmware.vcloud.productSections+xml'
     PROVIDER_VDC = 'application/vnd.vmware.admin.providervdc+xml'
     PROVIDER_VDC_PARAMS = \
         'application/vnd.vmware.admin.createProviderVdcParams+xml'

--- a/system_tests/vapp_tests.py
+++ b/system_tests/vapp_tests.py
@@ -1055,6 +1055,30 @@ class TestVApp(BaseTestCase):
         ).wait_for_success(task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
+    def test_0220_get_startup_section(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._sys_admin_client,
+            vapp_name=TestVApp._customized_vapp_name)
+        result = vapp.get_startup_section()
+        self.assertNotEqual(len(result), 0)
+        self.assertEqual(result[0]['Id'], TestVApp._customized_vapp_vm_name)
+
+    def test_0230_update_product_section(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._sys_admin_client,
+            vapp_name=TestVApp._customized_vapp_name)
+        task = vapp.update_product_section(key='admin', value='admin')
+        result = TestVApp._sys_admin_client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0240_get_product_sections(self):
+        vapp = Environment.get_vapp_in_test_vdc(
+            client=TestVApp._sys_admin_client,
+            vapp_name=TestVApp._customized_vapp_name)
+        result = vapp.get_product_sections()
+        self.assertNotEqual(len(result), 0)
+
     @developerModeAware
     def test_9998_teardown(self):
         """Test the  method vdc.delete_vapp().


### PR DESCRIPTION
VP-2637:[PySDK]show product section in vapp
VP-2720:[PySDK]show startup section of vapp 
VP-2725:[PySDK]update product section in vapp

This CLN contains show product section, show startup section and update product section of Vapp.

get_startup_section(), get_product_sections() and update_product_section methods are exposed in vapp.py class and corresponding test case added.
Testing Done:
test methods test_0220_get_startup_section(), test_0230_update_product_section() and test_0240_get_product_sections() are added in test class vapp_tests.py.
It is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/568)
<!-- Reviewable:end -->
