### PR TITLE
Fixing update_user to permit disabling a user

### DIFF
--- a/pyvcloud/vcd/org.py
+++ b/pyvcloud/vcd/org.py
@@ -1015,7 +1015,7 @@ class Org(object):
             updated_user["Password"] = E.Password(password)
             user["Password"] = updated_user["Password"]
 
-        if is_enabled or role_name or password:
+        if (is_enabled is not None) or role_name or password:
             return self.client.put_resource(
                 user.get('href'), updated_user, EntityType.USER.value)
 


### PR DESCRIPTION
When is_enabled is passed in as False, indicating that an account should be disabled, the conditional evaluates to False and does not execute the put_resource method to perform the requested action.

Apologies... trying once again with the comparison to None using "is not" instead of "!="

To help us process your pull request efficiently, please include: 

- (Required) Short description of changes in the PR topic line

- (Required) Detailed description of changes include tests and
  documentation.  If the pull request contains multiple commits with 
  detailed messages, refer to those instead

- (Optional) Names of reviewers using @ sign + name
