### PR TITLE
Fix query filter URL encoding

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,8 +25,10 @@ Jeff Blaine <jblaine@kickflop.net>
 Jeff Mace <jmace@vmware.com>
 Jiri Tyr <jiri.tyr@gmail.com>
 Kaneda-fr <sebastien@lacoste-seris.net>
+Kiril Traykov <46561844+kiril-traykov@users.noreply.github.com>
 Konstantin Ilyashenko <konstantin@gigaspaces.com>
 Kostya <konstantin@gigaspaces.com>
+Ludovic Rivallain <lrivallain@users.noreply.github.com>
 Michal Taratuta <MichalTaratuta@users.noreply.github.com>
 Mike <Mikhail@gigaspaces.com>
 Mykhailo Durnosvystov <Mikhail@gigaspaces.com>
@@ -50,6 +52,7 @@ Stephen Evanchik <evanchik@vmware.com>
 Suthan <suthan.venkataramana@rackspace.com>
 Szimszon <github@oregpreshaz.eu>
 Yuya Kusakabe <yuya.kusakabe@gmail.com>
+aharlaut <30958830+aharlaut@users.noreply.github.com>
 anusuyaceg <anusuya.ceg@gmail.com>
 anusuyar <32779454+anusuyar@users.noreply.github.com>
 anusuyar <arangasamy@vmware.com>
@@ -64,6 +67,7 @@ kostya13 <konstantin@gigaspaces.com>
 kousgy123 <44152564+kousgy123@users.noreply.github.com>
 lasko <lasko@nastyninja.net>
 malakars <malakars@vmware.com>
+not4mad <48958209+not4mad@users.noreply.github.com>
 pandeys <pandeys@vmware.com>
 rajeshk2013 <43401283+rajeshk2013@users.noreply.github.com>
 reversecipher <reversecipher@gmail.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,21 @@
 CHANGES
 =======
 
+* Add a client with model bindings for REST API and CloudAPI (#645)
+* fixing bug where only one disk is listed even if there are more (#644)
+
+22.0.0
+------
+
+* Adding supported API versions in README (#641)
+* [VCDA 1336, 1337, 1338, 1339] - Added support for vCD JWT token in pyvcloud (#637)
+* [VCDA-1333] Adding support for VMSizingPolicy while dealing with compute policies on VMs (#636)
+* fix-bug-page-size (#629)
+* Fix #630 list\_rights\_available\_in\_system (#631)
+* VP-3104 (#623)
+* there is bug releated to: vcd-cli issue 497
+* Updating AUTHORS and ChangeLog in pyvcloud github
+
 21.0.0
 ------
 

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -1810,7 +1810,7 @@ class _AbstractQuery(object):
                 self._filter = ''
             self._filter += equality_filter[0]
             self._filter += '=='
-            self._filter += urllib.parse.quote(equality_filter[1])
+            self._filter += equality_filter[1]
 
         self._sort_desc = sort_desc
         self._sort_asc = sort_asc


### PR DESCRIPTION
If the query filter has spaces, it is getting endoded twice as %2520 instead of %20. Because of this vCloud returns empty query result.
Removing encoding from _AbstractQuery constructor, _build_query_uri() is already encoding the query filter string.

@rajeshk2013 @rocknes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/646)
<!-- Reviewable:end -->
