### PR TITLE
Add compute policies in utils.vm_to_dict()

### DIFF
--- a/pyvcloud/vcd/utils.py
+++ b/pyvcloud/vcd/utils.py
@@ -500,6 +500,12 @@ def vm_to_dict(vm):
                 setting.AdapterType.text)
             disk_props['bus'] = setting.BusNumber.text
             disk_props['unit'] = setting.UnitNumber.text
+
+    if hasattr(vm, 'ComputePolicy'):
+        if hasattr(vm.ComputePolicy, 'VmPlacementPolicy'):
+            result['placement-policy'] = vm.ComputePolicy.VmPlacementPolicy.get('name')
+        if hasattr(vm.ComputePolicy, 'VmSizingPolicy'):
+            result['sizing-policy'] = vm.ComputePolicy.VmSizingPolicy.get('name')
     return result
 
 


### PR DESCRIPTION
If configured, add in the dictionary 'placement-policy' and 'sizing-policy'.

Signed-off-by: Olivier DRAGHI <odraghi@gmail.com>