### PR TITLE
Add option to specify if compute policy is modifiable

### DIFF
--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -1821,7 +1821,7 @@ class Org(object):
                                                      catalog_name,
                                                      catalog_item_name,
                                                      placement_policy_href,
-                                                     is_modifiable=False):
+                                                     placement_policy_final=False):  # noqa: E501
         """Assign placement policy to all vms of a given vApp template.
 
         The placement policy is identified by its href.
@@ -1829,7 +1829,8 @@ class Org(object):
         :param str catalog_name: Name of the catalog that contains the template
         :param str catalog_item_name: Name of the template (catalog item)
         :param str placement_policy_href: href of the placement policy
-        :param bool is_modifiable: True if the placement policy can overridden
+        :param bool placement_policy_final: True if the placement policy can
+            be overridden
 
         :return: an object of type EntityType.TASK XML which represents
                 the asynchronous task that is updating virtual application
@@ -1859,7 +1860,7 @@ class Org(object):
                     update_vm_compute_policy_element(api_version,
                                                      vm,
                                                      placement_policy_href=placement_policy_href,  # noqa: E501
-                                                     placement_policy_final=not is_modifiable)  # noqa: E501
+                                                     placement_policy_final=placement_policy_final)  # noqa: E501
 
             if template_update_required:
                 return self.client.put_resource(
@@ -1871,7 +1872,7 @@ class Org(object):
                                                   catalog_name,
                                                   catalog_item_name,
                                                   sizing_policy_href,
-                                                  is_modifiable=False):
+                                                  sizing_policy_final=False):
         """Assign sizing policy to all vms in a given vApp template.
 
         The sizing policy is identified by its href.
@@ -1879,7 +1880,8 @@ class Org(object):
         :param str catalog_name: Name of the catalog that contains the template
         :param str catalog_item_name: Name of the template (catalog item)
         :param str sizing_policy_href: href of the sizing policy
-        :param bool is_modifiable: True if the sizing policy can be overridden
+        :param bool sizing_policy_final: True if the sizing policy can be
+            overridden
 
         :return: an object of type EntityType.TASK XML which represents
             the asynchronous task that is updating virtual application
@@ -1909,7 +1911,7 @@ class Org(object):
                     update_vm_compute_policy_element(api_version,
                                                      vm,
                                                      sizing_policy_href=sizing_policy_href,  # noqa: E501
-                                                     sizing_policy_final=not is_modifiable)  # noqa: E501
+                                                     sizing_policy_final=sizing_policy_final)  # noqa: E501
 
             if template_update_required:
                 return self.client.put_resource(
@@ -1921,15 +1923,20 @@ class Org(object):
                                                    catalog_name,
                                                    catalog_item_name,
                                                    compute_policy_href,
-                                                   is_modifiable=False):
+                                                   sizing_policy_final=False):
         """Assign compute policy to all vms in a given vApp template.
+
+        NOTE: This function is deprecated as VdcComputePolicy Tags are
+        deprecated. When used with api_version >= 33.0, the function tries to
+        add a sizing policy with href 'compute_policy_href' to template VMs
 
         The compute policy is identified by its href.
 
         :param str catalog_name: Name of the catalog that contains the template
         :param str catalog_item_name: Name of the template (catalog item)
         :param str compute_policy_href: href of the compute policy
-        :param bool is_modifiable: True if the compute policy can be overridden
+        :param bool sizing_policy_final: True if the compute policy can be
+            overridden
 
         :return: an object of type EntityType.TASK XML which represents
             the asynchronous task that is updating virtual application
@@ -1978,7 +1985,7 @@ class Org(object):
                         update_vm_compute_policy_element(api_version,
                                                          vm,
                                                          sizing_policy_href=compute_policy_href,  # noqa: E501
-                                                         sizing_policy_final=not is_modifiable)  # noqa: E501
+                                                         sizing_policy_final=sizing_policy_final)  # noqa: E501
 
             if template_update_required:
                 return self.client.put_resource(

--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -1829,8 +1829,8 @@ class Org(object):
         :param str catalog_name: Name of the catalog that contains the template
         :param str catalog_item_name: Name of the template (catalog item)
         :param str placement_policy_href: href of the placement policy
-        :param bool placement_policy_final: True if the placement policy can
-            be overridden
+        :param bool placement_policy_final: if set to True, the placement
+            policy can't be overridden
 
         :return: an object of type EntityType.TASK XML which represents
                 the asynchronous task that is updating virtual application
@@ -1880,8 +1880,8 @@ class Org(object):
         :param str catalog_name: Name of the catalog that contains the template
         :param str catalog_item_name: Name of the template (catalog item)
         :param str sizing_policy_href: href of the sizing policy
-        :param bool sizing_policy_final: True if the sizing policy can be
-            overridden
+        :param bool sizing_policy_final: If set to True, the sizing policy
+            can't be overridden
 
         :return: an object of type EntityType.TASK XML which represents
             the asynchronous task that is updating virtual application
@@ -1935,8 +1935,8 @@ class Org(object):
         :param str catalog_name: Name of the catalog that contains the template
         :param str catalog_item_name: Name of the template (catalog item)
         :param str compute_policy_href: href of the compute policy
-        :param bool sizing_policy_final: True if the compute policy can be
-            overridden
+        :param bool sizing_policy_final: If set to True, the compute policy
+            can't be overridden.
 
         :return: an object of type EntityType.TASK XML which represents
             the asynchronous task that is updating virtual application

--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -1820,7 +1820,8 @@ class Org(object):
     def assign_placement_policy_to_vapp_template_vms(self,
                                                      catalog_name,
                                                      catalog_item_name,
-                                                     placement_policy_href):
+                                                     placement_policy_href,
+                                                     is_modifiable=False):
         """Assign placement policy to all vms of a given vApp template.
 
         The placement policy is identified by its href.
