### PR TITLE
[VCDA-1333] Adding support for VMSizingPolicy while dealing with compute policies on VMs

### DIFF
--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -1929,7 +1929,7 @@ class Org(object):
                                                              catalog_item_name)
         template_resource = self.client.get_resource(template_resource_href)
 
-        template_updation_required = False
+        template_update_required = False
         if hasattr(template_resource, 'Children') and \
                 hasattr(template_resource.Children, 'Vm'):
             for vm in template_resource.Children.Vm:
@@ -1937,19 +1937,19 @@ class Org(object):
                     vm_compute_policy_id = vm.VdcComputePolicy.get('id')
                     if not policy_id or policy_id == vm_compute_policy_id:
                         vm.remove(vm.VdcComputePolicy)
-                        template_updation_required = True
+                        template_update_required = True
                 if hasattr(vm, 'ComputePolicy') and hasattr(vm.ComputePolicy, 'VmSizingPolicy'):  # noqa: E501
                     vm_compute_policy_id = \
                         vm.ComputePolicy.VmSizingPolicy.get('id')
                     if not policy_id or policy_id == vm_compute_policy_id:
                         vm.ComputePolicy.remove(
                             vm.ComputePolicy.VmSizingPolicy)
-                        template_updation_required = True
+                        template_update_required = True
                         if hasattr(vm.ComputePolicy, 'VmSizingPolicyFinal'):  # noqa: E501
                             vm.ComputePolicy.remove(
                                 vm.ComputePolicy.VmSizingPolicyFinal)
 
-        if template_updation_required:
+        if template_update_required:
             return self.client.put_resource(
                 template_resource_href,
                 template_resource,


### PR DESCRIPTION
Till api v32.0, Compute Policies were associated with VMs via the VdcComputePolicy tag.
In api v33.0, VdcComputePolicy tag was deprecated and replaced by ComputePolicy-VmSizingPolicy tags.
And in api v34.0, VdcComputePolicy will be completely removed.

This PR, reflects the shift in XML tags for associating/disassociating compute policies with/from VMs. The methods to assign/remove compute policies to/from vms in either vApp template or vApp has been modified to take into account VmSizingPolicy (depending on the api version used).

Testing Done : 
Manually tested the following on vCD 9.7, vCD 10.0 and vCD 10.0.0.1
Template used - photon-v2_k8-1.14_weave-2.5.2

* CSE startup with template rule - Success - Assigned policy correctly to template vm
* Deploy cluster on ovdc without compute policy - Success
* Add policy to ovdc - Success
* List compute policy on ovdc - Success
* Deploy cluster on ovdc with compute policy - Success
* Remove compute policy from ovdc - Success - Removed policy from vApp vms correctly when used with --force option
* CSE startup without template rule - Success - Removed policy from template vm

No system tests were added since compute policy changes are not supported by system tests as of now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/636)
<!-- Reviewable:end -->
