### PR TITLE
Updating rel value for ResourceType.PORT_GROUP

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -301,7 +301,7 @@ class ResourceType(Enum):
     ORG_VDC_NETWORK = 'orgVdcNetwork'
     ORG_VDC_RESOURCE_POOL_RELATION = 'orgVdcResourcePoolRelation'
     ORG_VDC_STORAGE_PROFILE = 'orgVdcStorageProfile'
-    PORT_GROUP = 'portGroup'
+    PORT_GROUP = 'portgroup'
     PROVIDER_VDC = 'providerVdc'
     PROVIDER_VDC_RESOURCE_POOL_RELATION = 'providerVdcResourcePoolRelation'
     PROVIDER_VDC_STORAGE_PROFILE = 'providerVdcStorageProfile'


### PR DESCRIPTION
This commit updates rel value ResourceType.PORT_GROUP
from `portGroup` to `portgroup`

Signed-off-by: mukultaneja <mtaneja@vmware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/699)
<!-- Reviewable:end -->
