### PR TITLE
VP-2904: Logger issue in pyvcloud

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -808,11 +808,15 @@ class Client(object):
         if file_name is None:
             file_name = "vcd_pysdk.log"
         self._logger = logging.getLogger(file_name)
-        Path(file_name).parent.mkdir(parents=True, exist_ok=True)
-        default_log_handler = handlers.RotatingFileHandler(
-            filename=file_name, maxBytes=max_bytes, backupCount=backup_count)
-        default_log_handler.setLevel(log_level)
-        self._logger.addHandler(default_log_handler)
+        file = Path(file_name)
+        if not file.exists():
+            file.parent.mkdir(parents=True, exist_ok=True)
+        if not self._logger.handlers:
+            default_log_handler = handlers.RotatingFileHandler(
+                filename=file_name, maxBytes=max_bytes,
+                backupCount=backup_count)
+            default_log_handler.setLevel(log_level)
+            self._logger.addHandler(default_log_handler)
 
     def _get_response_request_id(self, response):
         """Extract request id of a request to vCD from the response.


### PR DESCRIPTION
VP-2904: Logger issue in pyvcloud

Bug in pyvcloud wire logging.

All pyvcloud clients share the same logger instance.

Everytime you create a new client, you will end up adding a new handler to the logger

which means each log statement will be printed n times where n = number of created clients

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/605)
<!-- Reviewable:end -->
