### PR TITLE
VP-2746: [PySDK]Update NAT rule in vapp network

### DIFF
--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1983,12 +1983,12 @@ class VApp(object):
                 hasattr(self.resource.Children, 'Vm'):
             for vm in self.resource.Children.Vm:
                 local_id = vm.VAppScopedLocalId
-                vm_interface_data = {}
                 if hasattr(vm, 'NetworkConnectionSection'):
                     net_con_section = vm.NetworkConnectionSection
                     if hasattr(net_con_section, 'NetworkConnection'):
                         net_con = net_con_section.NetworkConnection
                         for network_connection in net_con:
+                            vm_interface_data = {}
                             if network_connection.get(
                                     'network') == network_name:
                                 vm_interface_data['Name'] = network_name

--- a/system_tests/vapp_nat_tests.py
+++ b/system_tests/vapp_nat_tests.py
@@ -38,6 +38,9 @@ class TestVappNat(BaseTestCase):
     _policy_traffic = 'allowTraffic'
     _policy_traffic_in = 'allowTrafficIn'
     _allocate_ip_address = '90.80.70.10'
+    _rule_id = '65537'
+    _ext_ip_addr = '2.2.3.20'
+    _manual = 'manual'
 
     def test_0000_setup(self):
         TestVappNat._client = Environment.get_sys_admin_client()
@@ -141,13 +144,29 @@ class TestVappNat(BaseTestCase):
         self.assertEqual(result[0]['VAppScopedVmId'], TestVappNat._vm_id)
         self.assertEqual(str(result[0]['VmNicId']), TestVappNat._vm_nic_id)
 
+    def test_0060_update_nat_rule(self):
+        vapp_nat = VappNat(TestVappNat._client,
+                           vapp_name=TestVappNat._vapp_name,
+                           network_name=TestVappNat._network_name)
+        task = vapp_nat.update_nat_rule(
+            rule_id=TestVappNat._rule_id,
+            mapping_mode=TestVappNat._manual,
+            external_ip_address=TestVappNat._ext_ip_addr)
+        result = TestVappNat._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp_nat._reload()
+        nat_service = vapp_nat.resource.Configuration.Features.NatService
+        one_to_one_rule = nat_service.NatRule.OneToOneVmRule
+        self.assertEqual(one_to_one_rule.MappingMode, TestVappNat._manual)
+        self.assertEqual(one_to_one_rule.ExternalIpAddress,
+                         TestVappNat._ext_ip_addr)
+
     def test_0090_delete_nat_rule(self):
         vapp_nat = VappNat(TestVappNat._client,
                            vapp_name=TestVappNat._vapp_name,
                            network_name=TestVappNat._network_name)
         vapp_nat._get_resource()
-        id = vapp_nat.resource.Configuration.Features.NatService.NatRule.Id
-        task = vapp_nat.delete_nat_rule(id)
+        task = vapp_nat.delete_nat_rule(TestVappNat._rule_id)
         result = TestVappNat._client.get_task_monitor().wait_for_success(task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
         vapp_nat._reload()


### PR DESCRIPTION
VP-2746: [PySDK]Update NAT rule in vapp network

This CLN contains Update NAT rule in vapp network.  
update_nat_rule() method is exposed in vapp_nat.py class and corresponding test case added.  
Testing Done:  
test_0060_update_nat_rule() is added in test class vapp_nat_tests.py.  
It is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/585)
<!-- Reviewable:end -->
