### PR TITLE
VP-2938: Failure in SCS

### DIFF
--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -41,6 +41,7 @@ from pyvcloud.vcd.org import Org
 from pyvcloud.vcd.platform import Platform
 from pyvcloud.vcd.utils import cidr_to_netmask
 from pyvcloud.vcd.utils import get_admin_href
+from pyvcloud.vcd.utils import get_non_admin_href
 from pyvcloud.vcd.utils import is_admin
 from pyvcloud.vcd.utils import netmask_to_cidr_prefix_len
 from pyvcloud.vcd.utils import retrieve_compute_policy_id_from_href
@@ -1076,7 +1077,9 @@ class VDC(object):
         :rtype: lxml.objectify.ObjectifiedElement
         """
         self.get_resource()
-
+        if is_admin(self.resource.get('href')):
+            non_admin_href = get_non_admin_href(self.resource.get('href'))
+            self.resource = self.client.get_resource(non_admin_href)
         network_href = network_name = None
         if network is not None:
             if hasattr(self.resource, 'AvailableNetworks') and \

--- a/system_tests/vdc_tests.py
+++ b/system_tests/vdc_tests.py
@@ -17,13 +17,11 @@ from pyvcloud.system_test_framework.base_test import BaseTestCase
 from pyvcloud.system_test_framework.environment import CommonRoles
 from pyvcloud.system_test_framework.environment import developerModeAware
 from pyvcloud.system_test_framework.environment import Environment
-from pyvcloud.system_test_framework.utils import create_independent_disk
 from pyvcloud.vcd.client import TaskStatus
 from pyvcloud.vcd.exceptions import AccessForbiddenException
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
 from pyvcloud.vcd.utils import extract_metadata_value
-from pyvcloud.vcd.utils import get_non_admin_href
 from pyvcloud.vcd.vdc import VDC
 class TestOrgVDC(BaseTestCase):
     """Test OrgVDC functionalities implemented in pyvcloud."""
@@ -161,8 +159,7 @@ class TestOrgVDC(BaseTestCase):
         This test passes if all the acl operations are successful.
         """
         logger = Environment.get_default_logger()
-        vdc = VDC(TestOrgVDC._client,
-                  href=get_non_admin_href(TestOrgVDC._new_vdc_href))
+        vdc = VDC(TestOrgVDC._client, href=TestOrgVDC._new_vdc_href)
         vdc_name = TestOrgVDC._new_vdc_name
         vapp_user_name = Environment.get_username_for_role_in_test_org(
             CommonRoles.VAPP_USER)
@@ -236,8 +233,7 @@ class TestOrgVDC(BaseTestCase):
             vapp_author_client = Environment.get_client_in_default_org(
                 CommonRoles.VAPP_AUTHOR)
             vdc_vapp_author_view = VDC(client=vapp_author_client,
-                                       href=get_non_admin_href(
-                                           TestOrgVDC._new_vdc_href))
+                                       href=TestOrgVDC._new_vdc_href)
             sys_admin_client = Environment.get_sys_admin_client()
             vdc_sys_admin_view = VDC(client=sys_admin_client,
                                      href=TestOrgVDC._new_vdc_href)


### PR DESCRIPTION
VP-2938: Failure in SCS

Traceback (most recent call last):
  File "c:\code\container-service-extension\container_service_extension\vcdbroker.py", line 611, in _create_cluster_async
    fence_mode='bridged')
  File "C:\Users\sena\Envs\cse\lib\site-packages\pyvcloud-20.1.1.dev73-py3.7.egg\pyvcloud\vcd\vdc.py", line 1088, in create_vapp
    EntityType.COMPOSE_VAPP_PARAMS.value, params)
  File "C:\Users\sena\Envs\cse\lib\site-packages\pyvcloud-20.1.1.dev73-py3.7.egg\pyvcloud\vcd\client.py", line 1326, in post_linked_resource
    "Operation is not supported").with_traceback(e.__traceback__)
  File "C:\Users\sena\Envs\cse\lib\site-packages\pyvcloud-20.1.1.dev73-py3.7.egg\pyvcloud\vcd\client.py", line 1322, in post_linked_resource
    find_link(resource, rel, media_type).href, contents,
  File "C:\Users\sena\Envs\cse\lib\site-packages\pyvcloud-20.1.1.dev73-py3.7.egg\pyvcloud\vcd\client.py", line 1614, in find_link
    raise MissingLinkException(resource.get('href'), rel, media_type)
pyvcloud.vcd.exceptions.OperationNotSupportedException: Operation is not supported

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/608)
<!-- Reviewable:end -->
