### PR TITLE
VP-2755, VP-2757, VP-2759, VP-2761, VP-2812

### DIFF
--- a/pyvcloud/vcd/vapp_static_route.py
+++ b/pyvcloud/vcd/vapp_static_route.py
@@ -1,0 +1,188 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2014-2019 VMware, Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyvcloud.vcd.client import E
+from pyvcloud.vcd.client import EntityType
+from pyvcloud.vcd.client import RelationType
+from pyvcloud.vcd.exceptions import EntityNotFoundException
+from pyvcloud.vcd.exceptions import InvalidParameterException
+from pyvcloud.vcd.vapp_services import VappServices
+
+
+class VappStaticRoute(VappServices):
+    def _makeStaticRouteServiceAttr(features):
+        route_service = E.StaticRoutingService()
+        route_service.append(E.IsEnabled(True))
+        features.append(route_service)
+
+    def enable_service(self, isEnable):
+        """Enable static route service to vApp network.
+
+        :param bool isEnable: True for enable and False for Disable.
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vApp network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        :raises: InvalidParameterException: Enable static route service failed
+            as given network's connection is not routed
+        """
+        self._get_resource()
+        fence_mode = self.resource.Configuration.FenceMode
+        if fence_mode != 'natRouted':
+            raise InvalidParameterException(
+                "Enable static route service failed as given network's "
+                "connection is not routed")
+        features = self.resource.Configuration.Features
+        if not hasattr(features, 'StaticRoutingService'):
+            VappStaticRoute._makeStaticRouteServiceAttr(features)
+        route = features.StaticRoutingService
+        route.IsEnabled = E.IsEnabled(isEnable)
+        return self.client.put_linked_resource(self.resource,
+                                               RelationType.EDIT,
+                                               EntityType.vApp_Network.value,
+                                               self.resource)
+
+    def add(self, name, network_cidr, next_hop_ip):
+        """Add static route to vApp network.
+
+        :param str name: name of route.
+        :param str network_cidr: network CIDR.
+        :param str next_hop_ip: next hop IP.
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vApp network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        :raises: InvalidParameterException: Add route to static route
+            service failed as given network's connection is not routed
+        """
+        self._get_resource()
+        fence_mode = self.resource.Configuration.FenceMode
+        if fence_mode != 'natRouted':
+            raise InvalidParameterException(
+                "Add route to static route service failed as given network's "
+                "connection is not routed")
+        features = self.resource.Configuration.Features
+        if not hasattr(features, 'StaticRoutingService'):
+            VappStaticRoute._makeStaticRouteServiceAttr(features)
+        route_service = features.StaticRoutingService
+        static_route = E.StaticRoute()
+        static_route.append(E.Name(name))
+        static_route.append(E.Network(network_cidr))
+        static_route.append(E.NextHopIp(next_hop_ip))
+        route_service.append(static_route)
+        return self.client.put_linked_resource(self.resource,
+                                               RelationType.EDIT,
+                                               EntityType.vApp_Network.value,
+                                               self.resource)
+
+    def list(self):
+        """List static route of vApp network.
+
+        :return: list of dictionary contain detail of static route.
+        :rtype: list
+        """
+        list_of_route = []
+        self._get_resource()
+        fence_mode = self.resource.Configuration.FenceMode
+        if fence_mode != 'natRouted':
+            return list_of_route
+        features = self.resource.Configuration.Features
+        if not hasattr(features, 'StaticRoutingService'):
+            return list_of_route
+        route_service = features.StaticRoutingService
+        for route in route_service.StaticRoute:
+            result = {}
+            result['Name'] = route.Name
+            result['Network CIDR'] = route.Network
+            result['Next Hop IP'] = route.NextHopIp
+            list_of_route.append(result)
+        return list_of_route
+
+    def update(self, name, new_name=None, network_cidr=None, next_hop_ip=None):
+        """Update static route to vApp network.
+
+        :param str name: name of route.
+        :param str new_name: new name of route.
+        :param str network_cidr: network CIDR.
+        :param str next_hop_ip: next hop IP.
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vApp network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        :raises: InvalidParameterException: Update route to static route
+            service failed as given network's connection is not routed
+        :raises: EntityNotFoundException: if the static route not exist of
+            given name.
+        """
+        self._get_resource()
+        fence_mode = self.resource.Configuration.FenceMode
+        if fence_mode != 'natRouted':
+            raise InvalidParameterException(
+                "Update route to static route service failed as given "
+                "network's connection is not routed")
+        features = self.resource.Configuration.Features
+        if not hasattr(features, 'StaticRoutingService'):
+            raise EntityNotFoundException('static route ' + name +
+                                          ' doesn\'t exist.')
+        route_service = features.StaticRoutingService
+        is_updated = False
+        for route in route_service.StaticRoute:
+            if route.Name == name:
+                if new_name is not None:
+                    route.Name = E.Name(new_name)
+                if network_cidr is not None:
+                    route.Network = E.Network(network_cidr)
+                if next_hop_ip is not None:
+                    route.NextHopIp = E.NextHopIp(next_hop_ip)
+                is_updated = True
+        if not is_updated:
+            raise EntityNotFoundException('static route ' + name +
+                                          ' doesn\'t exist.')
+        else:
+            return self.client.put_linked_resource(
+                self.resource, RelationType.EDIT,
+                EntityType.vApp_Network.value, self.resource)
+
+    def delete(self, name):
+        """Delete static route from vApp network.
+
+        :param str name: name of static route.
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that is updating the vApp network.
+        :rtype: lxml.objectify.ObjectifiedElement
+        :raises: InvalidParameterException:  Delete route to static route
+            service failed as given network's connection is not routed
+        :raises: EntityNotFoundException: if the static route not exist of
+            given name.
+        """
+        self._get_resource()
+        fence_mode = self.resource.Configuration.FenceMode
+        if fence_mode != 'natRouted':
+            raise InvalidParameterException(
+                "Delete route to static route service failed as given "
+                "network's connection is not routed")
+        features = self.resource.Configuration.Features
+        if not hasattr(features, 'StaticRoutingService'):
+            raise EntityNotFoundException('static route ' + name +
+                                          ' doesn\'t exist.')
+        route_service = features.StaticRoutingService
+        is_deleted = False
+        for route in route_service.StaticRoute:
+            if route.Name == name:
+                route_service.remove(route)
+                is_deleted = True
+        if not is_deleted:
+            raise EntityNotFoundException('static route ' + name +
+                                          ' doesn\'t exist.')
+        else:
+            return self.client.put_linked_resource(
+                self.resource, RelationType.EDIT,
+                EntityType.vApp_Network.value, self.resource)

