### PR TITLE
[VCDA-2386] Method to get extra config information of vm

### DIFF
--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -1650,6 +1650,27 @@ class VM(object):
             put_resource(uri, vm_capabilities_section,
                          EntityType.VM_CAPABILITIES_SECTION.value)
 
+    def get_vm_extra_config_elements(self):
+        """Get vmw:ExtraConfig section of VM.
+
+        :return: list of all ExtraConfig elements
+        :rtype: list[lxml.objectify.StringElement]
+        """
+        vm_resource = self.get_resource()
+        return vm_resource.xpath(
+            'ovf:VirtualHardwareSection/vmw:ExtraConfig',
+            namespaces=NSMAP)
+
+    def list_vm_extra_config_info(self):
+        """List VM extra config key-value pairs.
+
+        :return: dictionary which contains VM ExtraConfig info
+        :rtype: dict
+        """
+        extra_config_items = self.get_vm_extra_config_elements()
+        return {item.get(f"{{{NSMAP['vmw']}}}key"): item.get(
+            f"{{{NSMAP['vmw']}}}value") for item in extra_config_items}
+
     def get_boot_options(self):
         """Get boot options of VM.
 


### PR DESCRIPTION
 - Support for getting vm extra config information
 - New method to get extra config elements
 - Tested by python script:
      - create a vm
      - set extra config key:value using vmtools
      - Get using the new method that is implemented for this PR 
      - verified the test data set is present in the returned dictionary
@rocknes @Anirudh9794

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/765)
<!-- Reviewable:end -->
