### PR TITLE
Include tenant context header when creating catalog

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -1146,14 +1146,16 @@ class Client(object):
                     contents=None,
                     media_type=None,
                     objectify_results=True,
-                    params=None):
+                    params=None,
+                    extra_headers=None):
         response = self._do_request_prim(
             method,
             uri,
             self._session,
             contents=contents,
             media_type=media_type,
-            params=params)
+            params=params,
+            extra_headers=extra_headers)
 
         sc = response.status_code
         if sc in (requests.codes.ok,
@@ -1261,8 +1263,9 @@ class Client(object):
                          media_type=None,
                          accept_type=None,
                          auth=None,
-                         params=None):
-        headers = {}
+                         params=None,
+                         extra_headers=None):
+        headers = extra_headers or {}
         if media_type is not None:
             headers[self._HEADER_CONTENT_TYPE_NAME] = media_type
 
@@ -1402,7 +1405,8 @@ class Client(object):
                       contents,
                       media_type,
                       params=None,
-                      objectify_results=True):
+                      objectify_results=True,
+                      extra_headers=None):
         """Posts to a resource link.
 
         Posts the specified contents to the specified resource. (Does an HTTP
@@ -1414,9 +1418,11 @@ class Client(object):
             contents=contents,
             media_type=media_type,
             objectify_results=objectify_results,
-            params=params)
+            params=params,
+            extra_headers=extra_headers)
 
-    def post_linked_resource(self, resource, rel, media_type, contents):
+    def post_linked_resource(self, resource, rel, media_type, contents,
+                             extra_headers=None):
         """Posts to a resource link.
 
         Posts the contents of the resource referenced by the link with the
@@ -1430,20 +1436,23 @@ class Client(object):
         try:
             return self.post_resource(
                 find_link(resource, rel, media_type).href, contents,
-                media_type)
+                media_type, extra_headers=extra_headers)
         except MissingLinkException as e:
             raise OperationNotSupportedException(
                 "Operation is not supported").with_traceback(e.__traceback__)
 
-    def get_resource(self, uri, params=None, objectify_results=True):
+    def get_resource(self, uri, params=None, objectify_results=True,
+                     extra_headers=None):
         """Gets the specified contents to the specified resource.
 
         This method does an HTTP GET.
         """
         return self._do_request(
-            'GET', uri, objectify_results=objectify_results, params=params)
+            'GET', uri, objectify_results=objectify_results, params=params,
+            extra_headers=extra_headers)
 
-    def get_linked_resource(self, resource, rel, media_type):
+    def get_linked_resource(self, resource, rel, media_type,
+                            extra_headers=None):
         """Gets the content of the resource link.
 
         Gets the contents of the resource referenced by the link with the
@@ -1458,16 +1467,20 @@ class Client(object):
             the link being not visible to the logged in user of the client.
         """
         try:
-            return self.get_resource(find_link(resource, rel, media_type).href)
+            return self.get_resource(find_link(resource, rel, media_type).href,
+                                     extra_headers=extra_headers)
         except MissingLinkException as e:
             raise OperationNotSupportedException(
                 "Operation is not supported").with_traceback(e.__traceback__)
 
-    def delete_resource(self, uri, params=None, force=False, recursive=False):
+    def delete_resource(self, uri, params=None, force=False, recursive=False,
+                        extra_headers=None):
         full_uri = '%s?force=%s&recursive=%s' % (uri, force, recursive)
-        return self._do_request('DELETE', full_uri, params=params)
+        return self._do_request('DELETE', full_uri, params=params,
+                                extra_headers=extra_headers)
 
-    def delete_linked_resource(self, resource, rel, media_type):
+    def delete_linked_resource(self, resource, rel, media_type,
+                               extra_headers=None):
         """Deletes the resource referenced by the link.
 
         Deletes the resource referenced by the link with the specified rel and
@@ -1478,7 +1491,8 @@ class Client(object):
         """
         try:
             return self.delete_resource(
-                find_link(resource, rel, media_type).href)
+                find_link(resource, rel, media_type).href,
+                extra_headers=extra_headers)
         except MissingLinkException as e:
             raise OperationNotSupportedException(
                 "Operation is not supported").with_traceback(e.__traceback__)

