### PR TITLE
VP-2661,VP-2656: Update VirtualHardwareSection media and disks

### DIFF
--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -1751,3 +1751,46 @@ class VM(object):
                 result.append(section)
 
         return result
+
+    def update_vhs_disks(self, element_name,
+                         virtual_quatntity_in_bytes=None):
+        """Update virtual hardware disk section of VM.
+
+        :param str element_name
+        :param int  virtual_quatntity_in_bytes
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task updating virtual hardware section disk.
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        uri = self.href + '/virtualHardwareSection/disks'
+        disk_list = self.client.get_resource(uri)
+
+        for disk in disk_list.Item:
+            if disk['{' + NSMAP['rasd'] + '}Description'] == 'Hard disk' and \
+                    disk['{' + NSMAP['rasd'] + '}ElementName'] == element_name:
+                disk['{' + NSMAP['rasd'] + '}VirtualQuantity'] = \
+                    virtual_quatntity_in_bytes
+
+        return self.client.put_resource(uri, disk_list,
+                                        EntityType.RASD_ITEMS_LIST.value)
+
+    def update_vhs_media(self, element_name,
+                         host_resource=None):
+        """Update virtual hardware media section of VM.
+
+        :param str element_name
+        :param str  host_resource
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task updating virtual hardware section media.
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        uri = self.href + '/virtualHardwareSection/media'
+        media_list = self.client.get_resource(uri)
+        for media in media_list.Item:
+            if media['{' + NSMAP['rasd'] + '}ElementName'] == element_name:
+                media['{' + NSMAP['rasd'] + '}HostResource'] = host_resource
+
+        return self.client.put_resource(uri, media_list,
+                                        EntityType.RASD_ITEMS_LIST.value)

--- a/system_tests/vm_tests.py
+++ b/system_tests/vm_tests.py
@@ -932,6 +932,22 @@ class TestVM(BaseTestCase):
         list = vm.list_product_sections()
         self.assertTrue(len(list) > 0)
 
+    def test_0440_update_vhs_disk(self):
+        # update vhs disk
+        vm = VM(TestVM._sys_admin_client,
+                href=TestVM._test_vapp_first_vm_href)
+        disk_list = vm.list_virtual_hardware_section(is_cpu=False,
+                                                     is_memory=False,
+                                                     is_disk=True)
+        for disk in disk_list:
+            element_name = disk['diskElementName']
+            virtual_quantity = disk['diskVirtualQuantityInBytes']
+            break
+        task = vm.update_vhs_disks(element_name=element_name,
+                                   virtual_quatntity_in_bytes=virtual_quantity)
+        result = TestVM._client.get_task_monitor().wait_for_success(task)
+        self.assertEqual(result.get('status'), TaskStatus.SUCCESS.value)
+
     @developerModeAware
     def test_9998_teardown(self):
         """Delete the vApp created during setup.


### PR DESCRIPTION
VP-2661:[PYSDK] update virtualHardwareSection/media
VP-2656:[PYSDK] Update virtualHardwareSection-disks

This CLN contains update operation on VirtualHardwareSection media and
disks.

Testing Done:
Test method test_0440_update_vhs_disk is added. IN the given VM template
update media gives response as 405/METHOD_NOT_ALLOWED, so test case is
not added for update media operation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/601)
<!-- Reviewable:end -->
