### PR TITLE
Added NIC adapter-type on utils.py

### DIFF
--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -480,6 +480,7 @@ def vm_to_dict(vm):
                 nic_props['network'] = nc.get('network')
                 nic_props['mode'] = nc.IpAddressAllocationMode.text
                 nic_props['connected'] = nc.IsConnected.text
+                nic_props['adapter_type'] = nc.NetworkAdapterType.text
                 if hasattr(nc, 'MACAddress'):
                     nic_props['mac'] = nc.MACAddress.text
                 if hasattr(nc, 'IpAddress'):


### PR DESCRIPTION
Just added a line to vm_to_dict function to include NIC adapter-type information
This is used by vcd-cli vm info command
