### PR TITLE
Add a client with model bindings for REST API and CloudAPI

### DIFF
--- a/pyvcloud/vcd/api_client.py
+++ b/pyvcloud/vcd/api_client.py
@@ -12,12 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pyvcloud.vcd.client import Client
-from pyvcloud.vcd.client import ClientException
-from pyvcloud.vcd.api_helper import ApiHelper
 
 from vcloud.api.rest.schema_v1_5.task_type import TaskType
 from vcloud.rest.openapi.models.link import Link
+
+from pyvcloud.vcd.api_helper import ApiHelper
+from pyvcloud.vcd.client import Client, ClientException
 
 
 class ApiClient(Client):
@@ -86,6 +86,7 @@ class ApiClient(Client):
         is_api = self._is_api_uri(uri)
         accept_type = self._get_accept_type(is_api)
         contents_json = self._api_helper.sanitize_for_serialization(contents)
+        self._status = self._headers = self._links = self._headers = None
         response = self._do_request_prim(method,
                                          uri,
                                          self._session,

--- a/pyvcloud/vcd/api_client.py
+++ b/pyvcloud/vcd/api_client.py
@@ -1,0 +1,332 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pyvcloud.vcd.client import Client
+from pyvcloud.vcd.client import ClientException
+from pyvcloud.vcd.api_helper import ApiHelper
+
+from vcloud.api.rest.schema_v1_5.task_type import TaskType
+from vcloud.rest.openapi.models.link import Link
+
+
+class ApiClient(Client):
+    """A low-level interface to the vCloud Director REST API and CloudAPI.
+
+    API client provides an uniform way to invoke REST API and CloudAPI
+    endpoints. The client uses generated model classes for request and
+    response payloads.
+
+    :param str uri: vCD server host name or connection URI.
+    :param str api_version: vCD API version to use.
+    :param boolean verify_ssl_certs: If True validate server certificate;
+        False allows self-signed certificates.
+    :param str log_file: log file name or None, which suppresses logging.
+    :param boolean log_request: if True log HTTP requests.
+    :param boolean log_headers: if True log HTTP headers.
+    :param boolean log_bodies: if True log HTTP bodies.
+    """
+    API = '/api/'
+    CLOUDAPI = '/cloudapi/'
+
+    ACCEPT_TYPE_API = 'application/json'
+    ACCEPT_TYPE_CLOUDAPI = 'application/*+json'
+
+    def __init__(self,
+                 uri,
+                 api_version=None,
+                 verify_ssl_certs=True,
+                 log_file=None,
+                 log_requests=False,
+                 log_headers=False,
+                 log_bodies=False):
+        super().__init__(uri, api_version, verify_ssl_certs, log_file,
+                         log_requests, log_headers, log_bodies)
+        self._api_helper = ApiHelper()
+        self._status = None
+        self._headers = None
+        self._links = None
+        self._task = None
+
+    def call_api(self,
+                 method,
+                 uri,
+                 contents=None,
+                 media_type=None,
+                 params=None,
+                 response_type=None):
+        """Invokes a vCD API.
+
+        This method calls a vCD API and stores response status code, links
+        and returned task if any. Model objects are serialized/deserialized
+        to/from JSON objects.
+
+        :param str method: http request method.
+        :param str uri: complete request URI.
+        :param object contents: model object containing the request payload.
+        :param str media_type: media type of content.
+        :param dict params: query parameters.
+        :param type response_type: model class of the response.
+
+        :return: model object containing the response.
+
+        :rtype: object
+
+        """
+        is_api = self._is_api_uri(uri)
+        accept_type = self._get_accept_type(is_api)
+        contents_json = self._api_helper.sanitize_for_serialization(contents)
+        response = self._do_request_prim(method,
+                                         uri,
+                                         self._session,
+                                         contents=contents_json,
+                                         media_type=media_type,
+                                         accept_type=accept_type,
+                                         params=params)
+        self._status = response.status_code
+        self._headers = response.headers
+        response_model = None
+        if response_type:
+            response_model = self._api_helper.deserialize(
+                response, response_type)
+        self._store_links(is_api, response_model)
+        self._store_task(is_api, response_model)
+        return response_model
+
+    def _is_api_uri(self, uri):
+        if self.API in uri:
+            return True
+        elif self.CLOUDAPI in uri:
+            return False
+        else:
+            raise ClientException('%s is not a valid vCD URI' % uri)
+
+    def build_api_uri(self, resource_path):
+        """Builds API uri.
+
+        :param str resource_path: relative resource path.
+
+        :return: complete API uri.
+
+        :rtype: str
+
+        """
+        return self.get_api_uri() + resource_path
+
+    def build_cloudapi_uri(self, resource_path):
+        """Builds CloudAPI uri.
+
+        :param str resource_path: relative resource path.
+
+        :return: complete CloudAPI uri.
+
+        :rtype: str
+
+        """
+        return self.get_cloudapi_uri() + resource_path
+
+    def _get_accept_type(self, is_api):
+        if is_api:
+            return self.ACCEPT_TYPE_CLOUDAPI
+        else:
+            return self.ACCEPT_TYPE_API
+
+    def _store_links(self, is_api, response):
+        self._links = []
+        if is_api:
+            if hasattr(response, 'link') and response.link is not None:
+                self._links = response.link
+        elif 'Link' in self._headers:
+            for link in self._headers['Link'].split(', '):
+                link_entries = link.split(';')
+                link = Link()
+                setattr(link, 'href', link_entries[0].strip('<>'))
+                for i in range(1, len(link_entries)):
+                    key_value = link_entries[i].split('=')
+                    setattr(link, key_value[0], key_value[1].strip('"'))
+                self._links.append(link)
+
+    def _store_task(self, is_api, response):
+        if isinstance(response, TaskType):
+            self._task = response
+        if is_api:
+            if hasattr(response, 'tasks'):
+                tasks = response.tasks
+                if tasks is not None and len(tasks) > 0:
+                    self._task = tasks[0]
+        elif 'Location' in self._headers:
+            task_href = self._headers.get('Location')
+            if task_href is not None:
+                self._task = self.call_api('GET',
+                                           uri=task_href,
+                                           response_type=TaskType)
+
+    def get_last_status(self):
+        """Returns the status of last API call
+
+        :return: Status code of last response
+
+        :rtype: int
+        """
+        return self._status
+
+    def get_last_headers(self):
+        """Returns response headers of last API call
+
+        :return: response headers
+
+        :rtype: dict
+        """
+        return self._headers
+
+    def get_last_links(self):
+        """Returns links received in last API call.
+
+        :return: list of Links.
+
+        :rtype: list
+        """
+        return self._links
+
+    def find_first_link(self, rel, **kwargs):
+        """Finds first links by relation and other attributes.
+
+        :param str rel: relation of the desired link.
+
+        :param dict kwargs: list of key-value pairs to search the desired link.
+
+        :return: first link with the given relation and search attributes,
+            None otherwise.
+
+        :rtype: list
+        """
+        for link in self._links:
+            if rel in link.rel.split():
+                link_found = True
+                for attr in kwargs:
+                    if kwargs[attr] != getattr(link, attr):
+                        link_found = False
+                        break
+                if link_found:
+                    return link
+        return None
+
+    def get_last_task(self):
+        """Gets the task of last API call.
+
+        :return: task received from vCD.
+
+        :rtype: TaskType
+        """
+        return self._task
+
+    def wait_for_task(self, task):
+        """Waits for success of a given task.
+
+        :param TaskType task: task we are waiting for.
+        """
+        if task is not None:
+            self.get_task_monitor().wait_for_success(
+                self.get_resource(task.href))
+
+    def wait_for_last_task(self):
+        """Waits for the success of last task.
+        """
+        self.wait_for_task(self._task)
+
+
+class QueryParamsBuilder(object):
+    """An interface to set query parameters.
+
+    It provides setters for all query parameters and a method to get complete
+    parameters set in a dictionary format.
+    """
+    IDRECORDS = 'idrecords',
+    RECORDS = 'records',
+    REFERENCES = 'references'
+
+    def __init__(self):
+        """Constructor of query parameters.
+
+        Initializes the parameters to am empty dictionary.
+        """
+        self._query_params = {}
+
+    def set_filter(self, filter_):
+        """Sets the filter expression.
+
+        :param str filter_: filter expression of the query
+        """
+        self._query_params['filter'] = filter_
+        return self
+
+    def set_format(self, format_):
+        """Sets the format of query result.
+
+        :param str format_: valid formats are, idrecords/records/references.
+        """
+        self._query_params['format'] = format_
+        return self
+
+    def set_page(self, page):
+        """Sets the page number of query result.
+
+        :param str page: if result has multiple pages, get the specific result
+            page.
+        """
+        self._query_params['page'] = page
+        return self
+
+    def set_page_size(self, page_size):
+        """Sets the page size of query result.
+
+        :param str page_size: get 'page_size' number of results per page.
+        """
+        self._query_params['pageSize'] = page_size
+        return self
+
+    def set_sort_asc(self, sort_asc):
+        """Sets sort_asc in the query.
+
+        :param str sort_asc: if 'name' field is present in the result sort
+            ascending by that field.
+        """
+        self._query_params['sortAsc'] = sort_asc
+        return self
+
+    def set_sort_desc(self, sort_desc):
+        """Sets sort_desc in the query.
+
+        :param str sort_desc: if 'name' field is present in the result sort
+            descending by that field.
+        """
+        self._query_params['sortDesc'] = sort_desc
+        return self
+
+    def set_type(self, type_):
+        """Sets type of entity to query REST API.
+
+        :param str type_: type of the vCD entity.
+        """
+        self._query_params['type'] = type_
+        return self
+
+    def build(self):
+        """Gets the final set of query parameters.
+
+        :return: final set of query parameters.
+
+        :rtype: dict
+        """
+        self._query_params['filterEncoded'] = 'true'
+        return self._query_params

--- a/pyvcloud/vcd/api_client.py
+++ b/pyvcloud/vcd/api_client.py
@@ -17,7 +17,8 @@ from vcloud.api.rest.schema_v1_5.task_type import TaskType
 from vcloud.rest.openapi.models.link import Link
 
 from pyvcloud.vcd.api_helper import ApiHelper
-from pyvcloud.vcd.client import Client, ClientException
+from pyvcloud.vcd.client import Client
+from pyvcloud.vcd.client import ClientException
 
 
 class ApiClient(Client):
@@ -36,6 +37,7 @@ class ApiClient(Client):
     :param boolean log_headers: if True log HTTP headers.
     :param boolean log_bodies: if True log HTTP bodies.
     """
+
     API = '/api/'
     CLOUDAPI = '/cloudapi/'
 
@@ -173,7 +175,7 @@ class ApiClient(Client):
                                            response_type=TaskType)
 
     def get_last_status(self):
-        """Returns the status of last API call
+        """Returns the status of last API call.
 
         :return: Status code of last response
 
@@ -182,7 +184,7 @@ class ApiClient(Client):
         return self._status
 
     def get_last_headers(self):
-        """Returns response headers of last API call
+        """Returns response headers of last API call.
 
         :return: response headers
 
@@ -241,8 +243,7 @@ class ApiClient(Client):
                 self.get_resource(task.href))
 
     def wait_for_last_task(self):
-        """Waits for the success of last task.
-        """
+        """Waits for the success of last task."""
         self.wait_for_task(self._task)
 
 
@@ -252,6 +253,7 @@ class QueryParamsBuilder(object):
     It provides setters for all query parameters and a method to get complete
     parameters set in a dictionary format.
     """
+
     IDRECORDS = 'idrecords',
     RECORDS = 'records',
     REFERENCES = 'references'

--- a/pyvcloud/vcd/api_helper.py
+++ b/pyvcloud/vcd/api_helper.py
@@ -1,0 +1,306 @@
+import os
+import re
+import json
+import mimetypes
+import tempfile
+from dateutil.parser import parse
+from datetime import date, datetime
+
+from six import integer_types, iteritems, text_type
+
+import inspect
+from importlib import import_module
+
+from vcloud.rest.openapi import models
+from vcloud.api.rest import schema_v1_5
+from vcloud.api.rest.schema_v1_5 import extension
+from vcloud.api.rest.schema_v1_5.query_result_record_type import (
+    QueryResultRecordType)
+from vcloud.api.rest.schema import ovf, versioning
+from vcloud.api.rest.schema.ovf import environment, vmware
+from vcloud.rest.openapi.models import session
+from pyvcloud.vcd.client import ClientException
+from enum import Enum
+
+
+class ApiHelper(object):
+
+    PRIMITIVE_TYPES = (float, bool, bytes, text_type) + integer_types
+    NATIVE_TYPES_MAPPING = {
+        'int': int,
+        'long': int,
+        'float': float,
+        'str': str,
+        'bool': bool,
+        'date': date,
+        'datetime': datetime,
+        'object': object,
+    }
+
+    def __init__(self):
+        """
+        Constructor of the class.
+        """
+        # Load all cloudapi model classes in models
+        for file in os.listdir(os.path.dirname(session.__file__)):
+            mod_name = file[:-3]
+            if mod_name.startswith('__'):
+                continue
+            module = import_module('vcloud.rest.openapi.models.' + mod_name)
+            setattr(models, mod_name, module)
+            for name, obj in inspect.getmembers(module, inspect.isclass):
+                if inspect.isclass(obj):
+                    setattr(models, name, obj)
+
+    def sanitize_for_serialization(self, obj):
+        """
+        Builds a JSON POST object.
+
+        If obj is None, return None.
+        If obj is str, int, long, float, bool, return directly.
+        If obj is datetime.datetime, datetime.date
+            convert to string in iso8601 format.
+        If obj is list, sanitize each element in the list.
+        If obj is dict, return the dict.
+        If obj is model, return the properties dict.
+
+        :param obj: The data to serialize.
+        :return: The serialized form of data.
+        """
+        if obj is None:
+            return None
+        elif isinstance(obj, self.PRIMITIVE_TYPES):
+            return obj
+        elif isinstance(obj, list):
+            return [
+                self.sanitize_for_serialization(sub_obj) for sub_obj in obj
+            ]
+        elif isinstance(obj, tuple):
+            return tuple(
+                self.sanitize_for_serialization(sub_obj) for sub_obj in obj)
+        elif isinstance(obj, (datetime, date)):
+            return obj.isoformat()
+
+        if isinstance(obj, dict):
+            obj_dict = obj
+        else:
+            # Convert model obj to dict except
+            # attributes `swagger_types`, `attribute_map`
+            # and attributes which value is not None.
+            # Convert attribute name to json key in
+            # model definition for request.
+            if isinstance(obj, Enum):
+                return obj.value
+
+            obj_dict = {}
+            cls_tree = list(inspect.getmro(obj.__class__))
+            cls_tree.remove(object)
+            for cls in cls_tree:
+                current_dict = {
+                    cls.attribute_map[attr]: getattr(obj, attr)
+                    for attr, _ in iteritems(cls.swagger_types)
+                    if hasattr(obj, attr) and getattr(obj, attr) is not None
+                }
+                obj_dict.update(current_dict)
+
+        return {
+            key: self.sanitize_for_serialization(val)
+            for key, val in iteritems(obj_dict)
+        }
+
+    def deserialize(self, response, response_type):
+        """
+        Deserializes response into an object.
+
+        :param response: Response object to be deserialized.
+        :param response_type: class literal for
+            deserialized object, or string of class name.
+
+        :return: deserialized object.
+        """
+        # handle file downloading
+        # save response body into a tmp file and return the instance
+        if response_type == "file":
+            return self.__deserialize_file(response)
+
+        # fetch data from response object
+        try:
+            data = json.loads(response.content)
+        except ValueError:
+            data = response.content
+
+        return self.__deserialize(data, response_type)
+
+    def __deserialize(self, data, klass):
+        """
+        Deserializes dict, list, str into an object.
+
+        :param data: dict, list or str.
+        :param klass: class literal, or string of class name.
+
+        :return: object.
+        """
+        if data is None:
+            return None
+
+        if type(klass) == str:
+            if klass.startswith('list['):
+                sub_kls = re.match('list\[(.*)\]', klass).group(1)
+                return [
+                    self.__deserialize(sub_data, sub_kls) for sub_data in data
+                ]
+
+            if klass.startswith('dict('):
+                sub_kls = re.match('dict\(([^,]*), (.*)\)', klass).group(2)
+                return {
+                    k: self.__deserialize(v, sub_kls)
+                    for k, v in iteritems(data)
+                }
+
+            # convert str to class
+            if klass in self.NATIVE_TYPES_MAPPING:
+                klass = self.NATIVE_TYPES_MAPPING[klass]
+            else:
+                if hasattr(models, klass):
+                    klass = getattr(models, klass)
+                elif hasattr(schema_v1_5, klass):
+                    klass = getattr(schema_v1_5, klass)
+                elif hasattr(extension, klass):
+                    klass = getattr(extension, klass)
+                elif hasattr(ovf, klass):
+                    klass = getattr(ovf, klass)
+                elif hasattr(versioning, klass):
+                    klass = getattr(versioning, klass)
+                elif hasattr(environment, klass):
+                    klass = getattr(environment, klass)
+                elif hasattr(vmware, klass):
+                    klass = getattr(vmware, klass)
+
+        if klass in self.PRIMITIVE_TYPES:
+            return self.__deserialize_primitive(data, klass)
+        elif klass == object:
+            return self.__deserialize_object(data)
+        elif klass == date:
+            return self.__deserialize_date(data)
+        elif klass == datetime:
+            return self.__deserialize_datatime(data)
+        else:
+            return self.__deserialize_model(data, klass)
+
+    def __deserialize_file(self, response):
+        """
+        Saves response body into a file in a temporary folder,
+        using the filename from the `Content-Disposition` header if provided.
+
+        :param response:  RESTResponse.
+        :return: file path.
+        """
+
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        os.remove(path)
+
+        content_disposition = response.getheader("Content-Disposition")
+        if content_disposition:
+            filename = re.\
+                search(r'filename=[\'"]?([^\'"\s]+)[\'"]?', content_disposition).\
+                group(1)
+            path = os.path.join(os.path.dirname(path), filename)
+
+        with open(path, "w") as f:
+            f.write(response.data)
+
+        return path
+
+    def __deserialize_primitive(self, data, klass):
+        """
+        Deserializes string to primitive type.
+
+        :param data: str.
+        :param klass: class literal.
+
+        :return: int, long, float, str, bool.
+        """
+        try:
+            return klass(data)
+        except UnicodeEncodeError:
+            return str(data)
+        except TypeError:
+            return data
+
+    def __deserialize_object(self, value):
+        """
+        Return a original value.
+
+        :return: object.
+        """
+        return value
+
+    def __deserialize_date(self, string):
+        """
+        Deserializes string to date.
+
+        :param string: str.
+        :return: date.
+        """
+        try:
+            return parse(string).date()
+        except ImportError:
+            return string
+        except ValueError:
+            raise ClientException(
+                "Failed to parse `{0}` into a date object".format(string))
+
+    def __deserialize_datatime(self, string):
+        """
+        Deserializes string to datetime.
+
+        The string should be in iso8601 datetime format.
+
+        :param string: str.
+        :return: datetime.
+        """
+        try:
+            return parse(string)
+        except ImportError:
+            return string
+        except ValueError:
+            raise ClientException(
+                "Failed to parse `{0}` into a datetime object".format(string))
+
+    def __deserialize_model(self, data, klass):
+        """
+        Deserializes list or dict to model.
+
+        :param data: dict, list.
+        :param klass: class literal.
+        :return: model object.
+        """
+        if 'EnumMeta' == type(klass).__name__:
+            return klass(data)
+        if not klass.swagger_types:
+            return data
+
+        if klass == QueryResultRecordType:
+            record_type = data.get('_type')
+            klass = getattr(schema_v1_5, record_type)
+
+        kwargs = {}
+        cls_tree = list(inspect.getmro(klass))
+        cls_tree.remove(object)
+        for cls in cls_tree:
+            for attr, attr_type in iteritems(cls.swagger_types):
+                if data is not None and cls.attribute_map[
+                        attr] in data and isinstance(data, (list, dict)):
+                    value = data[cls.attribute_map[attr]]
+                    kwargs[attr] = self.__deserialize(value, attr_type)
+
+        instance = None
+        if hasattr(models, klass.__name__):
+            instance = klass(**kwargs)
+        else:
+            instance = klass()
+            for key in kwargs:
+                setattr(instance, key, kwargs[key])
+
+        return instance

--- a/pyvcloud/vcd/api_helper.py
+++ b/pyvcloud/vcd/api_helper.py
@@ -1,26 +1,24 @@
+import inspect
+import json
 import os
 import re
-import json
-import mimetypes
 import tempfile
-from dateutil.parser import parse
 from datetime import date, datetime
-
-from six import integer_types, iteritems, text_type
-
-import inspect
+from enum import Enum
 from importlib import import_module
 
-from vcloud.rest.openapi import models
+from dateutil.parser import parse
+from six import integer_types, iteritems, text_type
 from vcloud.api.rest import schema_v1_5
-from vcloud.api.rest.schema_v1_5 import extension
-from vcloud.api.rest.schema_v1_5.query_result_record_type import (
-    QueryResultRecordType)
 from vcloud.api.rest.schema import ovf, versioning
 from vcloud.api.rest.schema.ovf import environment, vmware
+from vcloud.api.rest.schema_v1_5 import extension
+from vcloud.api.rest.schema_v1_5.query_result_record_type import \
+    QueryResultRecordType
+from vcloud.rest.openapi import models
 from vcloud.rest.openapi.models import session
+
 from pyvcloud.vcd.client import ClientException
-from enum import Enum
 
 
 class ApiHelper(object):
@@ -145,13 +143,13 @@ class ApiHelper(object):
 
         if type(klass) == str:
             if klass.startswith('list['):
-                sub_kls = re.match('list\[(.*)\]', klass).group(1)
+                sub_kls = re.match(r'list\[(.*)\]', klass).group(1)
                 return [
                     self.__deserialize(sub_data, sub_kls) for sub_data in data
                 ]
 
-            if klass.startswith('dict('):
-                sub_kls = re.match('dict\(([^,]*), (.*)\)', klass).group(2)
+            if klass.startswith(r'dict('):
+                sub_kls = re.match(r'dict\(([^,]*), (.*)\)', klass).group(2)
                 return {
                     k: self.__deserialize(v, sub_kls)
                     for k, v in iteritems(data)
@@ -202,9 +200,8 @@ class ApiHelper(object):
 
         content_disposition = response.getheader("Content-Disposition")
         if content_disposition:
-            filename = re.\
-                search(r'filename=[\'"]?([^\'"\s]+)[\'"]?', content_disposition).\
-                group(1)
+            filename = re.search(r'filename=[\'"]?([^\'"\s]+)[\'"]?',
+                                 content_disposition).group(1)
             path = os.path.join(os.path.dirname(path), filename)
 
         with open(path, "w") as f:

--- a/pyvcloud/vcd/api_helper.py
+++ b/pyvcloud/vcd/api_helper.py
@@ -1,17 +1,37 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import date
+from datetime import datetime
+from enum import Enum
+from importlib import import_module
 import inspect
 import json
 import os
 import re
 import tempfile
-from datetime import date, datetime
-from enum import Enum
-from importlib import import_module
 
 from dateutil.parser import parse
-from six import integer_types, iteritems, text_type
+from six import integer_types
+from six import iteritems
+from six import text_type
 from vcloud.api.rest import schema_v1_5
-from vcloud.api.rest.schema import ovf, versioning
-from vcloud.api.rest.schema.ovf import environment, vmware
+from vcloud.api.rest.schema import ovf  # noqa: H306
+from vcloud.api.rest.schema import versioning
+from vcloud.api.rest.schema.ovf import environment  # noqa: H306
+from vcloud.api.rest.schema.ovf import vmware  # noqa: H306
 from vcloud.api.rest.schema_v1_5 import extension
 from vcloud.api.rest.schema_v1_5.query_result_record_type import \
     QueryResultRecordType
@@ -22,6 +42,13 @@ from pyvcloud.vcd.client import ClientException
 
 
 class ApiHelper(object):
+    """Helper class to serialize and deserialize model objects.
+
+    Model classes are in a thirt party library, vcd-api-schemas-type. REST API
+    model classes are under vcloud.api.rest.* module. CloudAPI model classes
+    are under vcloud.rest.openapi.models module. Both modules are scanned to
+    find the right class for a given response type.
+    """
 
     PRIMITIVE_TYPES = (float, bool, bytes, text_type) + integer_types
     NATIVE_TYPES_MAPPING = {
@@ -36,9 +63,7 @@ class ApiHelper(object):
     }
 
     def __init__(self):
-        """
-        Constructor of the class.
-        """
+        """Constructor of the class."""
         # Load all cloudapi model classes in models
         for file in os.listdir(os.path.dirname(session.__file__)):
             mod_name = file[:-3]
@@ -51,8 +76,7 @@ class ApiHelper(object):
                     setattr(models, name, obj)
 
     def sanitize_for_serialization(self, obj):
-        """
-        Builds a JSON POST object.
+        """Builds a JSON POST object.
 
         If obj is None, return None.
         If obj is str, int, long, float, bool, return directly.
@@ -107,8 +131,7 @@ class ApiHelper(object):
         }
 
     def deserialize(self, response, response_type):
-        """
-        Deserializes response into an object.
+        """Deserializes response into an object.
 
         :param response: Response object to be deserialized.
         :param response_type: class literal for
@@ -130,8 +153,7 @@ class ApiHelper(object):
         return self.__deserialize(data, response_type)
 
     def __deserialize(self, data, klass):
-        """
-        Deserializes dict, list, str into an object.
+        """Deserializes dict, list, str into an object.
 
         :param data: dict, list or str.
         :param klass: class literal, or string of class name.
@@ -186,14 +208,14 @@ class ApiHelper(object):
             return self.__deserialize_model(data, klass)
 
     def __deserialize_file(self, response):
-        """
-        Saves response body into a file in a temporary folder,
-        using the filename from the `Content-Disposition` header if provided.
+        """Saves response body into a file.
+
+        Saves response in a temporary folder, using the filename from the
+        `Content-Disposition` header if provided.
 
         :param response:  RESTResponse.
         :return: file path.
         """
-
         fd, path = tempfile.mkstemp()
         os.close(fd)
         os.remove(path)
@@ -210,8 +232,7 @@ class ApiHelper(object):
         return path
 
     def __deserialize_primitive(self, data, klass):
-        """
-        Deserializes string to primitive type.
+        """Deserializes string to primitive type.
 
         :param data: str.
         :param klass: class literal.
@@ -226,16 +247,14 @@ class ApiHelper(object):
             return data
 
     def __deserialize_object(self, value):
-        """
-        Return a original value.
+        """Return a original value.
 
         :return: object.
         """
         return value
 
     def __deserialize_date(self, string):
-        """
-        Deserializes string to date.
+        """Deserializes string to date.
 
         :param string: str.
         :return: date.
@@ -249,8 +268,7 @@ class ApiHelper(object):
                 "Failed to parse `{0}` into a date object".format(string))
 
     def __deserialize_datatime(self, string):
