### PR TITLE
VP-2684,VP-2686,VP-2813: Boot options and runtime info

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -439,6 +439,7 @@ class EntityType(Enum):
     VIM_SERVER_REFS = 'application/vnd.vmware.admin.vmwVimServerReferences+xml'
     VIRTUAL_CENTER = 'application/vnd.vmware.admin.vmwvirtualcenter+xml'
     VM = 'application/vnd.vmware.vcloud.vm+xml'
+    VM_BOOT_OPTIONS = 'application/vnd.vmware.vcloud.bootOptionsSection+xml'
     VM_CAPABILITIES_SECTION = \
         'application/vnd.vmware.vcloud.vmCapabilitiesSection+xml'
     VMS = 'application/vnd.vmware.vcloud.vms+xml'

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -1493,7 +1493,7 @@ class VM(object):
 
     def update_boot_options(self, boot_delay=None,
                             enter_bios_setup=None):
-        """Update vm capabilities section of VM.
+        """Update boot options of VM.
 
         :param int boot_delay
         :param bool enter_bios_setup

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -1256,7 +1256,7 @@ class VM(object):
         :param str description
 
         :return: an object containing EntityType.TASK XML data which represents
-            the asynchronous task adding  a nic.
+            the asynchronous task updating OS section.
         :rtype: lxml.objectify.ObjectifiedElement
         """
         uri = self.href + '/operatingSystemSection/'
@@ -1449,7 +1449,7 @@ class VM(object):
         :param bool cpu_hot_add_enabled
 
         :return: an object containing EntityType.TASK XML data which represents
-            the asynchronous task adding  a nic.
+            the asynchronous task updating VM capabilities.
         :rtype: lxml.objectify.ObjectifiedElement
         """
         uri = self.href + '/vmCapabilities/'
@@ -1464,3 +1464,93 @@ class VM(object):
         return self.client. \
             put_resource(uri, vm_capabilities_section,
                          EntityType.VM_CAPABILITIES_SECTION.value)
+
+    def get_boot_options(self):
+        """Get boot options of VM.
+
+        :return: an object containing EntityType.BootOptions XML
+                 data which contains boot options of VM
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        uri = self.href + '/bootOptions/'
+        return self.client.get_resource(uri)
+
+    def list_boot_options(self):
+        """List boot options of VM.
+
+        :return: dict which contains boot options of VM
+
+        :rtype: dict
+        """
+        result = {}
+        boot_options = self.get_boot_options()
+        result['BootDelay'] = \
+            boot_options.BootDelay
+        result['EnterBIOSSetup'] = \
+            boot_options.EnterBIOSSetup
+
+        return result
+
+    def update_boot_options(self, boot_delay=None,
+                            enter_bios_setup=None):
+        """Update vm capabilities section of VM.
+
+        :param int boot_delay
+        :param bool enter_bios_setup
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task updating boot options.
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        uri = self.href + '/action/bootOptions/'
+        boot_options = self.get_boot_options()
+        if boot_delay is not None:
+            boot_options.BootDelay = E. \
+                BootDelay(boot_delay)
+        if enter_bios_setup is not None:
+            boot_options.EnterBIOSSetup = E.EnterBIOSSetup(
+                enter_bios_setup)
+
+        return self.client.post_resource(uri, boot_options,
+                                         EntityType.VM_BOOT_OPTIONS.value)
+
+    def get_run_time_info(self):
+        """Get run time info of VM.
+
+        :return: an object containing EntityType.BootOptions XML
+                 data which contains boot options of VM
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        uri = self.href + '/runtimeInfoSection/'
+        return self.client.get_resource(uri)
+
+    def list_boot_options(self):
+        """List boot options of VM.
+
+        :return: dict which contains boot options of VM
+
+        :rtype: dict
+        """
+        result = {}
+        boot_options = self.get_boot_options()
+        result['BootDelay'] = \
+            boot_options.BootDelay
+        result['EnterBIOSSetup'] = \
+            boot_options.EnterBIOSSetup
+
+        return result
+
+    def list_run_time_info(self):
+        """List runtime info of VM.
+
+        :return: dict which contains runtime info of VM
+
+        :rtype: dict
+        """
+        result = {}
+        runtime_info = self.get_run_time_info()
+        if hasattr(runtime_info, 'VMWareTools'):
+            result['vmware_tools_version'] = runtime_info.VMWareTools.get(
+                'version')
+
+        return result

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -1524,22 +1524,6 @@ class VM(object):
         uri = self.href + '/runtimeInfoSection/'
         return self.client.get_resource(uri)
 
-    def list_boot_options(self):
-        """List boot options of VM.
-
-        :return: dict which contains boot options of VM
-
-        :rtype: dict
-        """
-        result = {}
-        boot_options = self.get_boot_options()
-        result['BootDelay'] = \
-            boot_options.BootDelay
-        result['EnterBIOSSetup'] = \
-            boot_options.EnterBIOSSetup
-
-        return result
-
     def list_run_time_info(self):
         """List runtime info of VM.
 

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -804,6 +804,27 @@ class TestVM(BaseTestCase):
         vm_capabilities_section = vm.get_vm_capabilities_section()
         self.assertFalse(vm_capabilities_section.MemoryHotAddEnabled)
 
+    def test_0340_list_boot_options(self):
+        vm = VM(TestVM._sys_admin_client,
+                href=TestVM._test_vapp_vmtools_vm_href)
+        dict = vm.list_boot_options()
+        self.assertTrue(len(dict) > 0)
+
+    def test_0350_update_boot_options(self):
+        vm = VM(TestVM._sys_admin_client,
+                href=TestVM._test_vapp_vmtools_vm_href)
+        task = vm.update_boot_options(enter_bios_setup=False)
+        result = TestVM._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        boot_options = vm.get_boot_options()
+        self.assertFalse(boot_options.EnterBIOSSetup)
+
+    def test_0360_list_runtime_info(self):
+        vm = VM(TestVM._sys_admin_client,
+                href=TestVM._test_vapp_vmtools_vm_href)
+        dict = vm.list_run_time_info()
+        self.assertTrue(len(dict) > 0)
+
     @developerModeAware
     def test_9998_teardown(self):
         """Delete the vApp created during setup.


### PR DESCRIPTION
VP-2684:[PYSDK] List RunTime Info section
VP-2686:[PYSDK] List BootOptions
VP-2813:[PYSDK] Update boot options

This CLN contains VM's functionalities for runtime info and boot
options.

Testing Done:
Test methods test_0340_list_boot_options, test_0350_update_boot_options
and test_0360_list_runtime_info are added in vm_tests.py file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/584)
<!-- Reviewable:end -->
