### PR TITLE
Extended pyvcloud to allow SAML, LDAP integration and general setting…

### DIFF
--- a/pyvcloud/vcd/system.py
+++ b/pyvcloud/vcd/system.py
@@ -43,25 +43,209 @@ class System(object):
         if admin_resource is not None:
             self.admin_href = self.client.get_admin().get('href')
 
-    def create_org(self, org_name, full_org_name, is_enabled=False):
+    def create_org(self, org_name, full_org_name, is_enabled=False, org_settings={}):
         """Create new organization.
-
+        Syntax: def create_org(self, org_name, full_org_name, is_enabled=False, org_settings={})
         :param str org_name: name of the organization.
         :param str full_org_name: full name of the organization.
-        :param bool is_enabled: enable organization if True
-
+        :param bool is_enabled: enable organization if True.
+        :param dict org_settings: dictionary of settings used to customize the org creation
         :return: an object containing EntityType.ADMIN_ORG XML data which
             represents the newly created organization.
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
+
+        '''
+        org_settings is a dictionary made of other dictionaries with the following key value pairs
+        Dictionary org_general_settings:
+            can_publish_catalogs: allow publishing catalogs
+            can_publish_externally: allow publishing catalogs externally
+            can_subscribe: allow to subscribe to catalogs
+            deployed_vmquota: default quotas for how many VMs a User can power on in this organization
+            stored_vmquota: default quotas for how many VMs a User can store in this organization
+            use_server_boot_sequence: allow use of server boot sequence
+            delay_after_power_on_seconds: specify a delay after power on the VMs
+        Dictionary vapp_lease_settings:
+            delete_on_storage_lease_expiration: allow to delete vapp at the end of the lease
+            deployment_lease_seconds: specify length of the lease for a vapp
+            storage_lease_seconds: specify length of the lease for a vapp on the storage
+        Dictionary vapp_template_lease_settings:
+            delete_template_on_storage_lease_expiration: allow to delete vapp template at the end of the lease
+            storage_template_lease_seconds: specify length of the lease for a vapp template on the storage
+        Dictionary org_ldap_settings:
+              org_ldap_mode: determine if Ldap is enabled ("CUSTOM", "SYSTEM") or not ("NONE")
+              (if org_ldap_mode different from "NONE", please refer to the the API docs
+              https://pubs.vmware.com/vca/topic/com.vmware.vcloud.api.reference.doc_56/doc/types/CustomOrgLdapSettingsType.html
+              for the description of all the fields needed)
+              Dictionary 'user_attributes' and 'group_attributes' have defaults values so don't have to be specified from the
+              playbook/role in case OrgLdapMode value is not NONE, as the defaults values defined below in default_settings
+              will be used instead.
+        Dictionary org_email_settings:
+            is_default_smtp_server: specify if using the default smtp server
+            is_default_org_email: specify if using the default organization's email
+            from_email_address: specify email address
+            default_subject_prefix: specify default subject for the email
+            is_alert_to_all_admin: allow to send the alert to all admins
+        Dictionary org_federation_settings:
+            saml_metadata: XML content with the SAML Metdata
+            enabled: boolean that specifies if the SAML authentication is enabled or not
+        '''
+
+        # default_settings is a helper dictionary that containes the API defaults when creating an org
+        default_settings = {
+            "org_general_settings": {
+                "can_publish_catalogs": True,
+                "can_publish_externally": False,
+                "can_subscribe": False,
+                "deployed_vmquota": 10,
+                "stored_vmquota": 15,
+                "use_server_boot_sequence": False,
+                "delay_after_power_on_seconds": 1,
+            },
+            "vapp_lease_settings": {
+                "delete_on_storage_lease_expiration": False,
+                "deployment_lease_seconds": 604800,
+                "storage_lease_seconds": 2592000,
+            },
+            "vapp_template_lease_settings": {
+                "delete_template_on_storage_lease_expiration": False,
+                "storage_template_lease_seconds": 2592000,
+            },
+            "org_ldap_settings": {
+                "OrgLdapMode": "NONE",
+            },
+            "org_email_settings": {
+                "is_default_smtp_server": True,
+                "is_default_org_email": True,
+                "from_email_address": "",
+                "default_subject_prefix": " ",
+                "is_alert_to_all_admin": True,
+            },
+            "org_federation_settings": {
+                "saml_metadata": "",
+                "enabled": False,
+            },
+        }
+        # create the org_settings dict for the API consumption if none is provided or the one provided is not complete
+        for key1 in default_settings:
+            if key1 not in org_settings:
+                org_settings[key1] = default_settings[key1]
+            elif isinstance(default_settings[key1], dict):
+                for key2 in default_settings[key1]:
+                    if key2 not in org_settings[key1]:
+                        org_settings[key1][key2] = default_settings[key1][key2]
+
         if self.admin_resource is None:
             self.admin_resource = self.client.get_resource(self.admin_href)
+
         org_params = E.AdminOrg(
             E.FullName(full_org_name),
             E.IsEnabled(is_enabled),
-            E.Settings,
             name=org_name)
+        # Build the org_params_settings object
+        org_params_settings = E.Settings()
+        org_params_settings.OrgGeneralSettings = E.OrgGeneralSettings(
+            E.CanPublishCatalogs(org_settings.get("org_general_settings").get("can_publish_catalogs")),
+            E.CanPublishExternally(org_settings.get("org_general_settings").get("can_publish_externally")),
+            E.CanSubscribe(org_settings.get("org_general_settings").get("can_subscribe")),
+            E.DeployedVMQuota(org_settings.get("org_general_settings").get("deployed_vmquota")),
+            E.StoredVmQuota(org_settings.get("org_general_settings").get("stored_vmquota")),
+            E.UseServerBootSequence(org_settings.get("org_general_settings").get("use_server_boot_sequence")),
+            E.DelayAfterPowerOnSeconds(
+                org_settings.get("org_general_settings").get("delay_after_power_on_seconds"))
+        )
+        org_params_settings.VAppLeaseSettings = E.VAppLeaseSettings(
+            E.DeleteOnStorageLeaseExpiration(
+                org_settings.get("vapp_lease_settings").get("delete_on_storage_lease_expiration")),
+            E.DeploymentLeaseSeconds(org_settings.get("vapp_lease_settings").get("deployment_lease_seconds")),
+            E.StorageLeaseSeconds(org_settings.get("vapp_lease_settings").get("storage_lease_seconds"))
+        )
+        org_params_settings.VAppTemplateLeaseSettings = E.VAppTemplateLeaseSettings(
+            E.DeleteOnStorageLeaseExpiration(org_settings.get("vapp_template_lease_settings").get(
+                "delete_template_on_storage_lease_expiration")),
+            E.StorageLeaseSeconds(
+                org_settings.get("vapp_template_lease_settings").get("storage_template_lease_seconds"))
+        )
+        if org_settings.get("org_ldap_settings").get("org_ldap_mode") != 'NONE':
+            org_params_settings.OrgLdapSettings = E.OrgLdapSettings(
+            E.OrgLdapMode(org_settings.get("org_ldap_settings").get("org_ldap_mode")),
+            E.CustomOrgLdapSettings(
+                E.HostName(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get("hostname")),
+                E.Port(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get("port")),
+                E.IsSsl(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get("is_ssl")),
+                E.IsSslAcceptAll(
+                    org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get("is_ssl_accept_all")),
+                E.Realm(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get("realm")),
+                E.SearchBase(
+                    org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get("search_base")),
+                E.UserName(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get("username")),
+                E.Password(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get("password")),
+                E.AuthenticationMechanism(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                    "authentication_mechanism")),
+                E.GroupSearchBase(
+                    org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get("group_search_base")),
+                E.IsGroupSearchBaseEnabled(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                    "is_group_search_base_enabled")),
+                E.ConnectorType(
+                    org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get("connector_type")),
+                E.UserAttributes(
+                    E.ObjectClass(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                        "user_attributes").get("object_class")),
+                    E.ObjectIdentifier(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                        "user_attributes").get("object_identifier")),
+                    E.UserName(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                        "user_attributes").get("username")),
+                    E.Email(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                        "user_attributes").get("email")),
+                    E.FullName(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                        "user_attributes").get("fullname")),
+                    E.GivenName(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                        "user_attributes").get("given_name")),
+                    E.Surname(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                        "user_attributes").get("surname")),
+                    E.Telephone(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                        "user_attributes").get("telephone")),
+                    E.GroupMembershipIdentifier(
+                        org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                            "user_attributes").get("group_membership_identifier")),
+                    E.GroupBackLinkIdentifier(
+                        org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                            "user_attributes").get("group_back_link_identifier"))
+                ),
+                E.GroupAttributes(
+                    E.ObjectClass(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                        "group_attributes").get("object_class")),
+                    E.ObjectIdentifier(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                        "group_attributes").get("object_identifier")),
+                    E.GroupName(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                        "group_attributes").get("group_name")),
+                    E.Membership(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                        "group_attributes").get("membership")),
+                    E.MembershipIdentifier(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                        "group_attributes").get("membership_identifier")),
+                    E.BackLinkIdentifier(org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get(
+                        "group_attributes").get("backLink_identifier"))
+                ),
+                E.UseExternalKerberos(
+                    org_settings.get("org_ldap_settings").get("custom_org_ldap_settings").get("use_external_kerberos"))
+            )
+        )
+        org_params_settings.OrgEmailSettings = E.OrgEmailSettings(
+            E.IsDefaultSmtpServer(org_settings.get("org_email_settings").get("is_default_smtp_server")),
+            E.IsDefaultOrgEmail(org_settings.get("org_email_settings").get("is_default_org_email")),
+            E.FromEmailAddress(org_settings.get("org_email_settings").get("from_email_address")),
+            E.DefaultSubjectPrefix(org_settings.get("org_email_settings").get("default_subject_prefix")),
+            E.IsAlertEmailToAllAdmins(org_settings.get("org_email_settings").get("is_alert_to_all_admin"))
+        )
+
+        org_params_settings.OrgFederationSettings = E.OrgFederationSettings(
+            E.SAMLMetadata(org_settings.get("org_federation_settings").get("saml_metadata")),
+            E.Enabled(org_settings.get("org_federation_settings").get("enabled"))
+        )
+
+        # Build the org_params object
+        org_params.Settings = org_params_settings
         return self.client.post_linked_resource(
             self.admin_resource, RelationType.ADD, EntityType.ADMIN_ORG.value,
             org_params)
@@ -79,9 +263,7 @@ class System(object):
         """
         org_resource = self.client.get_org_by_name(org_name)
         org_admin_href = get_admin_href(org_resource.get('href'))
-        return self.client.delete_resource(org_admin_href,
-                                           force=force,
-                                           recursive=recursive)
+        return self.client.delete_resource(org_admin_href, force, recursive)
 
     def list_provider_vdcs(self):
         """List provider vdcs in the system organization.
@@ -182,3 +364,4 @@ class System(object):
                 return item
         raise EntityNotFoundException('Network pool \'%s\' not found or '
                                       'access to resource is forbidden' % name)
+


### PR DESCRIPTION
Extended pyvcloud to allow SAML, LDAP integration and general settings when creating a ORG

To help us process your pull request efficiently, please include: 

- (Required) Extended system.py to allows user to create org with general settings, ldap and/or SAML

- (Required) org_params now has a OrgGeneralSettings dictionary that allows to specify the General Settings for org creation (included LDAP and SAML ones)