-        """
-        Deserializes string to datetime.
+        """Deserializes string to datetime.
 
         The string should be in iso8601 datetime format.
 
@@ -266,8 +284,7 @@ class ApiHelper(object):
                 "Failed to parse `{0}` into a datetime object".format(string))
 
     def __deserialize_model(self, data, klass):
-        """
-        Deserializes list or dict to model.
+        """Deserializes list or dict to model.
 
         :param data: dict, list.
         :param klass: class literal.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pygments >= 2.2.0
 PyYAML >= 4.2b1
 requests >= 2.18.4
 unittest-xml-reporting >= 2.2.1
+python-dateutil >= 2.8.1
+vcd-api-schemas-type >= 9.1.2.dev10

--- a/system_tests/api_client_tests.py
+++ b/system_tests/api_client_tests.py
@@ -16,20 +16,17 @@
 import unittest
 from uuid import uuid1
 
-from pyvcloud.system_test_framework.base_test import BaseTestCase
-from pyvcloud.system_test_framework.environment import Environment
-
-from pyvcloud.vcd.api_client import ApiClient
-from pyvcloud.vcd.api_client import QueryParamsBuilder
-from pyvcloud.vcd.client import BasicLoginCredentials
-
 from vcloud.api.rest.schema_v1_5.admin_org_type import AdminOrgType
