### PR TITLE
Test Failure

### DIFF
--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -770,6 +770,26 @@ def get_admin_href(href):
         return href.replace('/api/', '/api/admin/')
 
 
+def get_non_admin_href(href):
+    """Returns non admin version of a given vCD url.
+
+    This function is idempotent, which also means that if input href is already
+    a non admin href no further action would be taken.
+
+    :param str href: the admin href whose non admin href version we need.
+
+    :return: non admin version of the href.
+
+    :rtype: str
+    """
+    if '/api/admin/extension/' in href:
+        return href.replace('/api/admin/extension', '/api/')
+    elif '/api/admin/' in href:
+        return href.replace('/api/admin/', '/api/')
+    else:
+        return href
+
+
 def is_admin(href):
     """Returns True if provided href has /api/admin into it.
 

--- a/system_tests/vdc_tests.py
+++ b/system_tests/vdc_tests.py
@@ -19,12 +19,12 @@ from pyvcloud.system_test_framework.base_test import BaseTestCase
 from pyvcloud.system_test_framework.environment import CommonRoles
 from pyvcloud.system_test_framework.environment import developerModeAware
 from pyvcloud.system_test_framework.environment import Environment
-
 from pyvcloud.vcd.client import TaskStatus
 from pyvcloud.vcd.exceptions import AccessForbiddenException
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
 from pyvcloud.vcd.utils import extract_metadata_value
+from pyvcloud.vcd.utils import get_non_admin_href
 from pyvcloud.vcd.vdc import VDC
 
 
@@ -160,7 +160,8 @@ class TestOrgVDC(BaseTestCase):
         This test passes if all the acl operations are successful.
         """
         logger = Environment.get_default_logger()
-        vdc = VDC(TestOrgVDC._client, href=TestOrgVDC._new_vdc_href)
+        vdc = VDC(TestOrgVDC._client,
+                  href=get_non_admin_href(TestOrgVDC._new_vdc_href))
         vdc_name = TestOrgVDC._new_vdc_name
         vapp_user_name = Environment.get_username_for_role_in_test_org(
             CommonRoles.VAPP_USER)
@@ -234,7 +235,8 @@ class TestOrgVDC(BaseTestCase):
             vapp_author_client = Environment.get_client_in_default_org(
                 CommonRoles.VAPP_AUTHOR)
             vdc_vapp_author_view = VDC(client=vapp_author_client,
-                                       href=TestOrgVDC._new_vdc_href)
+                                       href=get_non_admin_href(
+                                           TestOrgVDC._new_vdc_href))
             sys_admin_client = Environment.get_sys_admin_client()
             vdc_sys_admin_view = VDC(client=sys_admin_client,
                                      href=TestOrgVDC._new_vdc_href)


### PR DESCRIPTION
Test Failure in pyvcloud due to href issue.

 Traceback (most recent call last):
  File "/data/jenkins/jenkins-CToT4-pysdk-sp-main-daily-317/jenkins-venv/lib/python3.7/site-packages/pyvcloud/vcd/client.py", line 1350, in get_linked_resource
    return self.get_resource(find_link(resource, rel, media_type).href)
  File "/data/jenkins/jenkins-CToT4-pysdk-sp-main-daily-317/jenkins-venv/lib/python3.7/site-packages/pyvcloud/vcd/client.py", line 1613, in find_link
    raise MissingLinkException(resource.get('href'), rel, media_type)
pyvcloud.vcd.exceptions.MissingLinkException: ('https://wdc-vcd-sp-static-34-57.eng.vmware.com/api/admin/vdc/8e49800a-e8e3-4e04-92e7-d1c777aed72e', <RelationType.DOWN: 'down'>, 'application/vnd.vmware.vcloud.controlAccess+xml'); href: https://wdc-vcd-sp-static-34-57.eng.vmware.com/api/admin/vdc/8e49800a-e8e3-4e04-92e7-d1c777aed72e, rel: RelationType.DOWN, mediaType: application/vnd.vmware.vcloud.controlAccess+xml

Status code: 403/ACCESS_TO_RESOURCE_IS_FORBIDDEN, [ 8ddfd5b5-7342-4173-820f-4af3351d48ac ] Either you need some or all of the following rights [ORG_VDC_ADMIN_VIEW] to perform operations [ORGANIZATION_VDC_VIEW] for 8e49800a-e8e3-4e04-92e7-d1c777aed72e or the target entity is invalid. (request id: 8ddfd5b5-7342-4173-820f-4af3351d48ac)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/596)
<!-- Reviewable:end -->
