### PR TITLE
VP-2624: [PYSDK] get compliance result

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -338,6 +338,7 @@ class EntityType(Enum):
     CLONE_VAPP_PARAMS = 'application/vnd.vmware.vcloud.cloneVAppParams+xml'
     COMPOSE_VAPP_PARAMS = \
         'application/vnd.vmware.vcloud.composeVAppParams+xml'
+    COMPLIANCE_RESULT = 'application/vnd.vmware.vm.complianceResult+xml'
     CONTROL_ACCESS_PARAMS = 'application/vnd.vmware.vcloud.controlAccess+xml'
     DEFAULT_CONTENT_TYPE = 'application/*+xml'
     DEPLOY = 'application/vnd.vmware.vcloud.deployVAppParams+xml'

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -1036,3 +1036,16 @@ class VM(object):
                     ncard_count = ncard_count + 1
 
         return vhs_info
+
+    def get_compliance_result(self):
+        """Get compliance result of a VM.
+
+        :return: an object containing EntityType.ComplianceResult XML data
+                     which contains compliance status of VM
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        self.get_resource()
+        return self.client. \
+            get_linked_resource(self.resource, rel=RelationType.DOWN,
+                                media_type=EntityType.COMPLIANCE_RESULT.value)

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -688,8 +688,13 @@ class TestVM(BaseTestCase):
     def test_0220_list_virtual_harware_section(self):
         vm = VM(TestVM._client, href=TestVM._test_vapp_first_vm_href)
         dict = vm.list_virtual_hardware_section(is_disk=True, is_media=True,
-                                                  is_networkCards=True)
+                                                is_networkCards=True)
         self.assertTrue(len(dict) > 0)
+
+    def test_0230_get_compliance_result(self):
+        vm = VM(TestVM._sys_admin_client, href=TestVM._test_vapp_first_vm_href)
+        result = vm.get_compliance_result()
+        self.assertEqual(result.ComplianceStatus,'UNKNOWN')
 
     @developerModeAware
     def test_9998_teardown(self):


### PR DESCRIPTION
VP-2624: [PYSDK] get compliance result

This CLN contains functionality to get compliance result. It calls VCD
GET API for complianceResult.

Testing Done:
test method test_0230_get_compliance_result is added in vm_tests.py
file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/569)
<!-- Reviewable:end -->
