### PR TITLE
VP-2652, VP-2655, VP-2640, VP-2642, VP-2778

### DIFF
--- a/pyvcloud/vcd/vapp_firewall.py
+++ b/pyvcloud/vcd/vapp_firewall.py
@@ -44,3 +44,214 @@ class VappFirewall(VappServices):
         return self.client.put_linked_resource(
             self.resource, RelationType.EDIT, EntityType.vApp_Network.value,
             self.resource)
+
+    def set_default_action(self, action='drop', log_action=True):
+        """Set default action on firewall services to vApp network.
+
+        :param string action: Default action on firewall service drop/allow.
+        :param bool log_action: True for enable and False for Disable.
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vApp network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        :raises: InvalidParameterException: Enable firewall service failed as
+            given network's connection is not routed
+        """
+        self._get_resource()
+        fence_mode = self.resource.Configuration.FenceMode
+        if fence_mode != 'natRouted':
+            raise InvalidParameterException(
+                "Enable firewall service failed as given network's connection "
+                "is not routed")
+        firewall_service = self.resource.Configuration.Features.FirewallService
+        firewall_service.DefaultAction = E.DefaultAction(action)
+        firewall_service.LogDefaultAction = E.LogDefaultAction(log_action)
+        return self.client.put_linked_resource(
+            self.resource, RelationType.EDIT, EntityType.vApp_Network.value,
+            self.resource)
+
+    def add_firewall_rule(self, name, is_enabled=False, policy='drop',
+                          protocols=['Any'], source_port_range='Any',
+                          source_ip='Any', destination_port_range='Any',
+                          destination_ip='Any', enable_logging=False):
+        """Add firewall rule on firewall services to vApp network.
+
+        :param str name: name of firewall rule.
+        :param str policy: policy on firewall rule.
+        :param list protocols: list of protocols on firewall rule.
+        :param str source_port_range: source port range for firewall rule.
+        :param str source_ip: source IP.
+        :param str destination_port_range:destination port range for firewall
+            rule.
+        :param str destination_ip: destination IP.
+        :param str enable_logging: enable logging on firewall rule.
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vApp network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        :raises: InvalidParameterException: Enable firewall service failed as
+            given network's connection is not routed
+        """
+        self._get_resource()
+        fence_mode = self.resource.Configuration.FenceMode
+        if fence_mode != 'natRouted':
+            raise InvalidParameterException(
+                "Enable firewall service failed as given network's connection "
+                "is not routed")
+        firewall_service = self.resource.Configuration.Features.FirewallService
+        firewall_rule = E.FirewallRule()
+        firewall_rule.append(E.IsEnabled(is_enabled))
+        firewall_rule.append(E.Description(name))
+        firewall_rule.append(E.Policy(policy))
+        protocol = E.Protocols()
+        for proto in protocols:
+            if proto == 'Any':
+                protocol.append(E.Any(True))
+            elif proto == 'Icmp':
+                protocol.append(E.Icmp(True))
+            elif proto == 'Tcp':
+                protocol.append(E.Tcp(True))
+            elif proto == 'Udp':
+                protocol.append(E.Udp(True))
+        firewall_rule.append(protocol)
+        firewall_rule.append(E.DestinationPortRange(destination_port_range))
+        firewall_rule.append(E.DestinationIp(destination_ip))
+        firewall_rule.append(E.SourcePortRange(source_port_range))
+        firewall_rule.append(E.SourceIp(source_ip))
+        firewall_rule.append(E.EnableLogging(enable_logging))
+        firewall_service.append(firewall_rule)
+        return self.client.put_linked_resource(self.resource,
+                                               RelationType.EDIT,
+                                               EntityType.vApp_Network.value,
+                                               self.resource)
+
+    def list_firewall_rule(self):
+        """List all firewall rules on firewall services to vApp network.
+
+        :return: a list of firewall rules info.
+        :rtype: list
+        :raises: InvalidParameterException: Enable firewall service failed as
+            given network's connection is not routed
+        """
+        self._get_resource()
+        fence_mode = self.resource.Configuration.FenceMode
+        if fence_mode != 'natRouted':
+            raise InvalidParameterException(
+                "Enable firewall service failed as given network's connection "
+                "is not routed")
+        firewall_service = self.resource.Configuration.Features.FirewallService
+        firewall_rule_list = []
+        for firewall_rule in firewall_service.FirewallRule:
+            info = {}
+            info['Name'] = firewall_rule.Description
+            info['Policy'] = firewall_rule.Policy
+            info['IsEnabled'] = firewall_rule.IsEnabled
+            info['DestinationPortRange'] = firewall_rule.DestinationPortRange
+            info['DestinationIp'] = firewall_rule.DestinationIp
+            info['SourcePortRange'] = firewall_rule.SourcePortRange
+            info['SourceIp'] = firewall_rule.SourceIp
+            info['EnableLogging'] = firewall_rule.EnableLogging
+            list_of_protocol = []
+            if hasattr(firewall_rule.Protocols, 'Any'):
+                list_of_protocol.append('Any')
+            if hasattr(firewall_rule.Protocols, 'Icmp'):
+                list_of_protocol.append('Icmp')
+            if hasattr(firewall_rule.Protocols, 'Tcp'):
+                list_of_protocol.append('Tcp')
+            if hasattr(firewall_rule.Protocols, 'Udp'):
+                list_of_protocol.append('Udp')
+            info['Protocols'] = ','.join(list_of_protocol)
+            firewall_rule_list.append(info)
+        return firewall_rule_list
+
+    def update_firewall_rule(self, name, new_name=None, is_enabled=None,
+                             policy=None, protocols=None,
+                             source_port_range=None,
+                             source_ip=None, destination_port_range=None,
+                             destination_ip=None, enable_logging=None):
+        """Update firewall rule on firewall services to vApp network.
+
+        :param str name: name of firewall rule.
+        :param str new_name: new name of firewall rule.
+        :param str policy: policy on firewall rule.
+        :param list protocols: list of protocols on firewall rule.
+        :param str source_port_range: source port range for firewall rule.
+        :param str source_ip: source IP.
+        :param str destination_port_range:destination port range for firewall
+            rule.
+        :param str destination_ip: destination IP.
+        :param str enable_logging: enable logging on firewall rule.
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vApp network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        :raises: InvalidParameterException: Enable firewall service failed as
+            given network's connection is not routed
+        """
+        self._get_resource()
+        fence_mode = self.resource.Configuration.FenceMode
+        if fence_mode != 'natRouted':
+            raise InvalidParameterException(
+                "Enable firewall service failed as given network's connection "
+                "is not routed")
+        firewall_service = self.resource.Configuration.Features.FirewallService
+        for firewall_rule in firewall_service.FirewallRule:
+            if firewall_rule.Description == name:
+                if new_name is not None:
+                    firewall_rule.Description = E.Description(new_name)
+                if is_enabled is not None:
+                    firewall_rule.IsEnabled = E.IsEnabled(is_enabled)
+                if policy is not None:
+                    firewall_rule.Policy = E.Policy(policy)
+                if protocols is not None:
+                    protocol = E.Protocols()
+                    for proto in protocols:
+                        if proto == 'Any':
+                            protocol.append(E.Any(True))
+                        elif proto == 'Icmp':
+                            protocol.append(E.Icmp(True))
+                        elif proto == 'Tcp':
+                            protocol.append(E.Tcp(True))
+                        elif proto == 'Udp':
+                            protocol.append(E.Udp(True))
+                    firewall_rule.Protocols = protocol
+                if destination_port_range is not None:
+                    firewall_rule.DestinationPortRange = \
+                        E.DestinationPortRange(destination_port_range)
+                if destination_ip is not None:
+                    firewall_rule.DestinationIp = E.DestinationIp(
+                        destination_ip)
+                if source_port_range is not None:
+                    firewall_rule.SourcePortRange = E.SourcePortRange(
+                        source_port_range)
+                if source_ip is not None:
+                    firewall_rule.SourceIp = E.SourceIp(source_ip)
+                if enable_logging is not None:
+                    firewall_rule.EnableLogging = E.EnableLogging(
+                        enable_logging)
+        return self.client.put_linked_resource(self.resource,
+                                               RelationType.EDIT,
+                                               EntityType.vApp_Network.value,
+                                               self.resource)
+
+    def delete_firewall_rule(self, name):
+        """Delete firewall rule on firewall services to vApp network.
+
+        :param str name: name of firewall rule.
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vApp network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        :raises: InvalidParameterException: Enable firewall service failed as
+            given network's connection is not routed
+        """
+        self._get_resource()
+        fence_mode = self.resource.Configuration.FenceMode
+        if fence_mode != 'natRouted':
+            raise InvalidParameterException(
+                "Enable firewall service failed as given network's connection "
+                "is not routed")
+        firewall_service = self.resource.Configuration.Features.FirewallService
+        for firewall_rule in firewall_service.FirewallRule:
+            if firewall_rule.Description == name:
+                firewall_service.remove(firewall_rule)
+        return self.client.put_linked_resource(self.resource,
+                                               RelationType.EDIT,
+                                               EntityType.vApp_Network.value,
+                                               self.resource)


### PR DESCRIPTION
VP-2652:[PySDK] Add firewall rule in vapp network
VP-2655: [PySDK]Remove firewall rule in vapp network
VP-2640: [PySDK] update firewall rule default action and log in vapp network
VP-2642: [PySDK]Update firewall rule in vapp network
VP-2778: [PySDK] list firewall rule  in vapp network

This CLN contains Add firewall rule, Remove firewall rule, Update firewall rule,  update firewall rule default action and log, list firewall rule  in vapp network.

set_default_action(), add_firewall_rule(), list_firewall_rule(),  update_firewall_rule() and delete_firewall_rule() methods are exposed in vapp_firewall.py class and corresponding test case added.
Testing Done:
test_0020_set_default_action(), test_0030_add_firewall_rule(), test_0040_list_firewall_rule(),  test_0050_update_firewall_rule() and test_0060_delete_firewall_rule() are added in test class vapp_firewall_tests.py.
It is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/573)
<!-- Reviewable:end -->
