### PR TITLE
Fix #630 list_rights_available_in_system

### DIFF
--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -1261,7 +1261,7 @@ class Org(object):
 
         :rtype: list
         """
-        return self.list_rights_available_in_vcd(self, name_filter)
+        return self.list_rights_available_in_vcd(name_filter)
 
     def list_rights_available_in_vcd(self, name_filter=None):
         """Retrieves all rights available in the vcd.


### PR DESCRIPTION
Fix #630 : list_rights_available_in_system: bad usage of list_rights_available_in_vcd

Remove self as an arg of `list_rights_available_in_vcd` where it is not expected to be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/631)
<!-- Reviewable:end -->
