### PR TITLE
Implement update VM compute policy

### DIFF
--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -125,6 +125,16 @@ class VM(object):
             self.resource.VmSpecSection.MemoryResourceMb.Configured.text)
 
     def update_compute_policy(self, compute_policy_href, compute_policy_id):
+        """Updates the VdcComputePolicy of this VM.
+
+        :param str compute_policy_href: compute policy href to update to.
+        :param str id: compute policy id to update to.
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task that updates the vm.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
         if float(self.client.get_api_version()) < \
                 float(ApiVersion.VERSION_32.value):
             raise OperationNotSupportedException("Unsupported API version")

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -135,9 +135,12 @@ class VM(object):
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
-        if float(self.client.get_api_version()) < \
-                float(ApiVersion.VERSION_32.value):
-            raise OperationNotSupportedException("Unsupported API version")
+        api_version = self.client.get_api_version()
+        required_api_version = ApiVersion.VERSION_32.value
+        if float(api_version) < float(required_api_version):
+            raise OperationNotSupportedException(
+                f"Unsupported API version. Received '{required_api_version}' "
+                f"but '{api_version}' is required.")
 
         vm_resource = self.get_resource()
         vm_resource.VdcComputePolicy.set('href', compute_policy_href)

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -133,11 +133,12 @@ class VM(object):
         vm_resource.VdcComputePolicy.set('href', compute_policy_href)
         vm_resource.VdcComputePolicy.set('id', compute_policy_id)
 
-        link = find_link(self.resource,
-                         RelationType.RECONFIGURE_VM,
-                         EntityType.VM.value)
-        uri = link.href
-        return self.client.post_resource(uri, vm_resource, EntityType.VM.value)
+        reconfigure_vm_link = find_link(self.resource,
+                                        RelationType.RECONFIGURE_VM,
+                                        EntityType.VM.value)
+        return self.client.post_resource(reconfigure_vm_link.href,
+                                         vm_resource,
+                                         EntityType.VM.value)
 
     def modify_cpu(self, virtual_quantity, cores_per_socket=None):
         """Updates the number of CPUs of a vm.


### PR DESCRIPTION
Added `update_compute_policy` function to **vm.py**

This function takes a compute policy href and id and updates the VM to have the specified compute policy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/615)
<!-- Reviewable:end -->
