### PR TITLE
[VCDA-2669] Add VCDApiVersion object for easy version comparison

### DIFF
--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -15,8 +15,6 @@
 
 from datetime import datetime
 from datetime import timedelta
-
-from packaging.version import Version
 from enum import Enum
 import json
 import logging
@@ -790,7 +788,9 @@ class Client(object):
         self._api_base_uri = self._prep_base_uri(uri)
         self._cloudapi_base_uri = self._prep_base_uri(uri, True)
         self._api_version = api_version
-        self._vcd_api_version = VCDApiVersion(api_version)
+        self._vcd_api_version = None
+        if api_version:
+            self._vcd_api_version = VCDApiVersion(api_version)
 
         self._session_endpoints = None
         self._session = None
@@ -902,7 +902,7 @@ class Client(object):
 
         return False
 
-    def get_supported_versions_list(self, include_alpha_versions: bool = False):
+    def get_supported_versions_list(self, include_alpha_versions: bool = False):  # noqa: E501
         """Return non-deprecated server API versions as a list.
 
         :param bool include_alpha_versions: boolean indicating if alpha
@@ -939,20 +939,19 @@ class Client(object):
             active_versions.sort(key=VCDApiVersion)
             return active_versions
 
-
     def get_supported_versions(self, include_alpha_versions: bool = False):
         """Return non-deprecated server API version Objects as a list.
 
         :param bool include_alpha_versions: boolean indicating if alpha
             versions need to be considered.
-    
+
         :rtype: List[VCDApiVersion]
         :return: versions as strings, sorted in numerical order.
         """
         api_version_list = self.get_supported_versions_list(
             include_alpha_versions=include_alpha_versions)
         if api_version_list:
-            return [VCDApiVersion(api_version) \
+            return [VCDApiVersion(api_version)
                     for api_version in api_version_list]
 
     def set_highest_supported_version(self):
@@ -998,7 +997,8 @@ class Client(object):
             # Use /cloudapi/1.0.0/sessions for Xendi and beyond i.e. api v33+
             # otherwise use /api/sessions
             use_cloudapi_login_endpoint = \
-                VCDApiVersion(self._api_version) >= VCDApiVersion(ApiVersion.VERSION_33.value)
+                VCDApiVersion(self._api_version) >= \
+                VCDApiVersion(ApiVersion.VERSION_33.value)
             if use_cloudapi_login_endpoint:
                 accept_type = 'application/json'
                 uri = self._cloudapi_base_uri + '/1.0.0/sessions'

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -15,7 +15,8 @@
 
 from datetime import datetime
 from datetime import timedelta
-from distutils.version import StrictVersion
+
+from packaging.version import Version
 from enum import Enum
 import json
 import logging
@@ -29,6 +30,7 @@ from lxml import etree
 from lxml import objectify
 import requests
 
+from pyvcloud.vcd.vcd_api_version import VCDApiVersion
 from pyvcloud.vcd.exceptions import AccessForbiddenException, \
     BadRequestException, ClientException, ConflictException, \
     EntityNotFoundException, InternalServerException, \
@@ -107,6 +109,7 @@ class ApiVersion(Enum):
     VERSION_34 = '34.0'
     VERSION_35 = '35.0'
     VERSION_36 = '36.0'
+    VERSION_37_ALPHA = '37.0.0-alpha'
 
 
 # Important! Values must be listed in ascending order.
@@ -119,6 +122,19 @@ API_CURRENT_VERSIONS = [
     ApiVersion.VERSION_34.value,
     ApiVersion.VERSION_35.value,
     ApiVersion.VERSION_36.value
+]
+
+
+VCD_API_CURRENT_VERSIONS = [
+    VCDApiVersion(ApiVersion.VERSION_29.value),
+    VCDApiVersion(ApiVersion.VERSION_30.value),
+    VCDApiVersion(ApiVersion.VERSION_31.value),
+    VCDApiVersion(ApiVersion.VERSION_32.value),
+    VCDApiVersion(ApiVersion.VERSION_33.value),
+    VCDApiVersion(ApiVersion.VERSION_34.value),
+    VCDApiVersion(ApiVersion.VERSION_35.value),
+    VCDApiVersion(ApiVersion.VERSION_36.value),
+    VCDApiVersion(ApiVersion.VERSION_37_ALPHA.value)
 ]
 
 
@@ -774,6 +790,7 @@ class Client(object):
         self._api_base_uri = self._prep_base_uri(uri)
         self._cloudapi_base_uri = self._prep_base_uri(uri, True)
         self._api_version = api_version
+        self._vcd_api_version = VCDApiVersion(api_version)
 
         self._session_endpoints = None
         self._session = None
@@ -839,8 +856,9 @@ class Client(object):
             # Versions are strings sorted in ascending order, so we can work
             # backwards to find a match.
             for version in reversed(active_versions):
-                if version in API_CURRENT_VERSIONS:
+                if VCDApiVersion(version) in VCD_API_CURRENT_VERSIONS:
                     self._api_version = version
+                    self._vcd_api_version = VCDApiVersion(version)
                     self._logger.debug(
                         f"API version negotiated to: {self._api_version}")
                     break
@@ -884,8 +902,11 @@ class Client(object):
 
         return False
 
-    def get_supported_versions_list(self):
+    def get_supported_versions_list(self, include_alpha_versions: bool = False):
         """Return non-deprecated server API versions as a list.
