### PR TITLE
fix-bug-page-size

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -1790,7 +1790,7 @@ class _AbstractQuery(object):
         uri += str(page)
 
         if (page_size is not None):
-            uri += 'pageSize='
+            uri += '&pageSize='
             uri += str(page_size)
 
         if qfilter is not None:


### PR DESCRIPTION
Fixing issue when executing a typed query using the parameter pageSize : 400 Bad request.

& character is not added on the URI when using the paramater pageSize on the function _build_query_uri. It lealds to a 400 bad request when executing it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/629)
<!-- Reviewable:end -->
