### PR TITLE
Remove hardcoding of API version from examples

### DIFF
--- a/examples/list-vapps.py
+++ b/examples/list-vapps.py
@@ -39,12 +39,12 @@ requests.packages.urllib3.disable_warnings()
 # certificates.  You should only do this in trusted environments.
 print("Logging in: host={0}, org={1}, user={2}".format(host, org, user))
 client = Client(host,
-                api_version='29.0',
                 verify_ssl_certs=False,
                 log_file='pyvcloud.log',
                 log_requests=True,
                 log_headers=True,
                 log_bodies=True)
+client.set_highest_supported_version()
 client.set_credentials(BasicLoginCredentials(user, org, password))
 
 print("Fetching Org...")

--- a/examples/system-info.py
+++ b/examples/system-info.py
@@ -37,12 +37,12 @@ requests.packages.urllib3.disable_warnings()
 # certificates.  You should only do this in trusted environments.
 print("Logging in: host={0}, org={1}, user={2}".format(vcd_host, org, user))
 client = Client(vcd_host,
-                api_version='29.0',
                 verify_ssl_certs=False,
                 log_file='pyvcloud.log',
                 log_requests=True,
                 log_headers=True,
                 log_bodies=True)
+client.set_highest_supported_version()
 client.set_credentials(BasicLoginCredentials(user, org, password))
 
 print("Fetching vCD installation info...")


### PR DESCRIPTION
API version is hard coded as "29.0" in some of the files under examples. Removed them and setting highest supported API version. 

Testing done:
Ran examples/run_examples.sh, works with latest cloud director. 

- @rajeshk2013

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/755)
<!-- Reviewable:end -->
