### PR TITLE
Stop pyvcloud creating an empty log file called 'vcd_sdk.log'

### DIFF
--- a/pyvcloud/vcd/vapp.py
+++ b/pyvcloud/vcd/vapp.py
@@ -24,7 +24,6 @@ from pyvcloud.vcd.client import E_OVF
 from pyvcloud.vcd.client import EntityType
 from pyvcloud.vcd.client import FenceMode
 from pyvcloud.vcd.client import find_link
-from pyvcloud.vcd.client import get_logger
 from pyvcloud.vcd.client import MetadataDomain
 from pyvcloud.vcd.client import MetadataValueType
 from pyvcloud.vcd.client import MetadataVisibility
@@ -42,7 +41,6 @@ from pyvcloud.vcd.vdc import VDC
 from pyvcloud.vcd.vm import VM
 
 DEFAULT_CHUNK_SIZE = 10 * 1024 * 1024
-LOGGER = get_logger()
 
 
 class VApp(object):
@@ -1604,8 +1602,9 @@ class VApp(object):
                 self.client.get_task_monitor().wait_for_success(task)
                 no_of_vm_upgraded += 1
             except OperationNotSupportedException:
-                LOGGER.error('Operation not supported  for vm ' +
-                             vm.get('name'))
+                raise OperationNotSupportedException(
+                    'Operation not supported for vm' +  vm.get('name')
+                )
         return no_of_vm_upgraded
 
     def vapp_clone(self, vdc_href, vapp_name, description, source_delete):


### PR DESCRIPTION
Remove the need to call "Get_logger" which inadvertently creates an empty `vcd_sdk.log` file in your current working directory, which seems un-useful for a single log across the whole project.

pyvcloud is great -but there is no logging, I think that is basically fine so long as we are consistent with that fact, implementing logging for one log feels like the worst of both worlds, and is leaving us with an empty file in our current working directory, with no way to configure this log file name or location. I rejected the idea of doing anything fancier here,  because sorting out logging in this project felt too big a task for a Tuesday morning. 

I've not tested. 

Can someone please review?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/766)
<!-- Reviewable:end -->
