### PR TITLE
[issue-669] get_catalog() func failed with Catalog not found error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Alessio Rocchi <rocchi.b.a@gmail.com>
 Andrew Ni <niandrew7@gmail.com>
 Andrew Ni <niandrewdev@gmail.com>
+Anirudh9794 <aniruddha.9794@gmail.com>
 Aritra Sen <aritra.iitkgp@gmail.com>
 Aritra Sen <sena@vmware.com>
 Belmin Fernandez <belminf@users.noreply.github.com>
@@ -56,6 +57,7 @@ aharlaut <30958830+aharlaut@users.noreply.github.com>
 anusuyaceg <anusuya.ceg@gmail.com>
 anusuyar <32779454+anusuyar@users.noreply.github.com>
 anusuyar <arangasamy@vmware.com>
+azzamsa <17734314+azzamsa@users.noreply.github.com>
 brosano <brahyan.rosano@gmail.com>
 chaitanya118 <chaitanya118@gmail.com>
 ckolovson <ckolovson@gmail.com>
@@ -67,8 +69,9 @@ kkkothari <46557216+kkkothari@users.noreply.github.com>
 kostya13 <konstantin@gigaspaces.com>
 kousgy123 <44152564+kousgy123@users.noreply.github.com>
 lasko <lasko@nastyninja.net>
+mac <mtaneja@vmware.com>
+mac <mukultaneja91@gmail.com>
 malakars <malakars@vmware.com>
-mukultaneja <mtaneja@vmware.com>
 not4mad <48958209+not4mad@users.noreply.github.com>
 pandeys <pandeys@vmware.com>
 rajeshk2013 <43401283+rajeshk2013@users.noreply.github.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,17 @@
 CHANGES
 =======
 
-* Fix Not able to add a new disk to a VM #647
+* Added sizing policy to vapp.add\_vm() (#662)
+* Adding support for api version 34.0 and 35.0 in pyvcloud (#666)
+* Fix - disk list size (#660)
+* Updates \`create\_vapp\_network\` to check \`ip\_ranges\` before using (#659)
+* Fixed - Updating a VM nic as primary nic (#657)
+* Fix Not able to add a new disk to a VM #647 (#648)
 * Added disk adaptertype on vcd vm info command (#654)
+
+22.0.1
+------
+
 * Fix query filter URL encoding (#646)
 * Add a client with model bindings for REST API and CloudAPI (#645)
 * fixing bug where only one disk is listed even if there are more (#644)


### PR DESCRIPTION
get_catalog() searches only in the first page of the query records. Due to which the API can fail if number of catalogs are more than default page size i.e 25. This change also fixes another similar issue for vDC.

Testing done:
Ran catalog_tests.py. All tests passed.
Manually tested in an org having more than 25 catalogs, able to get catalog from 2nd page of query records.

@rajeshk2013

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/670)
<!-- Reviewable:end -->