--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -46,6 +46,7 @@ from pyvcloud.vcd.exceptions import OperationNotSupportedException
 from pyvcloud.vcd.exceptions import UploadException
 from pyvcloud.vcd.metadata import Metadata
 from pyvcloud.vcd.system import System
+from pyvcloud.vcd.utils import extract_id
 from pyvcloud.vcd.utils import get_admin_href
 from pyvcloud.vcd.utils import get_non_admin_href
 from pyvcloud.vcd.utils import get_safe_members_in_tar_file
@@ -63,14 +64,6 @@ from pyvcloud.vcd.utils import VM_SIZING_POLICY_MIN_API_VERSION
 DEFAULT_CHUNK_SIZE = 10 * 1024 * 1024
 
 TENANT_CONTEXT_HDR = 'X-VMWARE-VCLOUD-TENANT-CONTEXT'
-
-
-def get_org_id_from_urn(org_urn_id):
-    urn_id_split = org_urn_id.split('urn:vcloud:org:')
-    try:
-        return urn_id_split[1]
-    except IndexError:
-        return ''
 
 
 class Org(object):
@@ -129,7 +122,7 @@ class Org(object):
             self.reload()
         payload = E.AdminCatalog(E.Description(description), name=name)
         extra_headers = {TENANT_CONTEXT_HDR:
-                         get_org_id_from_urn(self.resource.attrib['id'])}
+                         extract_id(self.resource.attrib['id'])}
         return self.client.post_linked_resource(
             self.resource, RelationType.ADD, EntityType.ADMIN_CATALOG.value,
             payload, extra_headers=extra_headers)

--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -62,7 +62,7 @@ from pyvcloud.vcd.utils import VM_SIZING_POLICY_MIN_API_VERSION
 # 10MB is a happy medium between 50MB and 1MB.
 DEFAULT_CHUNK_SIZE = 10 * 1024 * 1024
 
-TENANT_CONTEXT_HDR = 'X_VMWARE_VCLOUD_TENANT_CONTEXT'
+TENANT_CONTEXT_HDR = 'X-VMWARE-VCLOUD-TENANT-CONTEXT'
 
 
 def get_org_id_from_urn(org_urn_id):

--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -62,6 +62,16 @@ from pyvcloud.vcd.utils import VM_SIZING_POLICY_MIN_API_VERSION
 # 10MB is a happy medium between 50MB and 1MB.
 DEFAULT_CHUNK_SIZE = 10 * 1024 * 1024
 
+TENANT_CONTEXT_HDR = 'X_VMWARE_VCLOUD_TENANT_CONTEXT'
+
+
+def get_org_id_from_urn(org_urn_id):
+    urn_id_split = org_urn_id.split('urn:vcloud:org:')
+    try:
+        return urn_id_split[1]
+    except IndexError:
+        return ''
+
 
 class Org(object):
     def __init__(self, client, href=None, resource=None):
@@ -118,9 +128,11 @@ class Org(object):
         if self.resource is None:
             self.reload()
         payload = E.AdminCatalog(E.Description(description), name=name)
+        extra_headers = {TENANT_CONTEXT_HDR:
+                         get_org_id_from_urn(self.resource.attrib['id'])}
         return self.client.post_linked_resource(
             self.resource, RelationType.ADD, EntityType.ADMIN_CATALOG.value,
-            payload)
+            payload, extra_headers=extra_headers)
 
     def delete_catalog(self, name):
         """Delete a catalog in the organization.


### PR DESCRIPTION
Signed-off-by: ltimothy <ltimothy@vmware.com>

To help us process your pull request efficiently, please include: 

- (Required) Short description of changes in the PR topic line
Added support for including the tenant context header (X-VMWARE-VCLOUD-TENANT-CONTEXT) when creating an org. This change allows a non-system-admin user to create a catalog in another org.

- (Required) Detailed description of changes include tests and
  documentation.  If the pull request contains multiple commits with 
  detailed messages, refer to those instead
Adding this support included the client POST request having an added param: extra_headers. To generalize this change, this extra param was added to GET and DELETE client requests.

- (Optional) Names of reviewers using @ sign + name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/709)
<!-- Reviewable:end -->