-from vcloud.api.rest.schema_v1_5.task_type import TaskType
 from vcloud.api.rest.schema_v1_5.query_result_records_type import \
     QueryResultRecordsType
-
+from vcloud.api.rest.schema_v1_5.task_type import TaskType
 from vcloud.rest.openapi.models.role import Role
 from vcloud.rest.openapi.models.roles import Roles
+
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.environment import Environment
+from pyvcloud.vcd.api_client import ApiClient, QueryParamsBuilder
+from pyvcloud.vcd.client import BasicLoginCredentials
 
 
 class TestApiClient(BaseTestCase):

--- a/system_tests/api_client_tests.py
+++ b/system_tests/api_client_tests.py
@@ -1,0 +1,276 @@
+# VMware vCloud Director Python SDK
+# Copyright (c) 2020 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from uuid import uuid1
+
+from pyvcloud.system_test_framework.base_test import BaseTestCase
+from pyvcloud.system_test_framework.environment import Environment
+
+from pyvcloud.vcd.api_client import ApiClient
+from pyvcloud.vcd.api_client import QueryParamsBuilder
+from pyvcloud.vcd.client import BasicLoginCredentials
+
+from vcloud.api.rest.schema_v1_5.admin_org_type import AdminOrgType
+from vcloud.api.rest.schema_v1_5.task_type import TaskType
+from vcloud.api.rest.schema_v1_5.query_result_records_type import \
+    QueryResultRecordsType
+
+from vcloud.rest.openapi.models.role import Role
+from vcloud.rest.openapi.models.roles import Roles
+
+
+class TestApiClient(BaseTestCase):
+    """Test API client module functions.
+
+    Test cases in this module have ordering dependencies.
+    """
+
+    # Test configuration parameters and logger for output.
+    _config = None
+    _host = None
+    _org = None
+    _user = None
+    _pass = None
+
+    _logger = None
+
+    # Client to be used by all tests.
+    _client = None
+
+    ADMIN_ORG_MEDIA_TYPE = 'application/vnd.vmware.admin.organization+json'
+    OPEN_API_MEDIA_TYPE = 'application/json'
+
+    _test_org_name = 'test_org_' + str(uuid1())
+    _test_org_desc = 'Test org created by Python API client'
+    _org = None
+
+    _test_role_name = 'test_role' + str(uuid1())
+    _test_role_desc = 'Test role created by Python API client'
+    _role = None
+
+    def test_0000_setup(self):
+        """Setup a API client for other tests in this module.
+
+        Create a API client as per test configurations.
+
+        This test passes if the client in not None.
+        """
+        TestApiClient._logger = Environment.get_default_logger()
+        TestApiClient._client = TestApiClient._create_client_with_credentials()
+        self.assertIsNotNone(TestApiClient._client)
+
+    def test_0010_create_org(self):
+        """Create an org using generated model class.
+
+        This test passes if the org is created successfully and details of
+        the organization are correct.
+        """
+        org_model = AdminOrgType()
+        org_model.name = TestApiClient._test_org_name
+        org_model.full_name = TestApiClient._test_org_name
+        org_model.is_enabled = True
+        org_model.description = TestApiClient._test_org_desc
+        org_model.settings = {}
+
+        TestApiClient._logger.debug('Creating an org with name %s',
+                                    TestApiClient._test_org_name)
+        org = TestApiClient._client.call_api(
+            method='POST',
+            uri=TestApiClient._client.build_api_uri('/admin/orgs'),
+            contents=org_model,
+            media_type=TestApiClient.ADMIN_ORG_MEDIA_TYPE,
+            response_type=AdminOrgType)
+        self.assertIsNotNone(org)
+        self.assertEqual(org.name, TestApiClient._test_org_name)
+        self.assertEqual(org.full_name, TestApiClient._test_org_name)
+        self.assertTrue(org.is_enabled)
+        TestApiClient._org = org
+
+    def test_0020_update_org(self):
+        """Update an org.
+
+        Finds edit link by rel and type and updates the org.
+
+        This test passses if the retuned org is not None and the modified
+        property is updated.
+        """
+        edit_link = TestApiClient._client.find_first_link(
+            rel='edit', type=TestApiClient.ADMIN_ORG_MEDIA_TYPE)
+        self.assertIsNotNone(edit_link, 'Edit link not found')
+
+        TestApiClient._logger.debug('Updating org %s',
+                                    TestApiClient._test_org_name)
+        TestApiClient._org.is_enabled = False
+        org = TestApiClient._client.call_api(
+            method='PUT',
+            uri=edit_link.href,
+            contents=TestApiClient._org,
+            media_type=TestApiClient.ADMIN_ORG_MEDIA_TYPE,
+            response_type=AdminOrgType)
+        self.assertIsNotNone(org)
+        self.assertFalse(org.is_enabled)
+        TestApiClient._org = org
+
+    def test_0030_query_org(self):
+        """Query an org.
+
+        Queries an org by type and name filter.
+
+        This test passes if the query result consists exactly one record.
+        """
+        name_filter = 'name==%s' % TestApiClient._test_org_name
+        query_params = QueryParamsBuilder().set_type(
+            'organization').set_format(
+                QueryParamsBuilder.RECORDS).set_filter(name_filter).set_page(
+                    1).set_page_size(5).set_sort_asc('name').build()
+        query_uri = TestApiClient._client.build_api_uri('/query')
+
+        TestApiClient._logger.debug('Executing query on %s with params %s' %
+                                    (query_uri, query_params))
+        result = TestApiClient._client.call_api(
+            method='GET',
+            uri=query_uri,
+            params=query_params,
+            response_type=QueryResultRecordsType)
+        self.assertEqual(len(result.record), 1)
+
+    def test_0040_delete_org(self):
+        """Delete an org.
+
+        This test passes if the returned status code is 204.
+        """
+        TestApiClient._logger.debug('Deleting %s',
+                                    TestApiClient._test_org_name)
+
+        TestApiClient._client.call_api(method='DELETE',
+                                       uri=TestApiClient._org.href,
+                                       response_type=TaskType)
+        self.assertEqual(TestApiClient._client.get_last_status(), 202)
+        TestApiClient._client.wait_for_last_task()
+
+    def test_0050_create_role(self):
+        """Create a role using generated model class.
+
+        This test passes if the role is created successfully and details of
+        the role are correct.
+        """
+        role_model = Role(name=TestApiClient._test_role_name,
+                          description=TestApiClient._test_role_desc)
+
+        TestApiClient._logger.debug('Creating a role with name %s',
+                                    TestApiClient._test_role_name)
+        role = TestApiClient._client.call_api(
+            method='POST',
+            uri=TestApiClient._client.build_cloudapi_uri('/1.0.0/roles'),
+            contents=role_model,
+            media_type=TestApiClient.OPEN_API_MEDIA_TYPE,
+            response_type=Role)
+        self.assertIsNotNone(role)
+        self.assertEqual(role.name, TestApiClient._test_role_name)
+        self.assertEqual(role.description, TestApiClient._test_role_desc)
+        TestApiClient._role = role
+
+    def test_0060_update_role(self):
+        """Update a role.
+
+        Finds edit link by rel and model, then updates the org.
+
+        This test passses if the retuned role is not None and the modified
+        property is updated.
+        """
+        edit_link = TestApiClient._client.find_first_link(rel='edit',
+                                                          model='Role')
+        self.assertIsNotNone(edit_link, 'Edit link not found')
+
+        new_desc = "Updated " + TestApiClient._test_role_desc
+        TestApiClient._role.description = new_desc
+
+        TestApiClient._logger.debug('Updating role %s',
+                                    TestApiClient._test_role_name)
+        role = TestApiClient._client.call_api(
+            method='PUT',
+            uri=edit_link.href,
+            contents=TestApiClient._role,
+            media_type=TestApiClient.OPEN_API_MEDIA_TYPE,
+            response_type=Role)
+        self.assertIsNotNone(role)
+        self.assertEqual(role.description, new_desc)
+        TestApiClient._role = role
+
+    def test_0070_query_role(self):
+        """Query a role.
+
+        Queries a role by name filter.
+
+        This test passes if the query result consists exactly one record.
+        """
+        name_filter = 'name==%s' % TestApiClient._test_role_name
+        query_params = QueryParamsBuilder().set_filter(name_filter).set_page(
+            1).set_page_size(5).set_sort_asc('name').build()
+        query_uri = TestApiClient._client.build_cloudapi_uri('/1.0.0/roles')
+
+        TestApiClient._logger.debug('Executing query on %s with params %s' %
+                                    (query_uri, query_params))
+        roles = TestApiClient._client.call_api(method='GET',
+                                               uri=query_uri,
+                                               params=query_params,
+                                               response_type=Roles)
+        self.assertEqual(len(roles.values), 1)
+
+    def test_0080_delete_role(self):
+        """Delete a role.
+
+        This test passes if the returned status code is 204.
+        """
+        remove_link = TestApiClient._client.find_first_link(rel='remove',
+                                                            model='Role')
+        self.assertIsNotNone(remove_link, 'Remove link not found')
+
+        TestApiClient._logger.debug('Deleting role %s',
+                                    TestApiClient._test_role_name)
+        TestApiClient._client.call_api(method='DELETE', uri=remove_link.href)
+        self.assertEqual(TestApiClient._client.get_last_status(), 204)
+
+    def test_9999_cleanup(self):
+        """Log out client connection if allocated."""
+        if TestApiClient._client is not None:
+            try:
+                TestApiClient._logger.debug("Logging out client automatically")
+                TestApiClient._client.logout()
+            except Exception:
+                TestApiClient._logger.warning("Client logout failed",
+                                              exc_info=True)
+
+    @classmethod
+    def _create_client_with_credentials(cls):
+        """Create client and login."""
+        config = Environment.get_config()
+        host = config['vcd']['host']
+        org = config['vcd']['sys_org_name']
+        user = config['vcd']['sys_admin_username']
+        pwd = config['vcd']['sys_admin_pass']
+        client = ApiClient(host,
+                           verify_ssl_certs=False,
+                           log_requests=True,
+                           log_bodies=True,
+                           log_headers=True)
+        creds = BasicLoginCredentials(user, org, pwd)
+        client.set_credentials(creds)
+        return client
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add a client to provide an uniform way to invoke both REST API and CloudAPI endpoints. The new client is a wrapper over the existing client with some additional features. It uses generated model classes for request and response payloads.

Complete list of features are as follows:-
* Methods to build URI by providing relative resource paths, ex: '/admin/orgs','/1.0.0/roles' etc.
* Generic call_api() method for GET/POST/PUT/DELETE, it accepts/returns model objects and takes care of conversion to/from plain JSON objects.
* Methods to get response status, headers, links and task of the last HTTP call.
* Method to wait for the last task.
* A helper class to build query parameters.

Testing done:
Added a new test class api_client_test.py to perform CRUD on org (REST API) and role (CloudAPI). Tests also demonstrate how to query, find links and monitor tasks.

- @rajeshk2013 @pgowdavmw

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/645)
<!-- Reviewable:end -->
