### PR TITLE
VP-2051: [PySDK] relocate

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -214,6 +214,7 @@ class RelationType(Enum):
     RECOMPOSE = 'recompose'
     RECONFIGURE_VM = 'reconfigureVm'
     RELOAD_FROM_VC = 'reloadFromVc'
+    RELOCATE = 'relocate'
     REMOVE = 'remove'
     REPAIR = 'repair'
     RIGHTS = 'rights'
@@ -343,6 +344,7 @@ class EntityType(Enum):
     CONTROL_ACCESS_PARAMS = 'application/vnd.vmware.vcloud.controlAccess+xml'
     CURRENT_USAGE = \
         'application/vnd.vmware.vcloud.metrics.currentUsageSpec+xml'
+    DATASTORE_REFERENCES = 'application/vnd.vmware.admin.datastoreList+xml'
     DEFAULT_CONTENT_TYPE = 'application/*+xml'
     DEPLOY = 'application/vnd.vmware.vcloud.deployVAppParams+xml'
     DISK = 'application/vnd.vmware.vcloud.disk+xml'
@@ -401,6 +403,7 @@ class EntityType(Enum):
     RECORDS = 'application/vnd.vmware.vcloud.query.records+xml'
     REGISTER_VC_SERVER_PARAMS = \
         'application/vnd.vmware.admin.registerVimServerParams+xml'
+    RELOCATE_PARAMS = 'application/vnd.vmware.vcloud.relocateVmParams+xml'
     RESOURCE_POOL_LIST = \
         'application/vnd.vmware.admin.resourcePoolList+xml'
     RES_POOL_SET_UPDATE_PARAMS = \

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -1149,3 +1149,20 @@ class VM(object):
                     get('value')
                 metric_count = metric_count + 1
         return metrics_info
+
+    def relocate(self, datastore_href):
+        """Relocate VM to other datastore.
+
+        :param: datastore href for VM relocation
+
+        :return: an object containing EntityType.TASK XML data which represents
+                    the asynchronous task that is relocating VM.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        vm_resource = self.get_resource()
+        relocate_params = E.RelocateParams(E.Datastore(href=datastore_href))
+        return self.client. \
+            post_linked_resource(vm_resource, RelationType.RELOCATE,
+                                 EntityType.RELOCATE_PARAMS.value,
+                                 relocate_params)

--- a/system_tests/datastore_tests.py
+++ b/system_tests/datastore_tests.py
@@ -1,0 +1,45 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2014-2019 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.environment import Environment
+
+from pyvcloud.vcd.platform import Platform
+
+class TestDatastore(BaseTestCase):
+    """Test datastore functionalities implemented in pyvcloud."""
+    # All tests in this module should be run as System Administrator.
+
+    def test_0000_setup(self):
+        TestDatastore._client = Environment.get_sys_admin_client()
+
+    def test_0015_list_datastores(self):
+        """List all datastores
+        Invokes the list_datastores of the platform.
+        """
+        platform = Platform(client=TestDatastore._client)
+        datastore_list = platform.list_datastores()
+        # Verify
+        self.assertTrue(len(datastore_list) > 0)
+
+    def test_0098_teardown(self):
+        return
+
+    def test_0099_cleanup(self):
+        """Release all resources held by this object for testing purposes."""
+        TestDatastore._client.logout()
+
+    if __name__ == '__main__':
+        unittest.main()


### PR DESCRIPTION
VP-2051: [PySDK] relocate

This CLN contains functionality to relocate VM to other datastore. It
calls POST API of relocate for VM.

Testing Done:
Test method test_0260_relocate is added to test the functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/572)
<!-- Reviewable:end -->
