### PR TITLE
Adding functionality to retrieve and answer vm pending questions

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -461,6 +461,8 @@ class EntityType(Enum):
     VM_CAPABILITIES_SECTION = \
         'application/vnd.vmware.vcloud.vmCapabilitiesSection+xml'
     VMS = 'application/vnd.vmware.vcloud.vms+xml'
+    VM_PENDING_ANSWER = 'application/vnd.vmware.vcloud.vmPendingAnswer+xml'
+    VM_PENDING_QUESTION = 'application/vnd.vmware.vcloud.vmPendingQuestion+xml'
     VM_SCREEN_ACQUIRE_TICKET = \
         'application/vnd.vmware.vcloud.screenTicket+xml'
     VM_SCREEN_ACQUIRE_MKSTICKET = \

--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -1984,3 +1984,26 @@ class VM(object):
         uri = self.href + '/action/enableNestedHypervisor'
         return self.client. \
             post_resource(uri=uri, contents=None, media_type=None)
+
+    def get_pending_user_input_question(self):
+        """Retrieves pending user input question of the VM
+
+        :return: an object containing EntityType.VM_PENDING_QUESTION data which
+            represents the question pending the user's input
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        uri = self.href + '/question'
+        return self.client.get_resource(uri=uri)
+
+    def post_answer_to_pending_user_input_question(self, choice_id, question_id):
+        """POST an answer choice id for a pending question id
+
+        :param int choice_id
+        :param int question_id
+        """
+        uri = self.href + '/question/action/answer'
+        vm_question_answer = E.VmQuestionAnswer()
+        vm_question_answer.append(E.ChoiceId(choice_id))
+        vm_question_answer.append(E.QuestionId(question_id))
+        return self.client.post_resource(uri, vm_question_answer,
+                                         EntityType.VM_PENDING_ANSWER.value)


### PR DESCRIPTION
With some actions to VMs such as ejecting CDs from VMs, user input is required to force the eject action or not. This ends up with a request which times out and does not eject the CD. It's possibly applicable to other actions as well but I haven't stumbled across such so far.

I've added to methods to the VM class. One retrieves the pending VM question and the other posts an answer based on the choice id and the question id, which should be fetched from the VmPendingQuestion XML object.

This is also related to this issue I opened some time ago: https://github.com/vmware/pyvcloud/issues/673