### PR TITLE
Fix media download

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -1229,7 +1229,7 @@ class Client(object):
                 redacted_headers[key] = "[REDACTED]"
         return redacted_headers
 
-    def _log_request_sent(self, method, uri, headers=[], request_body=None):
+    def _log_request_sent(self, method, uri, headers={}, request_body=None):
         if not self._log_requests:
             return
 


### PR DESCRIPTION
Downloading a media fails with, Error: 'list' object has no attribute 'items'.
Error is coming from client._log_request_sent() method. Default value of headers should be an empty map not list.

Testing done:
Manually verified that media download from vcd-cli passes.

- @rajeshk2013

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/769)
<!-- Reviewable:end -->
