### PR TITLE
Fix disabling user accounts in an Org under certain conditions

### DIFF
--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -1017,7 +1017,7 @@ class Org(object):
             updated_user["Password"] = E.Password(password)
             user["Password"] = updated_user["Password"]
 
-        if is_enabled or role_name or password:
+        if is_enabled is not None or role_name or password:
             return self.client.put_resource(
                 user.get('href'), updated_user, EntityType.USER.value)
 


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

- (Required) Short description of changes in the PR topic line

Bugfix for issue #722.  This fixes disabling user accounts in an Org when no other changes are made to a user account.

- (Required) Detailed description of changes include tests and
  documentation.  If the pull request contains multiple commits with 
  detailed messages, refer to those instead

Details are included in submitted issue #722 (pasted below):

There is a bug that prevents disabling a user in an Org. I'll be submitting a PR for this shortly.

File: pyvcloud/vcd/org.py
Line: 1019
Current line:
if is_enabled or role_name or password:

Issue: If the only modification being made to a user is to disable the account, this will ALWAYS skip past this IF statement, as "is_enabled" is a boolean and evaluates to False. This works for enabling users, as "is_enabled" evaluates to True and enters the IF statement.

- (Optional) Names of reviewers using @ sign + name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/723)
<!-- Reviewable:end -->
