### PR TITLE
fixing bug where only one disk is listed even if there are more

### DIFF
--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -1037,16 +1037,16 @@ class VM(object):
         if is_disk:
             uri = self.href + '/virtualHardwareSection/disks'
             disk_list = self.client.get_resource(uri)
-            vhs_disk_info = {}
+
             for disk in disk_list.Item:
                 if disk['{' + NSMAP['rasd'] + '}Description'] == 'Hard disk':
-                    vhs_disk_info['diskElementName'] = disk[
-                        '{' + NSMAP['rasd'] + '}ElementName']
-                    vhs_disk_info['diskVirtualQuantityInBytes'] \
-                        = disk[
-                        '{' + NSMAP['rasd'] + '}VirtualQuantity']
-
-            result.append(vhs_disk_info)
+                    vhs_disk_info = {
+                        'diskElementName': disk[
+                            '{' + NSMAP['rasd'] + '}ElementName'],
+                        'diskVirtualQuantityInBytes': disk[
+                            '{' + NSMAP['rasd'] + '}VirtualQuantity']
+                    }
+                    result.append(vhs_disk_info)
 
         if is_media:
             uri = self.href + '/virtualHardwareSection/media'


### PR DESCRIPTION
Fixes a bug where only one disk is returned even if there are more.

https://github.com/vmware/pyvcloud/issues/628

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/644)
<!-- Reviewable:end -->
