### PR TITLE
Bugfixes for *_to_dict and list_nics methods

### DIFF
--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -193,7 +193,8 @@ def pvdc_to_dict(pvdc, refs=None, metadata=None):
     result = {}
     result['name'] = pvdc.get('name')
     result['id'] = extract_id(pvdc.get('id'))
-    result['description'] = str(pvdc.Description)
+    if hasattr(pvdc, 'Description'):
+        result['description'] = str(pvdc.Description)
     if hasattr(pvdc, 'IsEnabled'):
         result['is_enabled'] = bool(pvdc.IsEnabled)
     if hasattr(pvdc, 'AvailableNetworks') and \
@@ -439,32 +440,31 @@ def vm_to_dict(vm):
     if hasattr(vm, 'Description'):
         result['description'] = vm.Description.text
     result['id'] = vm.get('id')
-
     result['deployed'] = vm.get('deployed')
     result['status'] = VCLOUD_STATUS_MAP.get(int(vm.get('status')))
     result['needs-customization'] = vm.get('needsCustomization')
     if hasattr(vm, 'VCloudExtension'):
         result['moref'] = vm.VCloudExtension[
-            '{' + NSMAP['vmext'] +
-            '}VmVimInfo']['{' + NSMAP['vmext'] +
-                          '}VmVimObjectRef']['{' + NSMAP['vmext'] +
-                                             '}MoRef'].text
-    result['computer-name'] = vm.GuestCustomizationSection.ComputerName.text
+            '{' + NSMAP['vmext'] + '}VmVimInfo'][
+                '{' + NSMAP['vmext'] + '}VmVimObjectRef'][
+                    '{' + NSMAP['vmext'] + '}MoRef'].text
+    if hasattr(vm, 'GuestCustomizationSection'):
+        result['computer-name'] = \
+            vm.GuestCustomizationSection.ComputerName.text
 
     disk_instance_name_map = {}
     nic_instance_name_map = {}
-    for item in vm['{' + NSMAP['ovf'] +
-                   '}VirtualHardwareSection']['{' + NSMAP['ovf'] + '}Item']:
-        if item['{' + NSMAP['rasd'] + '}ResourceType'].text == str(10):
-            nic_instance_name_map[
-                item['{' + NSMAP['rasd'] +
-                     '}AddressOnParent'].text] = item['{' + NSMAP['rasd'] +
-                                                      '}ElementName'].text
-        if item['{' + NSMAP['rasd'] + '}ResourceType'].text == str(17):
-            disk_instance_name_map[
-                item['{' + NSMAP['rasd'] +
-                     '}InstanceID'].text] = item['{' + NSMAP['rasd'] +
-                                                 '}ElementName'].text
+    if hasattr(vm, '{' + NSMAP['ovf'] + '}VirtualHardwareSection'):
+        for item in vm['{' + NSMAP['ovf'] + '}VirtualHardwareSection'][
+                '{' + NSMAP['ovf'] + '}Item']:
+            if item['{' + NSMAP['rasd'] + '}ResourceType'].text == str(10):
+                nic_instance_name_map[
+                    item['{' + NSMAP['rasd'] + '}AddressOnParent'].text] = \
+                    item['{' + NSMAP['rasd'] + '}ElementName'].text
+            if item['{' + NSMAP['rasd'] + '}ResourceType'].text == str(17):
+                disk_instance_name_map[
+                    item['{' + NSMAP['rasd'] + '}InstanceID'].text] = \
+                    item['{' + NSMAP['rasd'] + '}ElementName'].text
 
     if hasattr(vm, 'NetworkConnectionSection'):
         ncs = vm.NetworkConnectionSection

