### PR TITLE
Fixing error in list_nics(self): primary_index referenced before assignment

### DIFF
--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -674,6 +674,7 @@ class VM(object):
         nics = []
         if hasattr(net_conn_section, 'PrimaryNetworkConnectionIndex'):
             primary_index = net_conn_section.PrimaryNetworkConnectionIndex.text
+            self.primary_index = primary_index
 
         if hasattr(net_conn_section, 'NetworkConnection'):
             for nc in net_conn_section.NetworkConnection:


### PR DESCRIPTION
### Issue details:

When we use Ansible VMware vCloud Director modules from:

https://github.com/vmware/ansible-module-vcloud-director

When we **add_nic()** are first, after successful complete adding module fail with error about referenced variable which called before assigment.

### Description of proposed changes in the PR:

- [X] For prevention that need to add self.instance call and declaration for case when its are a first adapter provided by add_nic calls from ansible.

### Detailed description of proposed changes:

When we use [Ansible Module](https://github.com/vmware/ansible-module-vcloud-director), and inside Ansible module calling list_nics() on adding time (list_nics called afer add_nic), we crash after successful adding the NIC - Fatal error, what try to say about first added NIC and him "**primary_index**", _**which referenced before assignment**_.

### This issue blocks fix Ansible module in child repository 

[feat2RFC(vcd_vapp_vm_nic): Do a module invocation better #131](https://github.com/vmware/ansible-module-vcloud-director/pull/131)


### Example of exception: 

[gist_exception_example](https://gist.github.com/westsouthnight/04f19ac37ec229df9921d380f67080b1)

<img width="1790" alt="Снимок экрана 2020-07-26 в 23 05 59" src="https://user-images.githubusercontent.com/17825649/88488249-a0511800-cf94-11ea-872b-1571384510a0.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/696)
<!-- Reviewable:end -->
