### PR TITLE
Add a timeout param to _do_request_prim

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -1269,7 +1269,8 @@ class Client(object):
                          accept_type=None,
                          auth=None,
                          params=None,
-                         extra_headers=None):
+                         extra_headers=None,
+                         timeout=None):
         headers = extra_headers or {}
         if media_type is not None:
             headers[self._HEADER_CONTENT_TYPE_NAME] = media_type
@@ -1300,7 +1301,8 @@ class Client(object):
             data=data,
             headers=headers,
             auth=auth,
-            verify=self._verify_ssl_certs)
+            verify=self._verify_ssl_certs,
+            timeout=timeout)
 
         self._log_request_response(response=response)
 


### PR DESCRIPTION
_do_request_prim in client.py doesn't have a timeout parameter, as a result there is no way to test connectivity to server without waiting for the request to timeout, which can be in minutes. By adding the timeout parameter, the client can control how long they need to wait before receiving a ReadTimeoutError.

Testing done:
Wrote a custom script that made a GET /api/cse/system call to vCD with no CSE server running,
1. without timeout the call took 30+ seconds to fail
2. With a timeout of 3.05 seconds, the call returned the expected error in ~3 seconds. 