### PR TITLE
Correctly ignore vApp networks when instantiating from template

### DIFF
--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -263,6 +263,7 @@ class VDC(object):
 
         # If network is not specified by user then default to
         # vApp network name specified in the template
+        network_is_template_vapp_network = False
         template_networks = template_resource.xpath(
             '//ovf:NetworkSection/ovf:Network',
             namespaces={'ovf': NSMAP['ovf']})
@@ -272,8 +273,10 @@ class VDC(object):
                 '{' + NSMAP['ovf'] + '}name')
             if ((network is None) and (network_name_from_template != 'none')):
                 network = network_name_from_template
+                network_is_template_vapp_network = True
+        
         # Find the network in vdc referred to by user, using
-        # name of the network
+        # name of the network, ignoring template vApp networks
         network_href = network_name = None
         if network is not None:
             if hasattr(self.resource, 'AvailableNetworks') and \
@@ -284,9 +287,12 @@ class VDC(object):
                         network_name = n.get('name')
                         break
             if network_href is None:
-                raise EntityNotFoundException(
-                    'Network \'%s\' not found in the Virtual Datacenter.' %
-                    network)
+                if network_is_template_vapp_network:
+                    pass
+                else:
+                    raise EntityNotFoundException(
+                        'Network \'%s\' not found in the Virtual Datacenter.' %
+                        network)
 
         # Configure the network of the vApp
         vapp_instantiation_param = None

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -263,7 +263,7 @@ class VDC(object):
 
         # If network is not specified by user then default to
         # vApp network name specified in the template
-        network_is_template_vapp_network = False
+        is_template_vapp_network = False
         template_networks = template_resource.xpath(
             '//ovf:NetworkSection/ovf:Network',
             namespaces={'ovf': NSMAP['ovf']})
@@ -273,7 +273,7 @@ class VDC(object):
                 '{' + NSMAP['ovf'] + '}name')
             if ((network is None) and (network_name_from_template != 'none')):
                 network = network_name_from_template
-                network_is_template_vapp_network = True
+                is_template_vapp_network = True
 
         # Find the network in vdc referred to by user, using
         # name of the network, ignoring template vApp networks
@@ -287,7 +287,7 @@ class VDC(object):
                         network_name = n.get('name')
                         break
             if network_href is None:
-                if network_is_template_vapp_network:
+                if is_template_vapp_network:
                     pass
                 else:
                     raise EntityNotFoundException(

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -274,7 +274,7 @@ class VDC(object):
             if ((network is None) and (network_name_from_template != 'none')):
                 network = network_name_from_template
                 network_is_template_vapp_network = True
-        
+
         # Find the network in vdc referred to by user, using
         # name of the network, ignoring template vApp networks
         network_href = network_name = None


### PR DESCRIPTION
When instantiating a new vApp from a template that has an existing vApp network, the current code attempts to look for this vApp network in the list of VDC networks, which results in an 400 error and EntityNotFoundException. To correct this, we skip the exception if we encounter a template network, which lets vCloud Director correctly handle the vApp network.

Fixes https://github.com/vmware/pyvcloud/issues/682.

Tested on an internal vCloud Director instance @ VMware, and verified that the changes made here correctly propagate to [`vcd-cli`](https://github.com/vmware/vcd-cli/) and [`ansible-module-vcloud-director`](https://github.com/vmware/ansible-module-vcloud-director).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/683)
<!-- Reviewable:end -->
