### PR TITLE
Update vApp to create VMs from template

### DIFF
--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -885,7 +885,6 @@ class VApp(object):
         :param dict spec: a dictionary containing
 
             - vapp: (resource): (required) source vApp or vAppTemplate
-            
                 resource.
             - source_vm_name: (str): (required) source vm name.
             - target_vm_name: (str): (optional) target vm name.

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -884,7 +884,8 @@ class VApp(object):
 
         :param dict spec: a dictionary containing
 
-            - vapp: (resource): (required) source vApp or vAppTemplate
+            - vapp: (resource): (required) source vApp or vApp
+            
                 resource.
             - source_vm_name: (str): (required) source vm name.
             - target_vm_name: (str): (optional) target vm name.
@@ -1033,7 +1034,8 @@ class VApp(object):
     
     def get_template(self, catalog, template):
         """Returns the template resource from the provided catalog name
-            and vapp template name"""
+           and vapp template name
+        """
         org_resource = self.client.get_org()
         org = Org(self.client, resource=org_resource)
         catalog_item = org.get_catalog_item(catalog, template)
@@ -1042,22 +1044,22 @@ class VApp(object):
         return template_vapp_resource
 
     def create_vm_from_template(self, 
-                catalog,
-                vapp_template,
-                vm_template,
-                isAdmin=False,
-                name=None,
-                hostname=None,
-                password=None,
-                password_auto=None,
-                password_reset=None,
-                cust_script=None,
-                network=None,
-                disk_size=None,
-                storage_profile=None,
-                sizing_policy_href=None,
-                placement_policy_href=None,
-                ip_allocation_mode='DHCP'):
+            catalog,
+            vapp_template,
+            vm_template,
+            isAdmin=False,
+            name=None,
+            hostname=None,
+            password=None,
+            password_auto=None,
+            password_reset=None,
+            cust_script=None,
+            network=None,
+            disk_size=None,
+            storage_profile=None,
+            sizing_policy_href=None,
+            placement_policy_href=None,
+            ip_allocation_mode='DHCP'):
         """Creates a vm from a template or based on an existing VM from a different vapp
         and recompose the vapp to add the new vm.
             
@@ -1065,33 +1067,33 @@ class VApp(object):
         instead the template resource, you provide a vapp name or vapp template name 
         to create the new VM based on an existing vm from the vapp.
 
-            :param str catalog: (required) catalog name cointaining vapp template.
-            :param str vapp_template: (required) source vApp template name.
-            :param str vm_template: (required) source vm template name.
-            :param str bame: (optional) new vm name.
-            :param str hostname: (optional) new guest hostname.
-            :param str password: (optional) the administrator password of the vm.
-            :param str password_auto: (bool): (optional) auto generate administrator
-                password.
-            :param str password_reset: (bool): (optional) True, if the administrator
-                password for this vm must be reset after first use.
-            :param str cust_script: (optional) script to run on guest
-                customization.
-            :param str network: (optional) name of the vApp network to connect.
-                If omitted, the vm won't be connected to any network.
-            :param str storage_profile: (optional) the name of the storage
-                profile to be used for this vm.
-            :param str sizing_policy_href: (optional) sizing policy used for
-                creating the VM.
-            :param str placement_policy_href: (optional) placement policy used
-                for creating the VM.
-            :param str ip_allocation_mode: (optional) the allocation mode for ip.
-                Default is for DHCP.
+        :param str catalog: (required) catalog name cointaining vapp template.
+        :param str vapp_template: (required) source vApp template name.
+        :param str vm_template: (required) source vm template name.
+        :param str bame: (optional) new vm name.
+        :param str hostname: (optional) new guest hostname.
+        :param str password: (optional) the administrator password of the vm.
+        :param str password_auto: (bool): (optional) auto generate administrator
+            password.
+        :param str password_reset: (bool): (optional) True, if the administrator
+            password for this vm must be reset after first use.
+        :param str cust_script: (optional) script to run on guest
+            customization.
+        :param str network: (optional) name of the vApp network to connect.
+            If omitted, the vm won't be connected to any network.
+        :param str storage_profile: (optional) the name of the storage
+            profile to be used for this vm.
+        :param str sizing_policy_href: (optional) sizing policy used for
+            creating the VM.
+        :param str placement_policy_href: (optional) placement policy used
+            for creating the VM.
+        :param str ip_allocation_mode: (optional) the allocation mode for ip.
+            Default is for DHCP.
 
