### PR TITLE
[VCDA-1112] pyvcloud: Unified exception for unsupported client versions that use compute policy api

### DIFF
--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -42,6 +42,7 @@ from pyvcloud.vcd.client import ResourceType
 from pyvcloud.vcd.exceptions import DownloadException
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import InvalidParameterException
+from pyvcloud.vcd.exceptions import OperationNotSupportedException
 from pyvcloud.vcd.exceptions import UploadException
 from pyvcloud.vcd.metadata import Metadata
 from pyvcloud.vcd.system import System
@@ -1800,8 +1801,14 @@ class Org(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
 
+        :raises: OperationNotSupportedException: if the api version is not
+        supported.
         :raises: EntityNotFoundException: if the vm cannot be located.
         """
+        if float(self.client.get_api_version()) < \
+                float(ApiVersion.VERSION_32.value):
+            raise OperationNotSupportedException("Unsupported API version")
+
         policy_id = retrieve_compute_policy_id_from_href(compute_policy_href)
         template_resource_href = self.get_vapp_template_href(catalog_name,
                                                              catalog_item_name)
@@ -1846,8 +1853,14 @@ class Org(object):
 
         :rtype: lxml.objectify.ObjectifiedElement.
 
+        :raises: OperationNotSupportedException: if the api version is not
+        supported.
         :raises: EntityNotFoundException: if the compute policy not found
         """
+        if float(self.client.get_api_version()) < \
+                float(ApiVersion.VERSION_32.value):
+            raise OperationNotSupportedException("Unsupported API version")
+
         policy_id = retrieve_compute_policy_id_from_href(compute_policy_href)
         template_resource_href = self.get_vapp_template_href(catalog_name,
                                                              catalog_item_name)

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -35,6 +35,7 @@ from pyvcloud.vcd.client import SIZE_1MB
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import InvalidParameterException
 from pyvcloud.vcd.exceptions import MultipleRecordsException
+from pyvcloud.vcd.exceptions import OperationNotSupportedException
 from pyvcloud.vcd.metadata import Metadata
 from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.platform import Platform
@@ -2069,7 +2070,13 @@ class VDC(object):
         refers to VcdComputePolicy.
 
         :rtype: list of lxml.objectify.StringElement
+        :raises: OperationNotSupportedException: if the api version is not
+        supported.
         """
+        if float(self.client.get_api_version()) < \
+                float(ApiVersion.VERSION_32.value):
+            raise OperationNotSupportedException("Unsupported API version")
+
         policy_references = self._fetch_compute_policies()
         policy_list = []
         for policy_reference in policy_references.VdcComputePolicyReference:
@@ -2085,7 +2092,14 @@ class VDC(object):
         that refers to individual VdcComputePolicies.
 
         :rtype: lxml.objectify.ObjectifiedElement
+
+        :raises: OperationNotSupportedException: if the api version is not
+        supported.
         """
+        if float(self.client.get_api_version()) < \
+                float(ApiVersion.VERSION_32.value):
+            raise OperationNotSupportedException("Unsupported API version")
+
         policy_references = self._fetch_compute_policies()
         policy_id = retrieve_compute_policy_id_from_href(href)
         policy_reference_element = E.VdcComputePolicyReference()
@@ -2107,9 +2121,15 @@ class VDC(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
 
+        :raises: OperationNotSupportedException: if the api version is not
+        supported.
         :raises: EntityNotFoundException: if the VdcComputePolicy cannot
             be located.
         """
+        if float(self.client.get_api_version()) < \
+                float(ApiVersion.VERSION_32.value):
+            raise OperationNotSupportedException("Unsupported API version")
+
         policy_references = self._fetch_compute_policies()
         policy_id = retrieve_compute_policy_id_from_href(href)
         for policy_reference in policy_references.VdcComputePolicyReference:


### PR DESCRIPTION
Signed-off-by: Sakthi Sundaram <sakthisunda@yahoo.com>

- Raise unified exception for unsupported client api versions on compute-policy crud operations.
- Currently, compute policy crud on vdc and vms throw different exceptions depending on the client versions that are not supported. In this PR, changes are made to throw unified exception depending on the client api version.

- Tests done on 9.1, 9.5 and 9.7 vcd with client api versions 29.0, 30.0, 31.0 and 32.0 with scripts 
- No System tests added since there is no access to /cloudapi from pyvcloud. 

- @rocknes @rajeshk2013

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/576)
<!-- Reviewable:end -->