--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -527,7 +527,7 @@ def task_to_dict(task):
 
     :rtype: dict
     """
-    result = to_dict(task)
+    result = to_dict(task, exclude=[])
     if hasattr(task, 'Owner'):
         result['owner_name'] = task.Owner.get('name')
         result['owner_href'] = task.Owner.get('href')
@@ -537,7 +537,7 @@ def task_to_dict(task):
     if hasattr(task, 'Organization'):
         result['organization'] = task.Organization.get('name')
     if hasattr(task, 'Details'):
-        result['details'] = task.Details
+        result['details'] = task.Details.text
     return result
 
 

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -585,30 +585,32 @@ class VM(object):
 
         :rtype: list
         """
-        nics = []
-        self.get_resource()
-        if hasattr(self.resource.NetworkConnectionSection,
-                   'PrimaryNetworkConnectionIndex'):
-            primary_index = self.resource.NetworkConnectionSection.\
-                PrimaryNetworkConnectionIndex.text
+        # get network connection section.
+        net_conn_section = self.get_resource().NetworkConnectionSection
 
-        for nc in self.resource.NetworkConnectionSection.NetworkConnection:
-            nic = {}
-            nic[VmNicProperties.INDEX.value] = nc.NetworkConnectionIndex.text
-            nic[VmNicProperties.CONNECTED.value] = nc.IsConnected.text
-            nic[VmNicProperties.PRIMARY.value] = (
-                primary_index == nc.NetworkConnectionIndex.text)
-            nic[VmNicProperties.ADAPTER_TYPE.
-                value] = nc.NetworkAdapterType.text
-            nic[VmNicProperties.NETWORK.value] = nc.get(
-                VmNicProperties.NETWORK.value)
-            nic[VmNicProperties.IP_ADDRESS_MODE.
-                value] = nc.IpAddressAllocationMode.text
-            if hasattr(nc, 'IpAddress'):
-                nic[VmNicProperties.IP_ADDRESS.value] = nc.IpAddress.text
-            if hasattr(nc, 'MACAddress'):
-                nic[VmNicProperties.MAC_ADDRESS.value] = nc.MACAddress.text
-            nics.append(nic)
+        nics = []
+        if hasattr(net_conn_section, 'PrimaryNetworkConnectionIndex'):
+            primary_index = net_conn_section.PrimaryNetworkConnectionIndex.text
+
+        if hasattr(net_conn_section, 'NetworkConnection'):
+            for nc in net_conn_section.NetworkConnection:
+                nic = {}
+                nic[VmNicProperties.INDEX.value] = \
+                    nc.NetworkConnectionIndex.text
+                nic[VmNicProperties.CONNECTED.value] = nc.IsConnected.text
+                nic[VmNicProperties.PRIMARY.value] = (
+                    primary_index == nc.NetworkConnectionIndex.text)
+                nic[VmNicProperties.ADAPTER_TYPE.
+                    value] = nc.NetworkAdapterType.text
+                nic[VmNicProperties.NETWORK.value] = nc.get(
+                    VmNicProperties.NETWORK.value)
+                nic[VmNicProperties.IP_ADDRESS_MODE.
+                    value] = nc.IpAddressAllocationMode.text
+                if hasattr(nc, 'IpAddress'):
+                    nic[VmNicProperties.IP_ADDRESS.value] = nc.IpAddress.text
+                if hasattr(nc, 'MACAddress'):
+                    nic[VmNicProperties.MAC_ADDRESS.value] = nc.MACAddress.text
+                nics.append(nic)
         return nics
 
     def delete_nic(self, index):


### PR DESCRIPTION
Fixed following issues:
1. `utils.task_to_dict` returned `task.Details` as `StringElement` and not `str`.
2. `utils.task_to_dict` didn't include the `href`, which is needed by TaskMonitor.
3. `vm.list_nics` failed when no nic is attached to vm (no attribute `NetworkConnection`).
4. `utils.pvdc_to_dict` failed with "no such child attribute error" when Description is not available.
5. `utils.vm_to_dict` failed with "no such child attribute error" when GuestCustomization is not enabled.
6. `utils.vm_to_dict` failed with "no such child attribute error" when VirtualHardwareSection is not available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/622)
<!-- Reviewable:end -->