-            :return: an object containing EntityType.VAPP XML data representing the
-                updated vApp.
+        :return: an object containing EntityType.VAPP XML data representing the
+            updated vApp.
 
-            :rtype: lxml.objectify.ObjectifiedElement
+        :rtype: lxml.objectify.ObjectifiedElement
         """
         try:
             template_vapp_resource = self.get_template(catalog, vapp_template)

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1030,6 +1030,99 @@ class VApp(object):
         return self.client.post_linked_resource(
             self.resource, RelationType.RECOMPOSE,
             EntityType.RECOMPOSE_VAPP_PARAMS.value, params)
+    
+    def get_template(self, catalog, template):
+        """Returns the template resource from the provided catalog name
+            and vapp template name"""
+        org_resource = self.client.get_org()
+        org = Org(self.client, resource=org_resource)
+        catalog_item = org.get_catalog_item(catalog, template)
+        template_vapp_resource = self.client.get_resource(
+            catalog_item.Entity.get('href'))
+        return template_vapp_resource
+
+    def create_vm_from_template(self, 
+                catalog,
+                vapp_template,
+                vm_template,
+                isAdmin=False,
+                name=None,
+                hostname=None,
+                password=None,
+                password_auto=None,
+                password_reset=None,
+                cust_script=None,
+                network=None,
+                disk_size=None,
+                storage_profile=None,
+                sizing_policy_href=None,
+                placement_policy_href=None,
+                ip_allocation_mode='DHCP'):
+        """Creates a vm from a template or based on an existing VM from a different vapp
+        and recompose the vapp to add the new vm.
+            
+        This method is similar to add_vms but,
+        instead the template resource, you provide a vapp name or vapp template name 
+        to create the new VM based on an existing vm from the vapp.
+
+            :param str catalog: (required) catalog name cointaining vapp template.
+            :param str vapp_template: (required) source vApp template name.
+            :param str vm_template: (required) source vm template name.
+            :param str bame: (optional) new vm name.
+            :param str hostname: (optional) new guest hostname.
+            :param str password: (optional) the administrator password of the vm.
+            :param str password_auto: (bool): (optional) auto generate administrator
+                password.
+            :param str password_reset: (bool): (optional) True, if the administrator
+                password for this vm must be reset after first use.
+            :param str cust_script: (optional) script to run on guest
+                customization.
+            :param str network: (optional) name of the vApp network to connect.
+                If omitted, the vm won't be connected to any network.
+            :param str storage_profile: (optional) the name of the storage
+                profile to be used for this vm.
+            :param str sizing_policy_href: (optional) sizing policy used for
+                creating the VM.
+            :param str placement_policy_href: (optional) placement policy used
+                for creating the VM.
+            :param str ip_allocation_mode: (optional) the allocation mode for ip.
+                Default is for DHCP.
+
+            :return: an object containing EntityType.VAPP XML data representing the
+                updated vApp.
+
+            :rtype: lxml.objectify.ObjectifiedElement
+        """
+        try:
+            template_vapp_resource = self.get_template(catalog, vapp_template)
+        except EntityNotFoundException:
+                print("Template vapp {0} couldn't be instantiated from {1}".format(vapp_template, catalog))
+                
+        vm_cfg = {
+                "vapp": template_vapp_resource,
+                "source_vm_name": vm_template,
+        }
+
+        if name:
+            vm_cfg["target_vm_name"] = name
+        if network:
+            vm_cfg["network"] = network
+            if ip_allocation_mode:
+                vm_cfg["ip_allocation_mode"] = ip_allocation_mode
+        if disk_size:
+            vm_cfg["disk_size"] = disk_size
+        if password:
+            vm_cfg["password"] = password
+        if password_auto:
+            vm_cfg["password_auto"] = password_auto
+        if password_reset:
+            vm_cfg["password_reset"] = password_reset
+        if cust_script:
+            vm_cfg["cust_script"] = cust_script
+        if hostname:
+            vm_cfg["hostname"] = hostname
+
+        return self.add_vms([vm_cfg])
 
     def delete_vms(self, names):
         """Recompose the vApp and delete vms.

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -884,7 +884,7 @@ class VApp(object):
 
         :param dict spec: a dictionary containing
 
