### PR TITLE
Add method delete_all_nics to vm.py

### DIFF
--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -739,6 +739,27 @@ class VM(object):
             net_conn_section, RelationType.EDIT,
             EntityType.NETWORK_CONNECTION_SECTION.value, net_conn_section)
 
+    def delete_all_nics(self):
+        """Deletes all nics from the VM.
+
+        :return: an object containing EntityType.TASK XML data which represents
+            the asynchronous task deleting all nics.
+
+        :rtype: lxml.objectify.ObjectifiedElement
+        """
+        # get network connection section.
+        net_conn_section = self.get_resource().NetworkConnectionSection
+
+        if hasattr(net_conn_section, 'NetworkConnection'):
+            for nc in net_conn_section.NetworkConnection:
+                net_conn_section.remove(nc)
+        else:
+            raise InvalidStateException(
+                'No nics found in the VM' % (self.get_resource().get('name')))
+        return self.client.put_linked_resource(
+            net_conn_section, RelationType.EDIT,
+            EntityType.NETWORK_CONNECTION_SECTION.value, net_conn_section)
+
     def install_vmware_tools(self):
         """Install vmware tools in the vm.
 


### PR DESCRIPTION
This PR add the method `delete_all_nics` to `vm.py`. The logic is basically the same as in the `delete_nic` method, except that instead of deleting just the NIC with given index, it deletes all.

NOTE: I have not added a dedicated test for this method, because of the same reason as above.

PS: I recommend to merge also PR #720, as it contains some bugfixes for `delete_nic` method.