### PR TITLE
Fix - can't toggle gateway high availability

### DIFF
--- a/pyvcloud/vcd/gateway.py
+++ b/pyvcloud/vcd/gateway.py
@@ -395,7 +395,7 @@ class Gateway(object):
                 gateway.Description = E.Description(desc)
             else:
                 gateway.insert(0, E.Description(desc))
-        if ha:
+        if ha is not None:
             gateway.Configuration.HaEnabled = E.HaEnabled(ha)
 
         return self.client.put_linked_resource(


### PR DESCRIPTION
``` python
        if ha: # <----
            gateway.Configuration.HaEnabled = E.HaEnabled(ha)
```

if `ha` value is set to `False` the code will never be executed. So that the Gateway High Availability will never be *Disabled*.

``` python
        if ha is not None: # <----
            gateway.Configuration.HaEnabled = E.HaEnabled(ha)
```