-            - vapp: (resource): (required) source vApp or vApp
+            - vapp: (resource): (required) source vApp or vAppTemplate
             
                 resource.
             - source_vm_name: (str): (required) source vm name.

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -1033,7 +1033,7 @@ class VApp(object):
     
     def get_template(self, catalog, template):
         """Returns the template resource from the provided catalog name
-           and vapp template name
+        and vapp template name
         """
         org_resource = self.client.get_org()
         org = Org(self.client, resource=org_resource)
@@ -1043,28 +1043,29 @@ class VApp(object):
         return template_vapp_resource
 
     def create_vm_from_template(self, 
-            catalog,
-            vapp_template,
-            vm_template,
-            isAdmin=False,
-            name=None,
-            hostname=None,
-            password=None,
-            password_auto=None,
-            password_reset=None,
-            cust_script=None,
-            network=None,
-            disk_size=None,
-            storage_profile=None,
-            sizing_policy_href=None,
-            placement_policy_href=None,
-            ip_allocation_mode='DHCP'):
-        """Creates a vm from a template or based on an existing VM from a different vapp
-        and recompose the vapp to add the new vm.
-            
+                                catalog,
+                                vapp_template,
+                                vm_template,
+                                isAdmin=False,
+                                name=None,
+                                hostname=None,
+                                password=None,
+                                password_auto=None,
+                                password_reset=None,
+                                cust_script=None,
+                                network=None,
+                                disk_size=None,
+                                storage_profile=None,
+                                sizing_policy_href=None,
+                                placement_policy_href=None,
+                                ip_allocation_mode='DHCP'):
+        """Creates a vm from a template or based on an existing VM from a
+        different vapp and recompose the vapp to add the new vm.
+
         This method is similar to add_vms but,
-        instead the template resource, you provide a vapp name or vapp template name 
-        to create the new VM based on an existing vm from the vapp.
+        instead the template resource, you provide an existing vapp name
+        or vapp template name to create the new VM based on an existing 
+        vm from inside the vapp.
 
         :param str catalog: (required) catalog name cointaining vapp template.
         :param str vapp_template: (required) source vApp template name.
@@ -1072,10 +1073,10 @@ class VApp(object):
         :param str bame: (optional) new vm name.
         :param str hostname: (optional) new guest hostname.
         :param str password: (optional) the administrator password of the vm.
-        :param str password_auto: (bool): (optional) auto generate administrator
-            password.
-        :param str password_reset: (bool): (optional) True, if the administrator
-            password for this vm must be reset after first use.
+        :param str password_auto: (bool): (optional) auto generate 
+            administrator password.
+        :param str password_reset: (bool): (optional) True, if the
+            administrator password for this vm must be reset after first use.
         :param str cust_script: (optional) script to run on guest
             customization.
         :param str network: (optional) name of the vApp network to connect.
@@ -1089,19 +1090,20 @@ class VApp(object):
         :param str ip_allocation_mode: (optional) the allocation mode for ip.
             Default is for DHCP.
 
-        :return: an object containing EntityType.VAPP XML data representing the
-            updated vApp.
+        :return: an object containing EntityType.VAPP XML data representing
+            the updated vApp.
 
         :rtype: lxml.objectify.ObjectifiedElement
         """
         try:
             template_vapp_resource = self.get_template(catalog, vapp_template)
         except EntityNotFoundException:
-                print("Template vapp {0} couldn't be instantiated from {1}".format(vapp_template, catalog))
+                print("Template vapp {0} couldn't be instantiated "
+                      "from {1}".format(vapp_template, catalog))
                 
         vm_cfg = {
-                "vapp": template_vapp_resource,
-                "source_vm_name": vm_template,
+            "vapp": template_vapp_resource,
+            "source_vm_name": vm_template,
         }
 
         if name:


### PR DESCRIPTION
-Short description: Makes easier to create a new VM and attach it to the vApp by providing the vapp template name and VM template name as input parameters. This also works by proving a vapp name and VM name to create a VM based on any VM from a different vApp.

-Detailed description: Adding a couple of methods to extend the functionality of vApp. Define method create_vm_from_template, this is an extension from add_vm in order to simplify the VM creation. In this method, a vapp template is retrieved from a catalog to be used as an input parameter for add_vm. But create_vm_from_template facilitates the process by accepting the vapp template name as a str parameter. The other method get_template, is used simply to get the tempalte resource the add_vm methods needs as a paramter.

For me as a developer was complex to figure out a way to create a VM based on a template and attached to my vApp by looking at the defined methods. I guess this method will make this operation more accesible and understandable for consumers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/718)
<!-- Reviewable:end -->
