### PR TITLE
VP-2634,VP-2728,VP-2730: List VM Metrics

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -199,6 +199,7 @@ class RelationType(Enum):
     INSERT_MEDIA = 'media:insertMedia'
     INSTALL_VMWARE_TOOLS = 'installVmwareTools'
     LINK_TO_TEMPLATE = 'linkToTemplate'
+    METRICS = 'metrics'
     MIGRATE_VMS = 'migrateVms'
     MODIFY_FORM_FACTOR = 'edgeGateway:modifyFormFactor'
     NEXT_PAGE = 'nextPage'
@@ -340,6 +341,8 @@ class EntityType(Enum):
         'application/vnd.vmware.vcloud.composeVAppParams+xml'
     COMPLIANCE_RESULT = 'application/vnd.vmware.vm.complianceResult+xml'
     CONTROL_ACCESS_PARAMS = 'application/vnd.vmware.vcloud.controlAccess+xml'
+    CURRENT_USAGE = \
+        'application/vnd.vmware.vcloud.metrics.currentUsageSpec+xml'
     DEFAULT_CONTENT_TYPE = 'application/*+xml'
     DEPLOY = 'application/vnd.vmware.vcloud.deployVAppParams+xml'
     DISK = 'application/vnd.vmware.vcloud.disk+xml'
@@ -362,6 +365,8 @@ class EntityType(Enum):
         'application/vnd.vmware.vcloud.instantiateVAppTemplateParams+xml'
     GUEST_CUSTOMIZATION_SECTION = \
         'application/vnd.vmware.vcloud.guestCustomizationSection+xml'
+    HISTORIC_USAGE = \
+        'application/vnd.vmware.vcloud.metrics.historicUsageSpec+xml'
     LEASE_SETTINGS = 'application/vnd.vmware.vcloud.leaseSettingsSection+xml'
     MEDIA = 'application/vnd.vmware.vcloud.media+xml'
     MEDIA_INSERT_OR_EJECT_PARAMS = \

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -1049,3 +1049,76 @@ class VM(object):
         return self.client. \
             get_linked_resource(self.resource, rel=RelationType.DOWN,
                                 media_type=EntityType.COMPLIANCE_RESULT.value)
+
+    def list_all_current_metrics(self):
+        """List current metrics of a VM.
+
+        :return: dict which contains current metrics of VM
+
+        :rtype: dict
+        """
+        metrics_info = {}
+        self.get_resource()
+        metrics_list = self.client. \
+            get_linked_resource(self.resource, rel=RelationType.DOWN,
+                                media_type=EntityType.CURRENT_USAGE.value)
+        metric_count = 0
+        for metric in metrics_list.Metric:
+            metrics_info['metric_name' + str(metric_count)] = metric. \
+                get('name')
+            metrics_info['metric_unit' + str(metric_count)] = metric. \
+                get('unit')
+            metrics_info['metric_value' + str(metric_count)] = metric.get(
+                'value')
+            metric_count = metric_count + 1
+        return metrics_info
+
+    def list_current_metrics_subset(self, metric_pattern=None):
+        """List current metrics subset of a VM.
+
+        :return: dict which contains current metrics subset of VM
+
+        :rtype: dict
+        """
+        metrics_info = {}
+        self.get_resource()
+        current_usage_spec = E.CurrentUsageSpec(
+            E.MetricPattern(metric_pattern))
+        metrics_list = self.client. \
+            post_linked_resource(self.resource, rel=RelationType.METRICS,
+                                 media_type=EntityType.CURRENT_USAGE.value,
+                                 contents=current_usage_spec)
+
+        metric_count = 0
+        for metric in metrics_list.Metric:
+            metrics_info['metric_name' + str(metric_count)] = metric. \
+                get('name')
+            metrics_info['metric_unit' + str(metric_count)] = metric. \
+                get('unit')
+            metrics_info['metric_value' + str(metric_count)] = metric.get(
+                'value')
+            metric_count = metric_count + 1
+        return metrics_info
+
+    def list_all_historic_metrics(self):
+        """List historic metrics of a VM.
+
+        :return: dict which contains historic metrics of VM
+
+        :rtype: dict
+        """
+        metrics_info = {}
+        self.get_resource()
+        metrics_list = self.client. \
+            get_linked_resource(self.resource, rel=RelationType.DOWN,
+                                media_type=EntityType.HISTORIC_USAGE.value)
+        metric_count = 0
+        for metric in metrics_list.MetricSeries:
+            metrics_info['metric_name' + str(metric_count)] = metric. \
+                get('name')
+            metrics_info['expected_interval' + str(metric_count)] = metric. \
+                get('expectedInterval')
+            metrics_info['metric_unit' + str(metric_count)] = metric.get(
+                'unit')
+            metric_count = metric_count + 1
+        return metrics_info

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -696,6 +696,16 @@ class TestVM(BaseTestCase):
         result = vm.get_compliance_result()
         self.assertEqual(result.ComplianceStatus,'UNKNOWN')
 
+    def test_0240_list_all_current_metrics(self):
+        vm = VM(TestVM._sys_admin_client, href=TestVM._test_vapp_first_vm_href)
+        dict = vm.list_all_current_metrics()
+        self.assertTrue(len(dict) > 0)
+
+    def test_0250_list_subset_current_metrics(self):
+        vm = VM(TestVM._sys_admin_client, href=TestVM._test_vapp_first_vm_href)
+        dict = vm.list_current_metrics_subset(metric_pattern='*.average')
+        self.assertTrue(len(dict) > 0)
+
     @developerModeAware
     def test_9998_teardown(self):
         """Delete the vApp created during setup.


### PR DESCRIPTION
VP-2634: [PYSDK] Get current metrics
VP-2728: [PYSDK] List subset of current metrics
VP-2730: [PYSDK] List historic metrics

This CLN contains listing of current and historic metrics of VM.

Testing Done:
Test method test_0240_list_all_current_metrics and
test_0250_list_subset_current_metrics added for current metrics. For
historic metrics, we need VM monitoring set-up which is not part of test
lab setup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/570)
<!-- Reviewable:end -->
