### PR TITLE
Add methods to remove/add api filters to existing api extension services

### DIFF
--- a/pyvcloud/vcd/api_extension.py
+++ b/pyvcloud/vcd/api_extension.py
@@ -137,26 +137,6 @@ class APIExtension(object):
         except Exception as err:
             raise Exception(f"Failed to get extension XML with error: {err}")
 
-    def get_api_filters(self, service_id):
-        """Fetch the API filters defined for the service.
-
-        :param str service_id: the id of the extension service.
-
-        :return: API filters registered for the API extension.
-
-        :rtype: generator object
-        """
-        try:
-            records = self.client.get_typed_query(
-                ResourceType.API_FILTER.value,
-                equality_filter=('service', service_id),
-                query_result_format=QueryResultFormat.ID_RECORDS).execute()
-        except OperationNotSupportedException:
-            msg = 'User doesn\'t have permission to view api filters.'
-            raise OperationNotSupportedException(msg)
-
-        return records
-
     def get_extension_info(self, name, namespace=None):
         """Return info about an API extension, including filters.
 
@@ -302,6 +282,51 @@ class APIExtension(object):
         """
         href = self.enable_extension(name, enabled=False, namespace=namespace)
         return self.client.delete_resource(href)
+
+    def get_api_filters(self, service_id, format=QueryResultFormat.ID_RECORDS):
+        """Fetch the API filters defined for the service.
+
+        :param str service_id: the id of the extension service.
+        :param format QueryResultFormat: dictates whether id or href should be
+            part of the returned record. By default id is returned.
+
+        :return: API filters registered for the API extension.
+
+        :rtype: generator object
+        """
+        try:
+            records = self.client.get_typed_query(
+                ResourceType.API_FILTER.value,
+                equality_filter=('service', service_id),
+                query_result_format=format).execute()
+        except OperationNotSupportedException:
+            msg = 'User doesn\'t have permission to view api filters.'
+            raise OperationNotSupportedException(msg)
+
+        return records
+
+    def remove_all_api_filters_from_service(self, name, namespace=None):
+        """."""
+        ext_record = self._get_extension_record(name=name, namespace=namespace)
+        api_filter_records = self.get_api_filters(
+            service_id=ext_record.get('id'),
+            format=QueryResultFormat.REFERENCES)
+        for record in api_filter_records:
+            api_filter = self.client.get_resource(uri=record.get('href'))
+            self.client.delete_linked_resource(
+                resource=api_filter, rel=RelationType.REMOVE, media_type=None)
+
+    def add_api_filters_to_service(self, name, patterns, namespace=None):
+        """."""
+        ext_record = self._get_extension_record(
+            name=name, namespace=namespace,
+            format=QueryResultFormat.REFERENCES)
+        ext = self.client.get_resource(uri=ext_record.get('href'))
+        for pattern in patterns:
+            api_filter = E_VMEXT.ApiFilter(E_VMEXT.UrlPattern(pattern.strip()))
+            self.client.post_linked_resource(
+                resource=ext, rel=RelationType.ADD,
+                media_type=EntityType.API_FILTER.value, contents=api_filter)
 
     def add_service_right(self, right_name, service_name, namespace,
                           description, category, bundle_key):

--- a/pyvcloud/vcd/api_extension.py
+++ b/pyvcloud/vcd/api_extension.py
@@ -74,9 +74,8 @@ class APIExtension(object):
 
         :return: the extension service record.
 
-        :rtype: generator object that returns lxml.objectify.ObjectifiedElement
-            object containing AdminServiceRecord XML data representing the
-            service.
+        :rtype: lxml.objectify.ObjectifiedElement object containing
+            AdminServiceRecord XML data representing the service.
 
         :raises MissingRecordException: if a service with the given name and
             namespace couldn't be found.

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -342,6 +342,7 @@ class EntityType(Enum):
         'application/vnd.vmware.vcloud.allocatedNetworkAddress+xml'
     AMQP_SETTINGS = 'application/vnd.vmware.admin.amqpSettings+xml'
     API_EXTENSIBILITY = 'application/vnd.vmware.vcloud.apiextensibility+xml'
+    API_FILTER = 'application/vnd.vmware.admin.apiFilter+xml'
     APPLICATION_BINARY = 'application/binary'
     CATALOG = 'application/vnd.vmware.vcloud.catalog+xml'
     CAPTURE_VAPP_PARAMS = \


### PR DESCRIPTION
Currently there is no way to update/modify api filters on an api extension service without first deleting the service and then recreating it. This PR introduces two new methods to 
* remove all api filters on an existing api extension service
* add new api filters to an existing api extension service

Testing done:
Tested the two functions via CSE upgrade and the api filters are getting removed and added without any issue without having to delete the service itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/675)
<!-- Reviewable:end -->
