### PR TITLE
VP-2750, VP-2753

### DIFF
--- a/pyvcloud/vcd/vapp_nat.py
+++ b/pyvcloud/vcd/vapp_nat.py
@@ -1,0 +1,112 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2014-2019 VMware, Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyvcloud.vcd.client import E
+from pyvcloud.vcd.client import EntityType
+from pyvcloud.vcd.client import RelationType
+from pyvcloud.vcd.exceptions import InvalidParameterException
+from pyvcloud.vcd.vapp_services import VappServices
+
+
+class VappNat(VappServices):
+    def _makeNatServiceAttr(features):
+        nat_service = E.NatService()
+        nat_service.append(E.IsEnabled(True))
+        nat_service.append(E.NatType('ipTranslation'))
+        nat_service.append(E.Policy('allowTrafficIn'))
+        features.append(nat_service)
+
+    def enable_nat_service(self, isEnable):
+        """Enable NAT service to vApp network.
+
+        :param bool isEnable: True for enable and False for Disable.
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vApp network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        :raises: InvalidParameterException: Enable NAT service failed as
+            given network's connection is not routed
+        """
+        self._get_resource()
+        fence_mode = self.resource.Configuration.FenceMode
+        if fence_mode != 'natRouted':
+            raise InvalidParameterException(
+                "Enable NAT service failed as given network's connection "
+                "is not routed")
+        features = self.resource.Configuration.Features
+        if not hasattr(features, 'NatService'):
+            VappNat._makeNatServiceAttr(features)
+        nat_service = features.NatService
+        nat_service.IsEnabled = E.IsEnabled(isEnable)
+        return self.client.put_linked_resource(self.resource,
+                                               RelationType.EDIT,
+                                               EntityType.vApp_Network.value,
+                                               self.resource)
+
+    def update_nat_type(self,
+                        nat_type='ipTranslation',
+                        policy='allowTrafficIn'):
+        """Update NAT type to vApp network.
+
+        :param str nat_type: NAT type (portForwarding/ipTranslation).
+        :param str policy: policy type(allowTrafficIn/allowTraffic).
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vApp network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        :raises: InvalidParameterException: Enable NAT service failed as
+            given network's connection is not routed
+        """
+        self._get_resource()
+        fence_mode = self.resource.Configuration.FenceMode
+        if fence_mode != 'natRouted':
+            raise InvalidParameterException(
+                "Enable NAT service failed as given network's connection "
+                "is not routed")
+        features = self.resource.Configuration.Features
+        if not hasattr(features, 'NatService'):
+            VappNat._makeNatServiceAttr(features)
+        nat_service = features.NatService
+        nat_service.NatType = E.NatType(nat_type)
+        nat_service.Policy = E.Policy(policy)
+        return self.client.put_linked_resource(self.resource,
+                                               RelationType.EDIT,
+                                               EntityType.vApp_Network.value,
+                                               self.resource)
+
+    def add_nat_rule(self, nat_type='ipTranslation', policy='allowTrafficIn'):
+        """Update NAT type to vApp network.
+
+        :param str nat_type: NAT type (portForwarding/ipTranslation).
+        :param str policy: policy type(allowTrafficIn/allowTraffic).
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vApp network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        :raises: InvalidParameterException: Enable NAT service failed as
+            given network's connection is not routed
+        """
+        self._get_resource()
+        fence_mode = self.resource.Configuration.FenceMode
+        if fence_mode != 'natRouted':
+            raise InvalidParameterException(
+                "Enable NAT service failed as given network's connection "
+                "is not routed")
+        features = self.resource.Configuration.Features
+        if not hasattr(features, 'NatService'):
+            VappNat._makeNatServiceAttr(features)
+        nat_service = features.NatService
+        nat_service.NatType = E.NatType(nat_type)
+        nat_service.Policy = E.Policy(policy)
+        return self.client.put_linked_resource(self.resource,
+                                               RelationType.EDIT,
+                                               EntityType.vApp_Network.value,
+                                               self.resource)

--- a/pyvcloud/vcd/vapp_nat.py
+++ b/pyvcloud/vcd/vapp_nat.py
@@ -82,31 +82,3 @@ class VappNat(VappServices):
                                                RelationType.EDIT,
                                                EntityType.vApp_Network.value,
                                                self.resource)
-
-    def add_nat_rule(self, nat_type='ipTranslation', policy='allowTrafficIn'):
-        """Update NAT type to vApp network.
-
-        :param str nat_type: NAT type (portForwarding/ipTranslation).
-        :param str policy: policy type(allowTrafficIn/allowTraffic).
-        :return: an object containing EntityType.TASK XML data which represents
-            the asynchronous task that is updating the vApp network.
-        :rtype: lxml.objectify.ObjectifiedElement
-        :raises: InvalidParameterException: Enable NAT service failed as
-            given network's connection is not routed
-        """
-        self._get_resource()
-        fence_mode = self.resource.Configuration.FenceMode
-        if fence_mode != 'natRouted':
-            raise InvalidParameterException(
-                "Enable NAT service failed as given network's connection "
-                "is not routed")
-        features = self.resource.Configuration.Features
-        if not hasattr(features, 'NatService'):
-            VappNat._makeNatServiceAttr(features)
-        nat_service = features.NatService
-        nat_service.NatType = E.NatType(nat_type)
-        nat_service.Policy = E.Policy(policy)
-        return self.client.put_linked_resource(self.resource,
-                                               RelationType.EDIT,
-                                               EntityType.vApp_Network.value,
-                                               self.resource)

