### PR TITLE
Preserve session's data when connecting for further usages

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -966,13 +966,13 @@ class Client(object):
                 else:
                     raise VcdException('Login failed.')
 
-            session = objectify.fromstring(response.content)
-            self._session_endpoints = _get_session_endpoints(session)
+            self.session = objectify.fromstring(response.content)
+            self._session_endpoints = _get_session_endpoints(self.session)
 
             self._session = new_session
             self._session.headers[self._HEADER_X_VCLOUD_AUTH_NAME] = \
                 response.headers[self._HEADER_X_VCLOUD_AUTH_NAME]
-            self._is_sysadmin = self._is_sys_admin(session.get('org'))
+            self._is_sysadmin = self._is_sys_admin(self.session.get('org'))
         except Exception:
             new_session.close()
             raise
@@ -1015,14 +1015,15 @@ class Client(object):
                 sc, self._get_response_request_id(response),
                 _objectify_response(response))
 
-        session = objectify.fromstring(response.content)
+        self.session = objectify.fromstring(response.content)
 
-        self._is_sysadmin = self._is_sys_admin(session.get('org'))
-        self._session_endpoints = _get_session_endpoints(session)
+        self._is_sysadmin = self._is_sys_admin(self.session.get('org'))
+        self._session_endpoints = _get_session_endpoints(self.session)
         self._session = new_session
         self._session.headers[self._HEADER_X_VCLOUD_AUTH_NAME] = \
             response.headers[self._HEADER_X_VCLOUD_AUTH_NAME]
-        return session
+        # Preserve backward compatibility by returning the session object
+        return self.session
 
     def logout(self):
         """Destroy the server session and de-allocate local resources.
@@ -1035,6 +1036,7 @@ class Client(object):
             result = self._do_request('DELETE', uri)
             self._session.close()
             self._session = None
+            self.session = None
             return result
 
     def _is_sys_admin(self, logged_in_org):


### PR DESCRIPTION
Preserve session's data when connecting for further usages

Set a `client.session` member based on the `objectify.fromstring(response.content)` from POST request to the /sessions. This enable to retrieve the session content (like current user's role) from the client object when needed.

Ex: Get user's role:
```python
# Get role for user
user_role = user_client.session.get('roles')
```

Backward compatibility should be preserved as the session is also returned directly when calling the `client.rehydrate_from_token(token)` method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/634)
<!-- Reviewable:end -->
