### PR TITLE
[VCDA-2334] Storage profile element should cbe added before compute policy

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -1140,6 +1140,14 @@ class Client(object):
         """
         return self._vcloud_access_token
 
+    def should_verify_ssl(self):
+        """Retrieve boolean indicating if ssl verification is enabled.
+
+        :return: True if ssl verification is enabled, else False
+        :rtype: bool
+        """
+        return self._verify_ssl_certs
+
     def get_task_monitor(self):
         if self._task_monitor is None:
             self._task_monitor = _TaskMonitor(self)

--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -975,15 +975,6 @@ class VApp(object):
         sourced_item.append(vm_general_params)
         sourced_item.append(vm_instantiation_param)
 
-        vdc_compute_policy_element, compute_policy_element = \
-            generate_compute_policy_tags(float(self.client.get_api_version()),
-                                         sizing_policy_href=spec.get('sizing_policy_href'),  # noqa: E501
-                                         placement_policy_href=spec.get('placement_policy_href'))  # noqa: E501
-        if vdc_compute_policy_element is not None:
-            sourced_item.append(vdc_compute_policy_element)
-        if compute_policy_element is not None:
-            sourced_item.append(compute_policy_element)
-
         if 'storage_profile' in spec:
             sp = spec['storage_profile']
             storage_profile = E.StorageProfile(
@@ -992,6 +983,15 @@ class VApp(object):
                 type=sp.get('type'),
                 name=sp.get('name'))
             sourced_item.append(storage_profile)
+
+        vdc_compute_policy_element, compute_policy_element = \
+            generate_compute_policy_tags(float(self.client.get_api_version()),
+                                         sizing_policy_href=spec.get('sizing_policy_href'),  # noqa: E501
+                                         placement_policy_href=spec.get('placement_policy_href'))  # noqa: E501
+        if vdc_compute_policy_element is not None:
+            sourced_item.append(vdc_compute_policy_element)
+        if compute_policy_element is not None:
+            sourced_item.append(compute_policy_element)
 
         return sourced_item
 


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Storage profile element should be added before compute policy element in recompose Vapp call

Testing done:
Create VM via CSE and verify if proper storage profile is added to the VM.

@rocknes @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/761)
<!-- Reviewable:end -->