+
+        :param bool include_alpha_versions: boolean indicating if alpha
+            versions should be included in the result.
 
         :return: versions as strings, sorted in numerical order.
 
@@ -910,8 +931,29 @@ class Client(object):
                 if not hasattr(version, 'deprecated') or \
                    version.get('deprecated') == 'false':
                     active_versions.append(str(version.Version.text))
-            active_versions.sort(key=StrictVersion)
+            if include_alpha_versions:
+                for version in versions.AlphaVersion:
+                    if not hasattr(version, 'deprecated') or \
+                            version.get('deprecated') == 'false':
+                        active_versions.append(str(version.Version.text))
+            active_versions.sort(key=VCDApiVersion)
             return active_versions
+
+
+    def get_supported_versions(self, include_alpha_versions: bool = False):
+        """Return non-deprecated server API version Objects as a list.
+
+        :param bool include_alpha_versions: boolean indicating if alpha
+            versions need to be considered.
+    
+        :rtype: List[VCDApiVersion]
+        :return: versions as strings, sorted in numerical order.
+        """
+        api_version_list = self.get_supported_versions_list(
+            include_alpha_versions=include_alpha_versions)
+        if api_version_list:
+            return [VCDApiVersion(api_version) \
+                    for api_version in api_version_list]
 
     def set_highest_supported_version(self):
         """Set the client API version to the highest server API version.
@@ -927,6 +969,7 @@ class Client(object):
         """
         active_versions = self.get_supported_versions_list()
         self._api_version = active_versions[-1]
+        self._vcd_api_version = VCDApiVersion(self._api_version)
         self._logger.debug('API versions supported: %s' % active_versions)
         self._logger.debug('API version set to: %s' % self._api_version)
         return self._api_version
@@ -955,7 +998,7 @@ class Client(object):
             # Use /cloudapi/1.0.0/sessions for Xendi and beyond i.e. api v33+
             # otherwise use /api/sessions
             use_cloudapi_login_endpoint = \
-                float(self._api_version) >= float(ApiVersion.VERSION_33.value)
+                VCDApiVersion(self._api_version) >= VCDApiVersion(ApiVersion.VERSION_33.value)
             if use_cloudapi_login_endpoint:
                 accept_type = 'application/json'
                 uri = self._cloudapi_base_uri + '/1.0.0/sessions'
@@ -1112,6 +1155,15 @@ class Client(object):
         :rtype: str
         """
         return self._api_version
+
+    def get_vcd_api_version(self):
+        """Return vCD API version object the client is using.
+
+        :return: api version of the client
+
+        :rtype: VCDApiVersion
+        """
+        return self._vcd_api_versions
 
     def get_vcloud_session(self):
         """Return the current vCD session.

--- a/pyvcloud/vcd/client.py
+++ b/pyvcloud/vcd/client.py
@@ -847,6 +847,10 @@ class Client(object):
             self._logger.addHandler(log_handler)
 
     def _negotiate_api_version(self):
+        """Negotiate the API version to use with VCD.
+
+        The negotiated API version cannot be a pre-release version.
+        """
         # If user provided API version we accept it, otherwise negotiate with
         # vCD server
         if not self._api_version:
@@ -928,8 +932,9 @@ class Client(object):
                 # .text property. Otherwise lxml will return "corrected"
                 # numbers that drop non-significant digits. For example, 5.10
                 # becomes 5.1.  This transformation corrupts the version.
