### PR TITLE
VP-2744: [PySDK]Add NAT rule in vapp network

### DIFF
--- a/pyvcloud/vcd/vapp_nat.py
+++ b/pyvcloud/vcd/vapp_nat.py
@@ -134,8 +134,6 @@ class VappNat(VappServices):
             VappNat._delete_all_nat_rule(nat_service)
             nat_service.NatType = E.NatType(nat_type)
         nat_rule = E.NatRule()
-        # rule_id =
-        # nat_rule.append(E.Id(rule_id))
         if nat_type == 'ipTranslation':
             one_to_vm_rule = E.OneToOneVmRule()
             one_to_vm_rule.append(E.MappingMode(mapping_mode))

--- a/pyvcloud/vcd/vapp_nat.py
+++ b/pyvcloud/vcd/vapp_nat.py
@@ -27,6 +27,11 @@ class VappNat(VappServices):
         nat_service.append(E.Policy('allowTrafficIn'))
         features.append(nat_service)
 
+    def _delete_all_nat_rule(nat_service):
+        if hasattr(nat_service, 'NatRule'):
+            for nat_rule in nat_service.NatRule:
+                nat_service.remove(nat_rule)
+
     def enable_nat_service(self, isEnable):
         """Enable NAT service to vApp network.
 
@@ -76,8 +81,78 @@ class VappNat(VappServices):
         if not hasattr(features, 'NatService'):
             VappNat._makeNatServiceAttr(features)
         nat_service = features.NatService
+        if nat_service.NatType != nat_type:
+            VappNat._delete_all_nat_rule(nat_service)
         nat_service.NatType = E.NatType(nat_type)
         nat_service.Policy = E.Policy(policy)
+        return self.client.put_linked_resource(self.resource,
+                                               RelationType.EDIT,
+                                               EntityType.vApp_Network.value,
+                                               self.resource)
+
+    def add_nat_rule(self,
+                     nat_type,
+                     vapp_scoped_vm_id,
+                     vm_nic_id,
+                     mapping_mode='automatic',
+                     external_ip_address=None,
+                     external_port=-1,
+                     internal_port=-1,
+                     protocol='TCP'):
+        """Add NAT rule to vApp network.
+
+        :param str nat_type: NAT type (portForwarding/ipTranslation).
+        :param str vapp_scoped_vm_id: vapp network scoped vm id.
+        :param str vm_nic_id: vapp network scoped vm nic id.
+        :param str mapping_mode: NAT rule mapping mode (automatic/manual) if
+            nat_type is ipTranslation.
+        :param str external_ip_address: external ip address if mapping mode is
+            manual.
+        :param int external_port: external port of NAT rule if nat_type is
+            portForwarding.
+        :param int internal_port: internal port of NAT rule if nat_type is
+            portForwarding.
+        :param str protocol: protocol of NAT rule if nat_type is
+            portForwarding.
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vApp network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        :raises: InvalidParameterException: Enable NAT service failed as
+            given network's connection is not routed
+        """
+        self._get_resource()
+        fence_mode = self.resource.Configuration.FenceMode
+        if fence_mode != 'natRouted':
+            raise InvalidParameterException(
+                "Enable NAT service failed as given network's connection "
+                "is not routed")
+        features = self.resource.Configuration.Features
+        if not hasattr(features, 'NatService'):
+            VappNat._makeNatServiceAttr(features)
+        nat_service = features.NatService
+        if nat_service.NatType != nat_type:
+            VappNat._delete_all_nat_rule(nat_service)
+            nat_service.NatType = E.NatType(nat_type)
+        nat_rule = E.NatRule()
+        # rule_id =
+        # nat_rule.append(E.Id(rule_id))
+        if nat_type == 'ipTranslation':
+            one_to_vm_rule = E.OneToOneVmRule()
+            one_to_vm_rule.append(E.MappingMode(mapping_mode))
+            if mapping_mode == 'manual':
+                one_to_vm_rule.append(E.ExternalIpAddress(external_ip_address))
+            one_to_vm_rule.append(E.VAppScopedVmId(vapp_scoped_vm_id))
+            one_to_vm_rule.append(E.VmNicId(vm_nic_id))
+            nat_rule.append(one_to_vm_rule)
+        elif nat_type == 'portForwarding':
+            vm_rule = E.VmRule()
+            vm_rule.append(E.ExternalPort(external_port))
+            vm_rule.append(E.VAppScopedVmId(vapp_scoped_vm_id))
+            vm_rule.append(E.VmNicId(vm_nic_id))
+            vm_rule.append(E.InternalPort(internal_port))
+            vm_rule.append(E.Protocol(protocol))
+            nat_rule.append(vm_rule)
+        nat_service.append(nat_rule)
         return self.client.put_linked_resource(self.resource,
                                                RelationType.EDIT,
                                                EntityType.vApp_Network.value,


### PR DESCRIPTION
VP-2744: [PySDK]Add NAT rule in vapp network

This CLN contains add nat rule in vapp network. 
add_nat_rule() method is exposed in vapp_nat.py class and corresponding test case added.
Testing Done:
test_0030_add_nat_rule() is added in test class vapp_nat_tests.py.
It is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/580)
<!-- Reviewable:end -->
