### PR TITLE
Add support to escape special characters in query filter for api v35.0+

### DIFF
--- a/pyvcloud/vcd/api_extension.py
+++ b/pyvcloud/vcd/api_extension.py
@@ -82,9 +82,9 @@ class APIExtension(object):
         :raise MultipleRecordsException: if more than one service with the
             given name and namespace are found.
         """
-        qfilter = 'name==%s' % urllib.parse.quote_plus(name)
+        qfilter = 'name==%s' % urllib.parse.quote(name)
         if namespace is not None:
-            qfilter += ';namespace==%s' % urllib.parse.quote_plus(namespace)
+            qfilter += ';namespace==%s' % urllib.parse.quote(namespace)
         try:
             ext = self.client.get_typed_query(
                 ResourceType.ADMIN_SERVICE.value,

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -1829,9 +1829,9 @@ class _AbstractQuery(object):
 
         is_below_v35_query = float(client.get_api_version()) < float(ApiVersion.VERSION_35.value)  # noqa: E501
         if is_below_v35_query:
-            self._filter = self._escape_special_characters(qfilter)
-        else:
             self._filter = qfilter
+        else:
+            self._filter = self._escape_special_characters(qfilter)
 
         if equality_filter:
             if self._filter:

--- a/pyvcloud/vcd/external_network.py
+++ b/pyvcloud/vcd/external_network.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import urllib
+
 from pyvcloud.vcd.client import E
 from pyvcloud.vcd.client import E_VMEXT
 from pyvcloud.vcd.client import EntityType
@@ -562,7 +564,7 @@ class ExternalNetwork(object):
         :raises: EntityNotFoundException: if any direct org vDC network
          cannot be found.
         """
-        query_filter = 'connectedTo==' + self.name
+        query_filter = 'connectedTo==' + urllib.parse.quote(self.name)
         if filter:
             query_filter += ';' + filter
         query = self.client.get_typed_query(
@@ -585,7 +587,7 @@ class ExternalNetwork(object):
         :rtype: list
         """
         out_list = []
-        query_filter = 'networkName==' + self.name
+        query_filter = 'networkName==' + urllib.parse.quote(self.name)
         if filter:
             query_filter += ';' + filter
         query = self.client.get_typed_query(

--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -1059,7 +1059,7 @@ class Org(object):
         if self.client.is_sysadmin():
             resource_type = ResourceType.ADMIN_USER.value
             org_filter = 'org==%s' % \
-                urllib.parse.quote_plus(self.resource.get('href'))
+                urllib.parse.quote(self.resource.get('href'))
         query = self.client.get_typed_query(
             resource_type,
             query_result_format=QueryResultFormat.RECORDS,
@@ -1168,7 +1168,7 @@ class Org(object):
         if self.client.is_sysadmin():
             resource_type = ResourceType.ADMIN_ROLE.value
             org_filter = 'org==%s' % \
-                urllib.parse.quote_plus(self.resource.get('href'))
+                urllib.parse.quote(self.resource.get('href'))
 
         query = self.client.get_typed_query(
             resource_type,

--- a/pyvcloud/vcd/platform.py
+++ b/pyvcloud/vcd/platform.py
@@ -1013,7 +1013,7 @@ class Platform(object):
         :raises: EntityNotFoundException: if any port group name cannot be
         found.
         """
-        vcfilter = 'vcName==%s' % urllib.parse.quote_plus(vim_server_name)
+        vcfilter = 'vcName==%s' % urllib.parse.quote(vim_server_name)
         query = self.client.get_typed_query(
             ResourceType.PORT_GROUP.value,
             qfilter=vcfilter,
@@ -1041,7 +1041,7 @@ class Platform(object):
         :raises: EntityNotFoundException: if any port group name cannot be
         found.
         """
-        vcfilter = 'vcName==%s' % urllib.parse.quote_plus(vim_server_name)
+        vcfilter = 'vcName==%s' % urllib.parse.quote(vim_server_name)
         query = self.client.get_typed_query(
             ResourceType.PORT_GROUP.value,
             qfilter=vcfilter,

--- a/pyvcloud/vcd/system.py
+++ b/pyvcloud/vcd/system.py
@@ -18,6 +18,7 @@ from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import NSMAP
 from pyvcloud.vcd.client import QueryResultFormat
 from pyvcloud.vcd.client import RelationType
+from pyvcloud.vcd.client import ResourceType
 from pyvcloud.vcd.exceptions import EntityNotFoundException
 from pyvcloud.vcd.exceptions import InvalidParameterException
 from pyvcloud.vcd.utils import get_admin_href
@@ -129,7 +130,7 @@ class System(object):
             name_filter = ('name', name)
 
         q = self.client.get_typed_query(
-            'providerVdcStorageProfile',
+            ResourceType.PROVIDER_VDC_STORAGE_PROFILE.value,
             query_result_format=QueryResultFormat.RECORDS,
             equality_filter=name_filter)
 

--- a/pyvcloud/vcd/task.py
+++ b/pyvcloud/vcd/task.py
@@ -125,7 +125,7 @@ class Task(object):
         """
         query_filter = ''
         for f in filter_status_list:
-            query_filter += 'status==%s,' % urllib.parse.quote_plus(f)
+            query_filter += 'status==%s,' % urllib.parse.quote(f)
         if len(query_filter) > 0:
             query_filter = query_filter[:-1]
         sort_asc = None

--- a/pyvcloud/vcd/vdc.py
+++ b/pyvcloud/vcd/vdc.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import urllib
+
 from lxml import etree
 
 from pyvcloud.vcd.acl import Acl
@@ -155,7 +157,7 @@ class VDC(object):
         :raises: MultipleRecordsException: if more than one VM with the
             provided name are found.
         """
-        vdc_filter = ('vdc==%s' % self.href)
+        vdc_filter = ('vdc==%s' % urllib.parse.quote(self.href))
         name_filter = ('name', name)
         query_obj = self.client.get_typed_query(
             ResourceType.ADMIN_VM.value,
@@ -166,7 +168,7 @@ class VDC(object):
 
     def get_vapp_href(self, name):
         name_filter = ('name', name)
-        vdc_filter = 'vdc==%s' % self.href
+        vdc_filter = 'vdc==%s' % urllib.parse.quote(self.href)
         resource_type = ResourceType.VAPP.value
         if self.client.is_sysadmin():
             resource_type = ResourceType.ADMIN_VAPP.value

--- a/system_tests/nsxt_tests.py
+++ b/system_tests/nsxt_tests.py
@@ -34,7 +34,7 @@ class TestNSXT(BaseTestCase):
         platform = Platform(TestNSXT._client)
 
         manager_name = Environment._config['nsxt']['manager_name']
-        query_filter = 'name==%s' % urllib.parse.quote_plus(manager_name)
+        query_filter = 'name==%s' % urllib.parse.quote(manager_name)
         query = TestNSXT._client.get_typed_query(
             ResourceType.NSXT_MANAGER.value,
             query_result_format=QueryResultFormat.REFERENCES,


### PR DESCRIPTION
For api v35.0+, vCD requires special characters viz. ( ) ; , to be escaped if used as value in query filter.
In _AbstractQuery, we escape the special characters in encoded filter value.

Additional changes, 
1. Replaced usage of quote_plus to quote, since quote_plus will replace spaces with + and thus can cause the filter value to distort.
2. Encoded all usage of qfilter in get_typed_query, since this field should be encoded by caller.

Testing done:
Ran all vcd-cli commands that invoke the affected methods at api v35.0 and made sure that all these commands returned expected result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/711)
<!-- Reviewable:end -->