+
                 if not hasattr(version, 'deprecated') or \
-                   version.get('deprecated') == 'false':
+                   version.get('deprecated').lower() == 'false':
                     active_versions.append(str(version.Version.text))
             if include_alpha_versions:
                 for version in versions.AlphaVersion:
@@ -977,7 +982,8 @@ class Client(object):
         """Set credentials and authenticate to create a new session.
 
         This call will automatically negotiate the server API version if
-        it was not set previously. Note that the method may generate
+        it was not set previously. The auto-negotiated API version cannot be
+        a pre-release version. Note that the method may generate
         exceptions from the underlying socket connection, which we pass
         up unchanged to the client.
 
@@ -1057,7 +1063,8 @@ class Client(object):
         """Use authorization token to retrieve vCD session.
 
         This call will automatically negotiate the server API version if
-        it was not set previously. Note that the method may generate
+        it was not set previously. The auto-negotiated API version cannot be a
+        pre-release version. Note that the method may generate
         exceptions from the underlying socket connection, which we pass
         up unchanged to the client.
 
@@ -1163,7 +1170,7 @@ class Client(object):
 
         :rtype: VCDApiVersion
         """
-        return self._vcd_api_versions
+        return self._vcd_api_version
 
     def get_vcloud_session(self):
         """Return the current vCD session.

--- a/pyvcloud/vcd/vcd_api_version.py
+++ b/pyvcloud/vcd/vcd_api_version.py
@@ -2,6 +2,16 @@ from packaging.version import Version
 
 
 class VCDApiVersion(Version):
+    """Objects representing VCD API versions.
+
+    Pre-release versions also contain a pre-release segment.
+    Example: '37.0.0-alpha-1625843840'.
+
+    Need to override all the comparison functions because
+    packaging.version.Version objects also compare pre-release segment
+    for pre-release versions.
+    """
+
     def __init__(self, version_string):
         super().__init__(version_string)
 
@@ -11,6 +21,9 @@ class VCDApiVersion(Version):
                 vcd_api_version.base_version == self.base_version:
             return True
         return super().__eq__(vcd_api_version)
+
+    def __ne__(self, vcd_api_version):
+        return not self.__eq__(vcd_api_version)
 
     def __lt__(self, vcd_api_version):
         if vcd_api_version.is_prerelease and self.is_prerelease and \

--- a/pyvcloud/vcd/vcd_api_version.py
+++ b/pyvcloud/vcd/vcd_api_version.py
@@ -1,0 +1,33 @@
+from packaging.version import Version
+
+
+class VCDApiVersion(Version):
+    def __init__(self, version_string):
+        super().__init__(version_string)
+
+    def __eq__(self, vcd_api_version):
+        if vcd_api_version.is_prerelease and self.is_prerelease and \
+                vcd_api_version.pre[0] == self.pre[0] and \
+                vcd_api_version.base_version == self.base_version:
+            return True
+        return super().__eq__(vcd_api_version)
+
+    def __lt__(self, vcd_api_version):
+        if vcd_api_version.is_prerelease and self.is_prerelease and \
+                vcd_api_version.pre[0] == self.pre[0] and \
+                vcd_api_version.base_version == self.base_version:
+            return False
+        return super().__lt__(vcd_api_version)
+
+    def __gt__(self, vcd_api_version):
+        if vcd_api_version.is_prerelease and self.is_prerelease and \
+                vcd_api_version.pre[0] == self.pre[0] and \
+                vcd_api_version.base_version == self.base_version:
+            return False
+        return super().__gt__(vcd_api_version)
+
+    def __lte__(self, vcd_api_version):
+        return not self.__gt__(vcd_api_version)
+
+    def __gte__(self, vcd_api_version):
+        return not self.__lt__(vcd_api_version)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 humanfriendly >= 4.8
 lxml >= 4.2.1
+packaging >= 21.0
 pygments >= 2.2.0
 PyYAML >= 4.2b1
 requests >= 2.18.4


### PR DESCRIPTION
Signed-off-by: Aniruddha Shamasundar <aniruddha.9794@gmail.com>

To help us process your pull request efficiently, please include: 

Create a version class for easy comparison of version objects

Testing done:
* Checked if comparisons are as expected.
* Added 37-alpha version to supported api version list
* Checked if login works properly after the changes

@rocknes @sakthisunda

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/pyvcloud/776)
<!-- Reviewable:end -->
