### PR TITLE
Add extension description to XML

### DIFF
--- a/pyvcloud/vcd/api_extension.py
+++ b/pyvcloud/vcd/api_extension.py
@@ -16,7 +16,6 @@
 import urllib
 
 from pyvcloud.vcd.client import E
-from pyvcloud.vcd.client import E_VCLOUD
 from pyvcloud.vcd.client import E_VMEXT
 from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import QueryResultFormat
@@ -201,7 +200,7 @@ class APIExtension(object):
         params = E_VMEXT.Service({'name': name})
         description = description or record.get('description')
         if description is not None:
-            params.append(E_VCLOUD.Description(description))
+            params.append(E.Description(description))
         params.append(E_VMEXT.Namespace(record.get('namespace')))
         params.append(E_VMEXT.Enabled(record.get('enabled')))
         params.append(E_VMEXT.RoutingKey(
@@ -230,7 +229,7 @@ class APIExtension(object):
         """
         params = E_VMEXT.Service({'name': name})
         if description is not None:
-            params.append(E_VCLOUD.Description(description))
+            params.append(E.Description(description))
         params.append(E_VMEXT.Namespace(namespace))
         params.append(E_VMEXT.Enabled('true'))
         params.append(E_VMEXT.RoutingKey(routing_key))

--- a/pyvcloud/vcd/api_extension.py
+++ b/pyvcloud/vcd/api_extension.py
@@ -17,6 +17,7 @@ import urllib
 
 from pyvcloud.vcd.client import E
 from pyvcloud.vcd.client import E_VMEXT
+from pyvcloud.vcd.client import E_VCLOUD
 from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.client import RelationType
@@ -176,7 +177,7 @@ class APIExtension(object):
         return ext
 
     def update_extension(self, name, namespace=None, routing_key=None,
-                         exchange=None):
+                         exchange=None, description=None):
         """Update properties for an existing API extension.
 
         :param str name: name of the API extension.
@@ -198,6 +199,9 @@ class APIExtension(object):
                                             format=QueryResultFormat.RECORDS)
 
         params = E_VMEXT.Service({'name': name})
+        description = description or record.get('description')
+        if description is not None:
+            params.append(E_VCLOUD.Description(description))
         params.append(E_VMEXT.Namespace(record.get('namespace')))
         params.append(E_VMEXT.Enabled(record.get('enabled')))
         params.append(E_VMEXT.RoutingKey(
@@ -208,7 +212,8 @@ class APIExtension(object):
         self.client.put_resource(record.get('href'), params, None)
         return record.get('href')
 
-    def add_extension(self, name, namespace, routing_key, exchange, patterns):
+    def add_extension(self, name, namespace, routing_key, exchange, patterns,
+                      description=None):
         """Add an API extension service.
 
         :param str name: name of the new API extension service.
@@ -224,6 +229,8 @@ class APIExtension(object):
         :rtype: lxml.objectify.ObjectifiedElement
         """
         params = E_VMEXT.Service({'name': name})
+        if description is not None:
+            params.append(E_VCLOUD.Description(description))
         params.append(E_VMEXT.Namespace(namespace))
         params.append(E_VMEXT.Enabled('true'))
         params.append(E_VMEXT.RoutingKey(routing_key))

--- a/pyvcloud/vcd/api_extension.py
+++ b/pyvcloud/vcd/api_extension.py
@@ -129,6 +129,14 @@ class APIExtension(object):
         ext_record = self._get_extension_record(name, namespace)
         return to_dict(ext_record, self.ATTRIBUTES)
 
+    def get_extension_xml(self, extension_id):
+        uri = f"{self.client.get_api_uri()}/admin/extension/service/{extension_id}"  # noqa: E501
+        try:
+            response_xml = self.client.get_resource(uri)
+            return response_xml
+        except Exception as err:
+            raise Exception(f"Failed to get extension XML with error: {err}")
+
     def get_api_filters(self, service_id):
         """Fetch the API filters defined for the service.
 

--- a/pyvcloud/vcd/api_extension.py
+++ b/pyvcloud/vcd/api_extension.py
@@ -16,8 +16,8 @@
 import urllib
 
 from pyvcloud.vcd.client import E
-from pyvcloud.vcd.client import E_VMEXT
 from pyvcloud.vcd.client import E_VCLOUD
+from pyvcloud.vcd.client import E_VMEXT
 from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.client import RelationType

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -78,20 +78,12 @@ E = objectify.ElementMaker(
         'ovf': NSMAP['ovf']
     })
 
-E_VCLOUD = objectify.ElementMaker(
-    annotate=False,
-    namespace=NSMAP['vcloud'],
-    nsmap={
-        'vcloud': NSMAP['vcloud'],
-    }
-)
 
 E_VMEXT = objectify.ElementMaker(
     annotate=False,
     namespace=NSMAP['vmext'],
     nsmap={
         'vmext': NSMAP['vmext'],
-        'vcloud': NSMAP['vcloud'],
         None: NSMAP['vcloud'],
     })
 

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -78,12 +78,21 @@ E = objectify.ElementMaker(
         'ovf': NSMAP['ovf']
     })
 
+E_VCLOUD = objectify.ElementMaker(
+    annotate=False,
+    namespace=NSMAP['vcloud'],
+    nsmap={
+        'vcloud': NSMAP['vcloud'],
+    }
+)
+
 E_VMEXT = objectify.ElementMaker(
     annotate=False,
     namespace=NSMAP['vmext'],
     nsmap={
+        'vmext': NSMAP['vmext'],
+        'vcloud': NSMAP['vcloud'],
         None: NSMAP['vcloud'],
-        'vmext': NSMAP['vmext']
     })
 
 E_OVF = objectify.ElementMaker(

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -78,13 +78,12 @@ E = objectify.ElementMaker(
         'ovf': NSMAP['ovf']
     })
 
-
 E_VMEXT = objectify.ElementMaker(
     annotate=False,
     namespace=NSMAP['vmext'],
     nsmap={
-        'vmext': NSMAP['vmext'],
         None: NSMAP['vcloud'],
+        'vmext': NSMAP['vmext'],
     })
 
 E_OVF = objectify.ElementMaker(


### PR DESCRIPTION
Adds optional `<Description>description</Description>` child element to the `<vmext:Service>` parent element.

Documentation: https://vdc-repo.vmware.com/vmwb-repository/dcr-public/06a3b3da-4c6d-4984-b795-5d64081a4b10/8e47d46b-cfa7-4c06-8b81-4f5548da3102/doc/doc//operations/PUT-Service.html

Tested; functions work and resulting XMLs look as expected when description is provided/omitted

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/668)
<!-- Reviewable:end -->
