### PR TITLE
Support addition of placement policy during adding vms to vapps

### DIFF
--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -1023,13 +1023,6 @@ def generate_compute_policy_tags(api_version, sizing_policy_href=None,
         vdc_compute_policy_element.set('type', 'application/json')
     else:
         compute_policy_element = E.ComputePolicy()
-        if sizing_policy_href:
-            sizing_policy_id = \
-                retrieve_compute_policy_id_from_href(sizing_policy_href)
-            sizing_policy_element = E.VmSizingPolicy()
-            compute_policy_element.append(sizing_policy_element)
-            sizing_policy_element.set('href', sizing_policy_href)
-            sizing_policy_element.set('id', sizing_policy_id)
         if placement_policy_href:
             placement_policy_id = \
                 retrieve_compute_policy_id_from_href(placement_policy_href)
@@ -1037,6 +1030,13 @@ def generate_compute_policy_tags(api_version, sizing_policy_href=None,
             compute_policy_element.append(placement_policy_element)
             placement_policy_element.set('href', placement_policy_href)
             placement_policy_element.set('id', placement_policy_id)
+        if sizing_policy_href:
+            sizing_policy_id = \
+                retrieve_compute_policy_id_from_href(sizing_policy_href)
+            sizing_policy_element = E.VmSizingPolicy()
+            compute_policy_element.append(sizing_policy_element)
+            sizing_policy_element.set('href', sizing_policy_href)
+            sizing_policy_element.set('id', sizing_policy_id)
     return (vdc_compute_policy_element, compute_policy_element)
 
 

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -37,7 +37,7 @@ from pyvcloud.vcd.exceptions import InvalidStateException
 from pyvcloud.vcd.exceptions import OperationNotSupportedException
 from pyvcloud.vcd.metadata import Metadata
 from pyvcloud.vcd.utils import cidr_to_netmask
-from pyvcloud.vcd.utils import get_compute_policy_tags
+from pyvcloud.vcd.utils import generate_compute_policy_tags
 from pyvcloud.vcd.vdc import VDC
 from pyvcloud.vcd.vm import VM
 
@@ -902,6 +902,8 @@ class VApp(object):
                 profile to be used for this vm.
             - sizing_policy_href: (str): (optional) sizing policy used for
                 creating the VM
+            - placement_policy_href: (str): (optional) placement policy used
+                for creating the VM
 
         :return: an object containing SourcedItem XML element.
 
@@ -974,8 +976,9 @@ class VApp(object):
         sourced_item.append(vm_instantiation_param)
 
         vdc_compute_policy_element, compute_policy_element = \
-            get_compute_policy_tags(float(self.client.get_api_version()),
-                                    spec.get('sizing_policy_href'))
+            generate_compute_policy_tags(float(self.client.get_api_version()),
+                                         sizing_policy_href=spec.get('sizing_policy_href'),  # noqa: E501
+                                         placement_policy_href=spec.get('placement_policy_href'))  # noqa: E501
         if vdc_compute_policy_element is not None:
             sourced_item.append(vdc_compute_policy_element)
         if compute_policy_element is not None:


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Support Addition of placement policies during vm creation
* changed the util function `generate_compute_policy_tags()` to accept placement policy so that placement policy tag will also be created.
* Since there is no need to send `VdcComputePolicy` tag for request to create the vm for api version >= 33.0, Avoided sending in the tag.

Testing:
* Made use of the function to create a cluster in CSE with placement policy and sizing policy.
  - tested with only placement policy
  - tested with both placement policy and sizing policy

@rocknes @sahithi @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/698)
<!-- Reviewable:end -->