--- a/system_tests/vapp_static_route_tests.py
+++ b/system_tests/vapp_static_route_tests.py
@@ -19,10 +19,6 @@ from pyvcloud.system_test_framework.vapp_constants import VAppConstants
 from pyvcloud.system_test_framework.environment import Environment
 from pyvcloud.system_test_framework.environment import developerModeAware
 from pyvcloud.vcd.client import TaskStatus
-from pyvcloud.vcd.client import FenceMode
-from pyvcloud.vcd.client import IpAddressMode
-from pyvcloud.vcd.client import NetworkAdapterType
-from pyvcloud.vcd.vm import VM
 
 
 class TestVappStaticRoute(BaseTestCase):

--- a/system_tests/vapp_static_route_tests.py
+++ b/system_tests/vapp_static_route_tests.py
@@ -51,7 +51,7 @@ class TestVappStaticRoute(BaseTestCase):
         ).wait_for_success(task)
         self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
 
-    def test_0010_enable_nat_service(self):
+    def test_0010_enable_service(self):
         vapp_route = VappStaticRoute(
             TestVappStaticRoute._client,
             vapp_name=TestVappStaticRoute._vapp_name,

--- a/system_tests/vapp_static_route_tests.py
+++ b/system_tests/vapp_static_route_tests.py
@@ -1,0 +1,164 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2014-2019 VMware, Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.vcd.vapp_static_route import VappStaticRoute
+from pyvcloud.system_test_framework.vapp_constants import VAppConstants
+from pyvcloud.system_test_framework.environment import Environment
+from pyvcloud.system_test_framework.environment import developerModeAware
+from pyvcloud.vcd.client import TaskStatus
+from pyvcloud.vcd.client import FenceMode
+from pyvcloud.vcd.client import IpAddressMode
+from pyvcloud.vcd.client import NetworkAdapterType
+from pyvcloud.vcd.vm import VM
+
+
+class TestVappStaticRoute(BaseTestCase):
+    """Test vapp static route functionalities implemented in pyvcloud."""
+    _vapp_name = VAppConstants.name
+    _network_name = VAppConstants.network1_name
+    _org_vdc_network_name = 'test-direct-vdc-network'
+    _enable = True
+    _disable = False
+    _route_name = 'test_route'
+    _network_cidr = '2.2.3.0/24'
+    _next_hop_ip = '2.2.3.4'
+
+    _update_route_name = 'update_test_route'
+    _update_next_hop_ip = '2.2.3.10'
+
+    def test_0000_setup(self):
+        TestVappStaticRoute._client = Environment.get_sys_admin_client()
+        vapp = Environment.get_test_vapp_with_network(
+            TestVappStaticRoute._client)
+        vapp.reload()
+        task = vapp.connect_vapp_network_to_ovdc_network(
+            network_name=TestVappStaticRoute._network_name,
+            orgvdc_network_name=TestVappStaticRoute._org_vdc_network_name)
+        result = TestVappStaticRoute._client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_0010_enable_nat_service(self):
+        vapp_route = VappStaticRoute(
+            TestVappStaticRoute._client,
+            vapp_name=TestVappStaticRoute._vapp_name,
+            network_name=TestVappStaticRoute._network_name)
+        # disable NAT service
+        task = vapp_route.enable_service(TestVappStaticRoute._disable)
+        result = TestVappStaticRoute._client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp_route._reload()
+        features = vapp_route.resource.Configuration.Features
+        self.assertFalse(features.StaticRoutingService.IsEnabled)
+        # enable NAT service
+        task = vapp_route.enable_service(TestVappStaticRoute._enable)
+        result = TestVappStaticRoute._client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp_route._reload()
+        features = vapp_route.resource.Configuration.Features
+        self.assertTrue(features.StaticRoutingService.IsEnabled)
+
+    def test_0020_add(self):
+        vapp_route = VappStaticRoute(
+            TestVappStaticRoute._client,
+            vapp_name=TestVappStaticRoute._vapp_name,
+            network_name=TestVappStaticRoute._network_name)
+        task = vapp_route.add(TestVappStaticRoute._route_name,
+                              TestVappStaticRoute._network_cidr,
+                              TestVappStaticRoute._next_hop_ip)
+        result = TestVappStaticRoute._client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp_route._reload()
+        features = vapp_route.resource.Configuration.Features
+        self.assertTrue(hasattr(features.StaticRoutingService, 'StaticRoute'))
+
+    def test_0030_list(self):
+        vapp_route = VappStaticRoute(
+            TestVappStaticRoute._client,
+            vapp_name=TestVappStaticRoute._vapp_name,
+            network_name=TestVappStaticRoute._network_name)
+        result = vapp_route.list()
+        self.assertEqual(result[0]['Name'], TestVappStaticRoute._route_name)
+
+    def test_0040_update(self):
+        vapp_route = VappStaticRoute(
+            TestVappStaticRoute._client,
+            vapp_name=TestVappStaticRoute._vapp_name,
+            network_name=TestVappStaticRoute._network_name)
+        task = vapp_route.update(
+            name=TestVappStaticRoute._route_name,
+            new_name=TestVappStaticRoute._update_route_name,
+            next_hop_ip=TestVappStaticRoute._update_next_hop_ip)
+        result = TestVappStaticRoute._client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp_route._reload()
+        result = vapp_route.list()
+        self.assertEqual(result[0]['Name'],
+                         TestVappStaticRoute._update_route_name)
+        self.assertEqual(result[0]['Next Hop IP'],
+                         TestVappStaticRoute._update_next_hop_ip)
+
+        #revert back changes
+        task = vapp_route.update(name=TestVappStaticRoute._update_route_name,
+                                 new_name=TestVappStaticRoute._route_name,
+                                 next_hop_ip=TestVappStaticRoute._next_hop_ip)
+        result = TestVappStaticRoute._client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp_route._reload()
+        result = vapp_route.list()
+        self.assertEqual(result[0]['Name'], TestVappStaticRoute._route_name)
+        self.assertEqual(result[0]['Next Hop IP'],
+                         TestVappStaticRoute._next_hop_ip)
+
+    def test_0090_delete(self):
+        vapp_route = VappStaticRoute(
+            TestVappStaticRoute._client,
+            vapp_name=TestVappStaticRoute._vapp_name,
+            network_name=TestVappStaticRoute._network_name)
+        task = vapp_route.delete(TestVappStaticRoute._route_name)
+        result = TestVappStaticRoute._client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+        vapp_route._reload()
+        features = vapp_route.resource.Configuration.Features
+        self.assertFalse(hasattr(features.StaticRoutingService, 'StaticRoute'))
+
+    @developerModeAware
+    def test_9998_teardown(self):
+        """Test the  method vdc.delete_vapp().
+
+        Invoke the method for all the vApps created by setup.
+
+        This test passes if all the tasks for deleting the vApps succeed.
+        """
+        vdc = Environment.get_test_vdc(TestVappStaticRoute._client)
+        task = vdc.delete_vapp(name=TestVappStaticRoute._vapp_name, force=True)
+        result = TestVappStaticRoute._client.get_task_monitor(
+        ).wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
+    def test_9999_cleanup(self):
+        """Release all resources held by this object for testing purposes."""
+        TestVappStaticRoute._client.logout()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
VP-2755: [PySDK]Enable static routing in vapp network
VP-2757: [PySDK]Add static route in vapp network
VP-2759: [PySDK]Update static route in vapp network
VP-2761: [PySDK]Delete static route in vapp network
VP-2812: [PySDK]List static route in vapp network

This CLN contains Enable, Add, Update, Delete and List  static routing in vapp network.
enable_service(), add(), list(), update() and delete() methods are exposed in vapp_static_route.py class and corresponding test case added.
Testing Done:
test_0010_enable_service(), test_0020_add(),  test_0030_list(),  test_0040_update()  and test_0090_delete() are  added in test class vapp_static_route_tests.py.
It is executing successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/594)
<!-- Reviewable:end -->