--- a/system_tests/vapp_nat_tests.py
+++ b/system_tests/vapp_nat_tests.py
@@ -1,0 +1,108 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2014-2019 VMware, Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.vcd.vapp_nat import VappNat
+from pyvcloud.system_test_framework.vapp_constants import VAppConstants
+from pyvcloud.system_test_framework.environment import Environment
+from pyvcloud.system_test_framework.environment import developerModeAware
+from pyvcloud.vcd.client import TaskStatus
+from pyvcloud.vcd.client import FenceMode
+
+
+class TestVappNat(BaseTestCase):
+    """Test vapp dhcp functionalities implemented in pyvcloud."""
+    _vapp_name = VAppConstants.name
+    _network_name = VAppConstants.network1_name
+    _org_vdc_network_name = 'test-direct-vdc-network'
+    _enable = True
+    _disable = False
+    _nat_type_ip_translation = 'ipTranslation'
+    _nat_type_port_forwarding = 'portForwarding'
+    _policy_traffic = 'allowTraffic'
+    _policy_traffic_in = 'allowTrafficIn'
+
+    def test_0000_setup(self):
+        TestVappNat._client = Environment.get_sys_admin_client()
+        vapp = Environment.get_test_vapp_with_network(TestVappNat._client)
+        vapp.reload()
+        task = vapp.connect_vapp_network_to_ovdc_network(
+            network_name=TestVappNat._network_name,
+            orgvdc_network_name=TestVappNat._org_vdc_network_name)
+        result = TestVappNat._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0010_enable_nat_service(self):
+        vapp_nat = VappNat(TestVappNat._client,
+                           vapp_name=TestVappNat._vapp_name,
+                           network_name=TestVappNat._network_name)
+        # disable NAT service
+        task = vapp_nat.enable_nat_service(TestVappNat._disable)
+        result = TestVappNat._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp_nat._reload()
+        nat_service = vapp_nat.resource.Configuration.Features.NatService
+        self.assertFalse(nat_service.IsEnabled)
+        # enable NAT service
+        task = vapp_nat.enable_nat_service(TestVappNat._enable)
+        result = TestVappNat._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp_nat._reload()
+        nat_service = vapp_nat.resource.Configuration.Features.NatService
+        self.assertTrue(nat_service.IsEnabled)
+
+    def test_0020_update_nat_type(self):
+        vapp_nat = VappNat(TestVappNat._client,
+                           vapp_name=TestVappNat._vapp_name,
+                           network_name=TestVappNat._network_name)
+        task = vapp_nat.update_nat_type(TestVappNat._nat_type_port_forwarding,
+                                        TestVappNat._policy_traffic)
+        result = TestVappNat._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp_nat._reload()
+        nat_service = vapp_nat.resource.Configuration.Features.NatService
+        self.assertEqual(nat_service.NatType,
+                         TestVappNat._nat_type_port_forwarding)
+        self.assertEqual(nat_service.Policy, TestVappNat._policy_traffic)
+        # Revert back changes
+        task = vapp_nat.update_nat_type(TestVappNat._nat_type_ip_translation,
+                                        TestVappNat._policy_traffic_in)
+        result = TestVappNat._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp_nat._reload()
+        self.assertEqual(nat_service.NatType,
+                         TestVappNat._nat_type_ip_translation)
+        self.assertEqual(nat_service.Policy, TestVappNat._policy_traffic_in)
+
+    @developerModeAware
+    def test_9998_teardown(self):
+        """Test the  method vdc.delete_vapp().
+
+        Invoke the method for all the vApps created by setup.
+
+        This test passes if all the tasks for deleting the vApps succeed.
+        """
+        vdc = Environment.get_test_vdc(TestVappNat._client)
+        task = vdc.delete_vapp(name=TestVappNat._vapp_name, force=True)
+        result = TestVappNat._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_9999_cleanup(self):
+        """Release all resources held by this object for testing purposes."""
+        TestVappNat._client.logout()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
VP-2750: [PySDK]Enable NAT rule in vapp network
VP-2753: [PySDK]Select NAT rule type in vapp network

This CLN contains Enable NAT rule, Select NAT rule type in vapp network.

enable_nat_service() and update_nat_type() methods are exposed in vapp_nat.py class and corresponding test case added.
Testing Done:
test_0010_enable_nat_service() and test_0020_update_nat_type() are added in test class vapp_nat_tests.py.
It is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/574)
<!-- Reviewable:end -->
