### PR TITLE
Fix HTTP 400 for CustomizationScript in update_guest_customization_section

### DIFF
--- a/pyvcloud/vcd/vm.py
+++ b/pyvcloud/vcd/vm.py
@@ -1568,8 +1568,13 @@ class VM(object):
             gc_section.ResetPasswordRequired = E.ResetPasswordRequired(
                 reset_password_required)
         if customization_script is not None:
-            gc_section.CustomizationScript = E.CustomizationScript(
-                customization_script)
+            cs = E.CustomizationScript(customization_script)
+            if hasattr(gc_section, "CustomizationScript"):
+                gc_section.CustomizationScript = cs
+            elif hasattr(gc_section, "ComputerName"):
+                gc_section.ComputerName.addprevious(cs)
+            else:
+                gc_section.Link.addprevious(cs)
 
         return self.client. \
             put_resource(uri, gc_section,


### PR DESCRIPTION
Fix use of Customization Script in update_guest_customization_section().

Problem:
When adding CustomizationScript tag to a VM's XML that did not include it previously, then the original code would place it as a last tag. As described in Issue #635, Cloud Director requires these tags to be ordered in a specific way. This is why the result is:
> HTTP 400 Bad Request  - cvc-complex-type.2.4.a: Invalid content was found starting with element 'CustomizationScript'. One of '{"http://www.vmware.com/vcloud/v1.5":Link, WC[##other:"http://www.vmware.com/vcloud/v1.5"]}' is expected.

This PR modifies location where the CustomizationScript is added to XML request, if it was not present before. It fixes some cases mentioned in Issue #635.