@@ -1828,6 +1829,7 @@ class Org(object):
         :param str catalog_name: Name of the catalog that contains the template
         :param str catalog_item_name: Name of the template (catalog item)
         :param str placement_policy_href: href of the placement policy
+        :param bool is_modifiable: True if the placement policy can overridden
 
         :return: an object of type EntityType.TASK XML which represents
                 the asynchronous task that is updating virtual application
@@ -1856,7 +1858,8 @@ class Org(object):
                 template_update_required = \
                     update_vm_compute_policy_element(api_version,
                                                      vm,
-                                                     placement_policy_href=placement_policy_href)  # noqa: E501
+                                                     placement_policy_href=placement_policy_href,  # noqa: E501
+                                                     placement_policy_final=not is_modifiable)  # noqa: E501
 
             if template_update_required:
                 return self.client.put_resource(
@@ -1867,7 +1870,8 @@ class Org(object):
     def assign_sizing_policy_to_vapp_template_vms(self,
                                                   catalog_name,
                                                   catalog_item_name,
-                                                  sizing_policy_href):
+                                                  sizing_policy_href,
+                                                  is_modifiable=False):
         """Assign sizing policy to all vms in a given vApp template.
 
         The sizing policy is identified by its href.
@@ -1875,6 +1879,7 @@ class Org(object):
         :param str catalog_name: Name of the catalog that contains the template
         :param str catalog_item_name: Name of the template (catalog item)
         :param str sizing_policy_href: href of the sizing policy
+        :param bool is_modifiable: True if the sizing policy can be overridden
 
         :return: an object of type EntityType.TASK XML which represents
             the asynchronous task that is updating virtual application
@@ -1903,7 +1908,8 @@ class Org(object):
                 template_update_required = \
                     update_vm_compute_policy_element(api_version,
                                                      vm,
-                                                     sizing_policy_href=sizing_policy_href)  # noqa: E501
+                                                     sizing_policy_href=sizing_policy_href,  # noqa: E501
+                                                     sizing_policy_final=not is_modifiable)  # noqa: E501
 
             if template_update_required:
                 return self.client.put_resource(
@@ -1914,7 +1920,8 @@ class Org(object):
     def assign_compute_policy_to_vapp_template_vms(self,
                                                    catalog_name,
                                                    catalog_item_name,
-                                                   compute_policy_href):
+                                                   compute_policy_href,
+                                                   is_modifiable=False):
         """Assign compute policy to all vms in a given vApp template.
 
         The compute policy is identified by its href.
@@ -1922,6 +1929,7 @@ class Org(object):
         :param str catalog_name: Name of the catalog that contains the template
         :param str catalog_item_name: Name of the template (catalog item)
         :param str compute_policy_href: href of the compute policy
+        :param bool is_modifiable: True if the compute policy can be overridden
 
         :return: an object of type EntityType.TASK XML which represents
             the asynchronous task that is updating virtual application
