### PR TITLE
add "if" conditional to avoid looping with a non-existent attribute

### DIFF
--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -1158,15 +1158,16 @@ class VM(object):
             uri = self.href + '/virtualHardwareSection/disks'
             disk_list = self.client.get_resource(uri)
 
-            for disk in disk_list.Item:
-                if disk['{' + NSMAP['rasd'] + '}Description'] == 'Hard disk':
-                    vhs_disk_info = {
-                        'diskElementName': str(disk[
-                            '{' + NSMAP['rasd'] + '}ElementName']),
-                        'diskVirtualQuantityInBytes': int(disk[
-                            '{' + NSMAP['rasd'] + '}VirtualQuantity'])
-                    }
-                    result.append(vhs_disk_info)
+            if hasattr(disk_list, 'Item'):
+                for disk in disk_list.Item:
+                    if disk['{' + NSMAP['rasd'] + '}Description'] == 'Hard disk':
+                        vhs_disk_info = {
+                            'diskElementName': str(disk[
+                                '{' + NSMAP['rasd'] + '}ElementName']),
+                            'diskVirtualQuantityInBytes': int(disk[
+                                '{' + NSMAP['rasd'] + '}VirtualQuantity'])
+                        }
+                        result.append(vhs_disk_info)
 
         if is_media:
             uri = self.href + '/virtualHardwareSection/media'


### PR DESCRIPTION
To help us process your pull request efficiently, please include: 

- Added in a hasattr check for the list_virtual_hardware_section.  Current behaviour, when running the function with a VM without any disk's an AttributeError is returned.  This changes avoids the error and in turn returns no results.
- 

- Testing:  
code snip

 ```
def __init__(self, client, vm):
        self.obj = VM(client=client, resource=vm)
        self.vm_resources = self.obj.get_resource()
        virtual_hardware = \
            self.obj.list_virtual_hardware_section(
                is_cpu=True,
                is_memory=True,
                is_disk=True,
                is_media=True,
                is_networkCards=True
                )
```
Before the change on a vm with no disk,  AttributeError was returned.

After,  no excetions were raised and the correct info returned.