@@ -1969,7 +1977,8 @@ class Org(object):
                     template_update_required = \
                         update_vm_compute_policy_element(api_version,
                                                          vm,
-                                                         sizing_policy_href=compute_policy_href)  # noqa: E501
+                                                         sizing_policy_href=compute_policy_href,  # noqa: E501
+                                                         sizing_policy_final=not is_modifiable)  # noqa: E501
 
             if template_update_required:
                 return self.client.put_resource(

--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -1024,16 +1024,20 @@ def get_compute_policy_tags(api_version, sizing_compute_policy_href):
 def update_vm_compute_policy_element(api_version,
                                      vm,
                                      sizing_policy_href=None,
-                                     placement_policy_href=None):
+                                     sizing_policy_final=False,
+                                     placement_policy_href=None,
+                                     placement_policy_final=False,):
     """Update the compute policy element of a VM.
 
     Note: This method only adds the policy elements if supported by the
         api_version
 
-    :param api_version float:
-    :param vm lxml.objectify.ObjectifiedElement: Element representing a VM
-    :param sizing_policy_href: href of the sizing policy to be added
-    :param placement_policy_href: href of the placement policy to be added
+    :param float api_version:
+    :param lxml.objectify.ObjectifiedElement vm: Element representing a VM
+    :param str sizing_policy_href: href of the sizing policy to be added
+    :param bool sizing_policy_final: is sizing policy modifiable
+    :param str placement_policy_href: href of the placement policy to be added
+    :param bool placement_policy_final: is placement policy modifiable
 
     :return: Boolean which indicates if update is required. (VM resource is
         manipulated in-place)
@@ -1065,7 +1069,7 @@ def update_vm_compute_policy_element(api_version,
             vm_placement_policy_element = E.VmPlacementPolicy()
             # VmPlacementPolicy should always precede VmSizingPolicy
             compute_policy_element.insert(0, vm_placement_policy_element)
-            compute_policy_element.insert(1, E.VmPlacementPolicyFinal('false'))  # noqa: E501
+            compute_policy_element.insert(1, E.VmPlacementPolicyFinal(str(placement_policy_final).lower()))  # noqa: E501
         vm_placement_policy_element.set('href', placement_policy_href)
         vm_placement_policy_element.set('id', placement_policy_id)
         vm_placement_policy_element.set('type', 'application/json')
@@ -1080,7 +1084,7 @@ def update_vm_compute_policy_element(api_version,
             update_required = True
             vm_sizing_policy_element = E.VmSizingPolicy()
             compute_policy_element.append(vm_sizing_policy_element)
-            compute_policy_element.append(E.VmSizingPolicyFinal('false'))
+            compute_policy_element.append(E.VmSizingPolicyFinal(str(sizing_policy_final).lower()))  # noqa: E501
         vm_sizing_policy_element.set('href', sizing_policy_href)
         vm_sizing_policy_element.set('id', sizing_policy_id)
         vm_sizing_policy_element.set('type', 'application/json')

--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -1035,10 +1035,11 @@ def update_vm_compute_policy_element(api_version,
     :param float api_version:
     :param lxml.objectify.ObjectifiedElement vm: Element representing a VM
     :param str sizing_policy_href: href of the sizing policy to be added
-    :param bool sizing_policy_final: True if sizing policy can be overridden
+    :param bool sizing_policy_final: If set to True, the sizing policy can't
+        be overridden
     :param str placement_policy_href: href of the placement policy to be added
-    :param bool placement_policy_final: True if placement policy can be
-        overridden
+    :param bool placement_policy_final: If set to True, the placement policy
+        can't be overridden
 
     :return: Boolean which indicates if update is required. (VM resource is
         manipulated in-place)

--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -1026,7 +1026,7 @@ def update_vm_compute_policy_element(api_version,
                                      sizing_policy_href=None,
                                      sizing_policy_final=False,
                                      placement_policy_href=None,
-                                     placement_policy_final=False,):
+                                     placement_policy_final=False):
     """Update the compute policy element of a VM.
 
     Note: This method only adds the policy elements if supported by the
@@ -1035,9 +1035,10 @@ def update_vm_compute_policy_element(api_version,
     :param float api_version:
     :param lxml.objectify.ObjectifiedElement vm: Element representing a VM
     :param str sizing_policy_href: href of the sizing policy to be added
-    :param bool sizing_policy_final: is sizing policy modifiable
+    :param bool sizing_policy_final: True if sizing policy can be overridden
     :param str placement_policy_href: href of the placement policy to be added
-    :param bool placement_policy_final: is placement policy modifiable
+    :param bool placement_policy_final: True if placement policy can be
+        overridden
 
     :return: Boolean which indicates if update is required. (VM resource is
         manipulated in-place)


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

- Templates created by pyvcloud currently specify VmSizingPolicyFinal and VmPlacementPolicyFinal as "false" all the time.

* Create optional parameters to specify if the compute policies can be modified. Change the util method to include parameters for vmSizingPolicyFinal and VmPlacementPolicyFinal.

- Testing done:
Tried associating the template with a placement policy and checked if the "Modifiable" check box is not checked from the UI
Creating cluster from CSE without publishing placement policy associated with the VM and the creation of cluster failed (expected)

@rocknes @sahithi @sakthisunda @andrew-ni

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/693)
<!-- Reviewable:end -->
